### PR TITLE
chore(build): stop re-running tsc inside next build

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -2,6 +2,17 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   reactCompiler: true,
+  typescript: {
+    // Type checking is NOT skipped — it is moved, not removed. `bun run
+    // typecheck` runs in the husky pre-commit and pre-push hooks and, crucially,
+    // as its own unbypassable CI job (.github/workflows/ci.yml). Letting
+    // `next build` run tsc a fourth time over ~213k lines of TSX pushed the
+    // Vercel builder past its 8 GB heap: deployment dpl_7tc137yhs died with
+    // SIGKILL 29s into "Running TypeScript" (Vercel flagged it
+    // buildMachineUpgradeReason: "out-of-memory"). Do not flip this back
+    // without first removing the CI typecheck job — the gate lives there now.
+    ignoreBuildErrors: true,
+  },
   images: {
     remotePatterns: [
       {


### PR DESCRIPTION
## Why

The production build for `ae8816f` failed:

```
11:56:15  $ next build
12:01:06    Running TypeScript ...
12:01:35  error: script "build" was terminated by signal SIGKILL
```

Vercel recorded `buildMachineUpgradeReason: "out-of-memory"` on the deployment. Type checking ~213k lines of TSX *on top of* bundling exhausted the 8 GB builder heap. The deploy only went green after switching to an elastic build machine — masking the cause rather than fixing it.

## What

Sets `typescript.ignoreBuildErrors: true` so `next build` skips its redundant `tsc` pass.

## This does not weaken the gate

`bun run typecheck` still runs in:

- husky `pre-commit`
- husky `pre-push`
- **the `typecheck` CI job** (push to main + every PR) — which, unlike the hooks, cannot be bypassed with `--no-verify`

The build was the fourth pass. The gate now lives in CI, and the config comment says so, including how to reverse this safely.

## Verification

`bun run typecheck` ✅ · `bun run lint` ✅ (0 errors) · `bun run format:check` ✅

The `typecheck` job on this PR is the real proof — it must be green before merging.