### PR TITLE
feat(auth): make every auth surface real and gate every portal

### DIFF
--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -1,0 +1,73 @@
+import { NextResponse, type NextRequest } from "next/server";
+import type { EmailOtpType } from "@supabase/supabase-js";
+
+import { createServerClient } from "@/lib/supabase/server";
+
+// ============================================================================
+// The landing point for every link Supabase sends by email — confirmation,
+// password recovery, magic link, invite, email-change.
+//
+// This route is the piece whose absence makes those flows look broken in a way
+// that is genuinely hard to diagnose: the mail arrives, the link opens a real
+// page, and nothing works, because the code in the URL was never exchanged for
+// a session. A reset form with no session cannot reset anything.
+//
+// Two link shapes exist and both are live depending on the project's settings
+// and the age of the email template:
+//   ?code=…                    PKCE — exchangeCodeForSession
+//   ?token_hash=…&type=recovery  OTP  — verifyOtp
+// Handling only the first is the common half-fix, so both are here.
+//
+// A Route Handler rather than a page because it must SET cookies. Establishing
+// the session is the entire job; the redirect afterwards is incidental.
+// ============================================================================
+
+/** Same-origin paths only — this value arrives from a URL we do not control. */
+function safeNext(value: string | null): string {
+  if (!value) return "/customer/dashboard";
+  if (!value.startsWith("/")) return "/customer/dashboard";
+  if (value.startsWith("//") || value.startsWith("/\\")) {
+    return "/customer/dashboard";
+  }
+  return value;
+}
+
+function failure(request: NextRequest, reason: string) {
+  const url = new URL("/login", request.url);
+  url.searchParams.set("error", reason);
+  return NextResponse.redirect(url);
+}
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url);
+  const next = safeNext(searchParams.get("next"));
+
+  // Supabase reports its own failures (expired link, already used) on the
+  // query string rather than by refusing to redirect.
+  const providerError =
+    searchParams.get("error_description") ?? searchParams.get("error");
+  if (providerError) return failure(request, providerError);
+
+  const code = searchParams.get("code");
+  const tokenHash = searchParams.get("token_hash");
+  const type = searchParams.get("type") as EmailOtpType | null;
+
+  const supabase = await createServerClient();
+
+  if (code) {
+    const { error } = await supabase.auth.exchangeCodeForSession(code);
+    if (error) return failure(request, error.message);
+    return NextResponse.redirect(new URL(next, request.url));
+  }
+
+  if (tokenHash && type) {
+    const { error } = await supabase.auth.verifyOtp({
+      type,
+      token_hash: tokenHash,
+    });
+    if (error) return failure(request, error.message);
+    return NextResponse.redirect(new URL(next, request.url));
+  }
+
+  return failure(request, "That link is missing its verification code.");
+}

--- a/src/app/customer/_shell.tsx
+++ b/src/app/customer/_shell.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+import Link from "next/link";
+import { MessageCircle } from "lucide-react";
+
+import { CustomerFacilityProvider } from "@/hooks/use-customer-facility";
+import { SettingsProviderWrapper } from "@/components/providers/ModulesConfigProviderWrapper";
+import { BookingModalProviderWrapper } from "@/components/providers/BookingModalProviderWrapper";
+import { CustomerHeader } from "@/components/customer/CustomerHeader";
+import { SidebarProvider, SidebarInset } from "@/components/ui/sidebar";
+import { CustomerSidebar } from "@/components/customer/CustomerSidebar";
+
+/**
+ * The customer portal's chrome.
+ *
+ * Split out of layout.tsx so the layout itself can be a Server Component and
+ * run the auth gate. Everything here needs the pathname — which shell to draw,
+ * and whether to show the chat bubble — so it stays on the client.
+ */
+export function CustomerShell({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname();
+  const isAuthRoute = pathname?.startsWith("/customer/auth");
+
+  return (
+    <SettingsProviderWrapper>
+      <CustomerFacilityProvider>
+        <BookingModalProviderWrapper>
+          {isAuthRoute ? (
+            <div className="flex min-h-screen flex-col">
+              <main className="flex-1">{children}</main>
+            </div>
+          ) : (
+            <SidebarProvider>
+              <>
+                <CustomerSidebar />
+                <SidebarInset className="flex min-h-screen min-w-0 flex-col overflow-x-clip">
+                  <CustomerHeader />
+                  <main className="min-w-0 flex-1 overflow-x-hidden">
+                    {children}
+                  </main>
+
+                  {/* Floating chat bubble */}
+                  {!pathname?.includes("/messages") && (
+                    <Link
+                      href="/customer/messages"
+                      className="fixed right-6 bottom-6 z-50 flex size-14 items-center justify-center rounded-full bg-blue-500 text-white shadow-lg shadow-blue-200 transition-all hover:-translate-y-1 hover:bg-blue-600 hover:shadow-xl"
+                    >
+                      <MessageCircle className="size-6" />
+                      <span className="absolute -top-1 -right-1 flex size-5 items-center justify-center rounded-full bg-red-500 text-[10px] font-bold text-white ring-2 ring-white">
+                        2
+                      </span>
+                    </Link>
+                  )}
+                </SidebarInset>
+              </>
+            </SidebarProvider>
+          )}
+        </BookingModalProviderWrapper>
+      </CustomerFacilityProvider>
+    </SettingsProviderWrapper>
+  );
+}

--- a/src/app/customer/auth/change-password/page.tsx
+++ b/src/app/customer/auth/change-password/page.tsx
@@ -1,231 +1,79 @@
 "use client";
 
-import { useState } from "react";
-import { useRouter } from "next/navigation";
-import Image from "next/image";
-import { toast } from "sonner";
-import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
+import { useActionState } from "react";
+import Link from "next/link";
+import { ArrowLeft } from "lucide-react";
+
+import { AuthCard } from "@/components/auth/AuthCard";
 import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
-import { Eye, EyeOff, Lock, Loader2 } from "lucide-react";
-import { getErrorMessage } from "@/lib/errors";
+  AuthMessage,
+  PasswordField,
+  SubmitButton,
+} from "@/components/auth/AuthFormParts";
+import { changePassword } from "@/lib/auth/actions";
+import { AUTH_INITIAL_STATE } from "@/lib/auth/form-state";
+
+// ============================================================================
+// Change your password while signed in.
+//
+// Distinct from the reset flow in one way that matters: this one demands the
+// CURRENT password. The action verifies it by re-authenticating before
+// changing anything, because otherwise a borrowed session — an unlocked
+// laptop, a copied cookie — could be turned into permanent ownership of the
+// account in two clicks.
+// ============================================================================
 
 export default function ChangePasswordPage() {
-  const router = useRouter();
-  const [isLoading, setIsLoading] = useState(false);
-  const [showCurrentPassword, setShowCurrentPassword] = useState(false);
-  const [showNewPassword, setShowNewPassword] = useState(false);
-  const [showConfirmPassword, setShowConfirmPassword] = useState(false);
-  const [formData, setFormData] = useState({
-    currentPassword: "",
-    newPassword: "",
-    confirmPassword: "",
-  });
-  const [errors, setErrors] = useState<Record<string, string>>({});
-
-  const validateForm = () => {
-    const newErrors: Record<string, string> = {};
-
-    if (!formData.currentPassword) {
-      newErrors.currentPassword = "Current password is required";
-    }
-
-    if (!formData.newPassword) {
-      newErrors.newPassword = "New password is required";
-    } else if (formData.newPassword.length < 8) {
-      newErrors.newPassword = "Password must be at least 8 characters";
-    } else if (formData.currentPassword === formData.newPassword) {
-      newErrors.newPassword =
-        "New password must be different from current password";
-    }
-
-    if (!formData.confirmPassword) {
-      newErrors.confirmPassword = "Please confirm your new password";
-    } else if (formData.newPassword !== formData.confirmPassword) {
-      newErrors.confirmPassword = "Passwords do not match";
-    }
-
-    setErrors(newErrors);
-    return Object.keys(newErrors).length === 0;
-  };
-
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-
-    if (!validateForm()) {
-      return;
-    }
-
-    setIsLoading(true);
-
-    try {
-      // TODO: Replace with actual API call
-      await changePassword(formData.currentPassword, formData.newPassword);
-      toast.success("Password changed successfully!");
-      router.push("/customer/dashboard");
-    } catch (error: unknown) {
-      toast.error(
-        getErrorMessage(error) ||
-          "Failed to change password. Please try again.",
-      );
-    } finally {
-      setIsLoading(false);
-    }
-  };
-
-  // Placeholder function - replace with actual API call
-  const changePassword = async (
-    _currentPassword: string,
-    _newPassword: string,
-  ) => {
-    // TODO: API call to change password
-    await new Promise((resolve) => setTimeout(resolve, 1000));
-  };
+  const [state, formAction] = useActionState(
+    changePassword,
+    AUTH_INITIAL_STATE,
+  );
 
   return (
-    <div className="from-background via-muted/20 to-background flex min-h-screen items-center justify-center bg-linear-to-br p-4">
-      <Card className="w-full max-w-md">
-        <CardHeader className="space-y-1 text-center">
-          <div className="mb-4 flex justify-center">
-            <Image
-              src="/yipyy-transparent.png"
-              alt="Yipyy"
-              width={120}
-              height={48}
-              className="h-12 w-auto"
-            />
-          </div>
-          <CardTitle className="text-2xl font-bold">Change password</CardTitle>
-          <CardDescription>Update your account password</CardDescription>
-        </CardHeader>
-        <CardContent className="space-y-4">
-          <form onSubmit={handleSubmit} className="space-y-4">
-            <div className="space-y-2">
-              <Label htmlFor="currentPassword">Current Password</Label>
-              <div className="relative">
-                <Lock className="text-muted-foreground absolute top-1/2 left-3 size-4 -translate-y-1/2" />
-                <Input
-                  id="currentPassword"
-                  type={showCurrentPassword ? "text" : "password"}
-                  placeholder="••••••••"
-                  value={formData.currentPassword}
-                  onChange={(e) =>
-                    setFormData({
-                      ...formData,
-                      currentPassword: e.target.value,
-                    })
-                  }
-                  className="px-9"
-                  aria-invalid={errors.currentPassword ? "true" : "false"}
-                />
-                <button
-                  type="button"
-                  onClick={() => setShowCurrentPassword(!showCurrentPassword)}
-                  className="text-muted-foreground hover:text-foreground absolute top-1/2 right-3 -translate-y-1/2"
-                >
-                  {showCurrentPassword ? (
-                    <EyeOff className="size-4" />
-                  ) : (
-                    <Eye className="size-4" />
-                  )}
-                </button>
-              </div>
-              {errors.currentPassword && (
-                <p className="text-destructive text-sm">
-                  {errors.currentPassword}
-                </p>
-              )}
-            </div>
+    <AuthCard
+      title="Change password"
+      description="Update your account password"
+    >
+      <form action={formAction} className="space-y-4">
+        <AuthMessage state={state} />
 
-            <div className="space-y-2">
-              <Label htmlFor="newPassword">New Password</Label>
-              <div className="relative">
-                <Lock className="text-muted-foreground absolute top-1/2 left-3 size-4 -translate-y-1/2" />
-                <Input
-                  id="newPassword"
-                  type={showNewPassword ? "text" : "password"}
-                  placeholder="••••••••"
-                  value={formData.newPassword}
-                  onChange={(e) =>
-                    setFormData({ ...formData, newPassword: e.target.value })
-                  }
-                  className="px-9"
-                  aria-invalid={errors.newPassword ? "true" : "false"}
-                />
-                <button
-                  type="button"
-                  onClick={() => setShowNewPassword(!showNewPassword)}
-                  className="text-muted-foreground hover:text-foreground absolute top-1/2 right-3 -translate-y-1/2"
-                >
-                  {showNewPassword ? (
-                    <EyeOff className="size-4" />
-                  ) : (
-                    <Eye className="size-4" />
-                  )}
-                </button>
-              </div>
-              {errors.newPassword && (
-                <p className="text-destructive text-sm">{errors.newPassword}</p>
-              )}
-            </div>
+        <PasswordField
+          id="currentPassword"
+          label="Current password"
+          autoComplete="current-password"
+          invalid={Boolean(state.error)}
+        />
+        <PasswordField
+          id="password"
+          label="New password"
+          autoComplete="new-password"
+          invalid={Boolean(state.error)}
+        />
+        <PasswordField
+          id="confirmPassword"
+          label="Confirm new password"
+          autoComplete="new-password"
+          invalid={Boolean(state.error)}
+        />
 
-            <div className="space-y-2">
-              <Label htmlFor="confirmPassword">Confirm New Password</Label>
-              <div className="relative">
-                <Lock className="text-muted-foreground absolute top-1/2 left-3 size-4 -translate-y-1/2" />
-                <Input
-                  id="confirmPassword"
-                  type={showConfirmPassword ? "text" : "password"}
-                  placeholder="••••••••"
-                  value={formData.confirmPassword}
-                  onChange={(e) =>
-                    setFormData({
-                      ...formData,
-                      confirmPassword: e.target.value,
-                    })
-                  }
-                  className="px-9"
-                  aria-invalid={errors.confirmPassword ? "true" : "false"}
-                />
-                <button
-                  type="button"
-                  onClick={() => setShowConfirmPassword(!showConfirmPassword)}
-                  className="text-muted-foreground hover:text-foreground absolute top-1/2 right-3 -translate-y-1/2"
-                >
-                  {showConfirmPassword ? (
-                    <EyeOff className="size-4" />
-                  ) : (
-                    <Eye className="size-4" />
-                  )}
-                </button>
-              </div>
-              {errors.confirmPassword && (
-                <p className="text-destructive text-sm">
-                  {errors.confirmPassword}
-                </p>
-              )}
-            </div>
+        <p className="text-muted-foreground text-xs">
+          At least 12 characters, and different from your current one.
+        </p>
 
-            <Button type="submit" className="w-full" disabled={isLoading}>
-              {isLoading ? (
-                <>
-                  <Loader2 className="mr-2 size-4 animate-spin" />
-                  Changing password...
-                </>
-              ) : (
-                "Change password"
-              )}
-            </Button>
-          </form>
-        </CardContent>
-      </Card>
-    </div>
+        <SubmitButton pendingLabel="Changing password...">
+          Change password
+        </SubmitButton>
+      </form>
+
+      <div className="text-center">
+        <Link
+          href="/customer/dashboard"
+          className="text-primary inline-flex items-center text-sm hover:underline"
+        >
+          <ArrowLeft className="mr-1 size-3" />
+          Back to dashboard
+        </Link>
+      </div>
+    </AuthCard>
   );
 }

--- a/src/app/customer/auth/forgot-password/page.tsx
+++ b/src/app/customer/auth/forgot-password/page.tsx
@@ -1,199 +1,33 @@
 "use client";
 
-import { useState } from "react";
-import { useRouter } from "next/navigation";
-import Image from "next/image";
-import Link from "next/link";
-import { toast } from "sonner";
-import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
+import { AuthCard } from "@/components/auth/AuthCard";
 import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
-import { Mail, Loader2, ArrowLeft } from "lucide-react";
-import { getErrorMessage } from "@/lib/errors";
+  ForgotPasswordForm,
+  ResetLinkSent,
+} from "@/components/auth/ForgotPasswordForm";
+
+// ============================================================================
+// Request a password reset link.
+//
+// The old version showed a "Check your email" screen after a stub that slept
+// for a second — convincing, and completely inert. It now really asks Supabase
+// to send a recovery mail, pointed at /auth/callback so the link arrives with a
+// session attached.
+//
+// The response is identical whether or not the address has an account, and
+// deliberately so: a page that says "no account with that email" is a free
+// tool for working out who your customers are.
+// ============================================================================
 
 export default function ForgotPasswordPage() {
-  const router = useRouter();
-  const [isLoading, setIsLoading] = useState(false);
-  const [email, setEmail] = useState("");
-  const [isSubmitted, setIsSubmitted] = useState(false);
-  const [error, setError] = useState("");
-
-  const validateEmail = () => {
-    if (!email.trim()) {
-      setError("Email is required");
-      return false;
-    }
-    if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
-      setError("Please enter a valid email address");
-      return false;
-    }
-    setError("");
-    return true;
-  };
-
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-
-    if (!validateEmail()) {
-      return;
-    }
-
-    setIsLoading(true);
-
-    try {
-      // TODO: Replace with actual API call
-      await sendPasswordResetEmail(email);
-      setIsSubmitted(true);
-      toast.success("Password reset email sent!");
-    } catch (error: unknown) {
-      toast.error(
-        getErrorMessage(error) ||
-          "Failed to send reset email. Please try again.",
-      );
-    } finally {
-      setIsLoading(false);
-    }
-  };
-
-  // Placeholder function - replace with actual API call
-  const sendPasswordResetEmail = async (_email: string) => {
-    // TODO: API call to send password reset email
-    await new Promise((resolve) => setTimeout(resolve, 1000));
-  };
-
-  if (isSubmitted) {
-    return (
-      <div className="from-background via-muted/20 to-background flex min-h-screen items-center justify-center bg-linear-to-br p-4">
-        <Card className="w-full max-w-md">
-          <CardHeader className="space-y-1 text-center">
-            <div className="mb-4 flex justify-center">
-              <Image
-                src="/yipyy-transparent.png"
-                alt="Yipyy"
-                width={120}
-                height={48}
-                className="h-12 w-auto"
-              />
-            </div>
-            <CardTitle className="text-2xl font-bold">
-              Check your email
-            </CardTitle>
-            <CardDescription>
-              We&apos;ve sent a password reset link to {email}
-            </CardDescription>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            <div className="bg-muted text-muted-foreground rounded-lg p-4 text-sm">
-              <p className="mb-2">
-                If an account exists with this email, you&apos;ll receive
-                instructions to reset your password.
-              </p>
-              <p>
-                Didn&apos;t receive the email? Check your spam folder or try
-                again.
-              </p>
-            </div>
-            <div className="flex flex-col gap-2">
-              <Button
-                variant="outline"
-                onClick={() => {
-                  setIsSubmitted(false);
-                  setEmail("");
-                }}
-                className="w-full"
-              >
-                <Mail className="mr-2 size-4" />
-                Resend email
-              </Button>
-              <Button
-                variant="ghost"
-                onClick={() => router.push("/customer/auth/login")}
-                className="w-full"
-              >
-                <ArrowLeft className="mr-2 size-4" />
-                Back to login
-              </Button>
-            </div>
-          </CardContent>
-        </Card>
-      </div>
-    );
-  }
-
   return (
-    <div className="from-background via-muted/20 to-background flex min-h-screen items-center justify-center bg-linear-to-br p-4">
-      <Card className="w-full max-w-md">
-        <CardHeader className="space-y-1 text-center">
-          <div className="mb-4 flex justify-center">
-            <Image
-              src="/yipyy-transparent.png"
-              alt="Yipyy"
-              width={120}
-              height={48}
-              className="h-12 w-auto"
-            />
-          </div>
-          <CardTitle className="text-2xl font-bold">Forgot password?</CardTitle>
-          <CardDescription>
-            Enter your email address and we&apos;ll send you a link to reset
-            your password
-          </CardDescription>
-        </CardHeader>
-        <CardContent className="space-y-4">
-          <form onSubmit={handleSubmit} className="space-y-4">
-            <div className="space-y-2">
-              <Label htmlFor="email">Email</Label>
-              <div className="relative">
-                <Mail className="text-muted-foreground absolute top-1/2 left-3 size-4 -translate-y-1/2" />
-                <Input
-                  id="email"
-                  type="email"
-                  placeholder="you@example.com"
-                  value={email}
-                  onChange={(e) => {
-                    setEmail(e.target.value);
-                    setError("");
-                  }}
-                  className="pl-9"
-                  aria-invalid={error ? "true" : "false"}
-                />
-              </div>
-              {error && <p className="text-destructive text-sm">{error}</p>}
-            </div>
-
-            <Button type="submit" className="w-full" disabled={isLoading}>
-              {isLoading ? (
-                <>
-                  <Loader2 className="mr-2 size-4 animate-spin" />
-                  Sending...
-                </>
-              ) : (
-                <>
-                  <Mail className="mr-2 size-4" />
-                  Send reset link
-                </>
-              )}
-            </Button>
-          </form>
-
-          <div className="text-center">
-            <Link
-              href="/customer/auth/login"
-              className="text-primary inline-flex items-center text-sm hover:underline"
-            >
-              <ArrowLeft className="mr-1 size-3" />
-              Back to login
-            </Link>
-          </div>
-        </CardContent>
-      </Card>
-    </div>
+    <AuthCard
+      title="Forgot password?"
+      description="Enter your email address and we'll send you a link to reset your password"
+    >
+      <ForgotPasswordForm redirectTo="/customer/auth/reset-password">
+        {(message) => <ResetLinkSent message={message} />}
+      </ForgotPasswordForm>
+    </AuthCard>
   );
 }

--- a/src/app/customer/auth/login/page.tsx
+++ b/src/app/customer/auth/login/page.tsx
@@ -1,162 +1,58 @@
-"use client";
-
-import { useActionState, useState } from "react";
-import { useSearchParams } from "next/navigation";
-import Image from "next/image";
+import type { Metadata } from "next";
 import Link from "next/link";
-import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
-import { Eye, EyeOff, Mail, Lock, Loader2 } from "lucide-react";
-import { signIn } from "@/lib/auth/actions";
 
-export default function LoginPage() {
-  const searchParams = useSearchParams();
-  const facilityParam = searchParams.get("facility");
-  // Where to land after login (e.g. the estimate that sent them here). Passed
-  // through as a hidden field and re-validated in the action — the client only
-  // suggests a destination, the server decides whether it is safe.
-  const redirectTo = searchParams.get("redirect") ?? "/customer/dashboard";
+import { AuthCard } from "@/components/auth/AuthCard";
+import { SignInForm } from "@/components/auth/SignInForm";
 
-  const [showPassword, setShowPassword] = useState(false);
+export const metadata: Metadata = { title: "Sign in — Yipyy" };
 
-  // The sign-in runs as a Server Action rather than a submit handler so the
-  // session cookie and the redirect land in the same response — a client-side
-  // push can paint the destination before the cookie is readable. It also
-  // means a plain <form action={...}> posts natively, so the button works on
-  // first paint instead of doing nothing until React hydrates. (It was doing
-  // exactly that: the inputs had no `name`, so a pre-hydration click submitted
-  // an empty GET.)
-  const [state, formAction, isPending] = useActionState(signIn, {
-    error: null,
-  });
+// ============================================================================
+// Pet-owner sign-in.
+//
+// Now a Server Component: the page reads its params on the server and only the
+// form hydrates. It used to be "use client" purely to call useSearchParams,
+// which cost the whole page a client bundle for two query strings.
+//
+// "Continue with Google" used to sit above this form. It called a stub that
+// returned a hardcoded user@example.com and pushed you into signup as that
+// fake person. Re-enabling it for real means turning Google on under
+// Authentication > Providers, an action calling signInWithOAuth, and pointing
+// it at /auth/callback — which now exists.
+// ============================================================================
+
+export default async function CustomerLoginPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ facility?: string; redirect?: string }>;
+}) {
+  const { facility, redirect } = await searchParams;
+
+  const signupHref = facility
+    ? `/customer/auth/signup?facility=${encodeURIComponent(facility)}`
+    : "/customer/auth/signup";
 
   return (
-    <div className="from-background via-muted/20 to-background flex min-h-screen items-center justify-center bg-linear-to-br p-4">
-      <Card className="w-full max-w-md">
-        <CardHeader className="space-y-1 text-center">
-          <div className="mb-4 flex justify-center">
-            <Image
-              src="/yipyy-transparent.png"
-              alt="Yipyy"
-              width={120}
-              height={48}
-              className="h-12 w-auto"
-            />
-          </div>
-          <CardTitle className="text-2xl font-bold">Welcome back</CardTitle>
-          <CardDescription>Sign in to your account to continue</CardDescription>
-        </CardHeader>
-        <CardContent className="space-y-4">
-          {/*
-            "Continue with Google" was removed here rather than left in place:
-            it called a stub that returned a hardcoded user@example.com and
-            pushed you into signup as that fake person. Alongside a real
-            sign-in, a button that fabricates an identity is worse than no
-            button. Bringing it back is small once Google is enabled in
-            Supabase (Authentication > Providers) — an action calling
-            signInWithOAuth({ provider: "google" }) plus a /auth/callback
-            route to exchange the code for a session.
-          */}
-          <form action={formAction} className="space-y-4">
-            <input type="hidden" name="redirectTo" value={redirectTo} />
-
-            {state.error && (
-              <p
-                role="alert"
-                className="border-destructive/40 bg-destructive/10 text-destructive rounded-md border px-3 py-2 text-sm"
-              >
-                {state.error}
-              </p>
-            )}
-
-            <div className="space-y-2">
-              <Label htmlFor="email">Email</Label>
-              <div className="relative">
-                <Mail className="text-muted-foreground absolute top-1/2 left-3 size-4 -translate-y-1/2" />
-                <Input
-                  id="email"
-                  name="email"
-                  type="email"
-                  autoComplete="email"
-                  required
-                  placeholder="you@example.com"
-                  className="pl-9"
-                  aria-invalid={state.error ? "true" : "false"}
-                />
-              </div>
-            </div>
-
-            <div className="space-y-2">
-              <div className="flex items-center justify-between">
-                <Label htmlFor="password">Password</Label>
-                <Link
-                  href="/customer/auth/forgot-password"
-                  className="text-primary text-sm hover:underline"
-                >
-                  Forgot password?
-                </Link>
-              </div>
-              <div className="relative">
-                <Lock className="text-muted-foreground absolute top-1/2 left-3 size-4 -translate-y-1/2" />
-                <Input
-                  id="password"
-                  name="password"
-                  type={showPassword ? "text" : "password"}
-                  autoComplete="current-password"
-                  required
-                  placeholder="••••••••"
-                  className="px-9"
-                  aria-invalid={state.error ? "true" : "false"}
-                />
-                <button
-                  type="button"
-                  onClick={() => setShowPassword(!showPassword)}
-                  className="text-muted-foreground hover:text-foreground absolute top-1/2 right-3 -translate-y-1/2"
-                >
-                  {showPassword ? (
-                    <EyeOff className="size-4" />
-                  ) : (
-                    <Eye className="size-4" />
-                  )}
-                </button>
-              </div>
-            </div>
-
-            <Button type="submit" className="w-full" disabled={isPending}>
-              {isPending ? (
-                <>
-                  <Loader2 className="mr-2 size-4 animate-spin" />
-                  Signing in...
-                </>
-              ) : (
-                "Sign in"
-              )}
-            </Button>
-          </form>
-
+    <AuthCard
+      title="Welcome back"
+      description="Sign in to your account to continue"
+    >
+      <SignInForm
+        // Honour "you were sent here from X", otherwise the customer area.
+        // Validated server-side in the action — this is only a suggestion.
+        redirectTo={redirect ?? "/customer/dashboard"}
+        forgotHref="/customer/auth/forgot-password"
+        footer={
           <p className="text-muted-foreground text-center text-sm">
             Don&apos;t have an account?{" "}
             <Link
-              href={
-                facilityParam
-                  ? `/customer/auth/signup?facility=${encodeURIComponent(facilityParam)}`
-                  : "/customer/auth/signup"
-              }
+              href={signupHref}
               className="text-primary font-medium hover:underline"
             >
               Sign up
             </Link>
           </p>
-        </CardContent>
-      </Card>
-    </div>
+        }
+      />
+    </AuthCard>
   );
 }

--- a/src/app/customer/auth/reset-password/_client.tsx
+++ b/src/app/customer/auth/reset-password/_client.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { useActionState } from "react";
+
+import {
+  AuthMessage,
+  PasswordField,
+  SubmitButton,
+} from "@/components/auth/AuthFormParts";
+import { updatePassword } from "@/lib/auth/actions";
+import { AUTH_INITIAL_STATE } from "@/lib/auth/form-state";
+
+/**
+ * The only interactive part of the reset page — split out so the page itself
+ * stays a Server Component and can check for a session before rendering a form
+ * that would otherwise be unusable.
+ */
+export function ResetPasswordForm() {
+  const [state, formAction] = useActionState(
+    updatePassword,
+    AUTH_INITIAL_STATE,
+  );
+
+  return (
+    <form action={formAction} className="space-y-4">
+      <AuthMessage state={state} />
+
+      <PasswordField
+        id="password"
+        label="New password"
+        autoComplete="new-password"
+        invalid={Boolean(state.error)}
+      />
+      <PasswordField
+        id="confirmPassword"
+        label="Confirm new password"
+        autoComplete="new-password"
+        invalid={Boolean(state.error)}
+      />
+
+      <p className="text-muted-foreground text-xs">
+        At least 12 characters. Longer beats complicated.
+      </p>
+
+      <SubmitButton pendingLabel="Resetting password...">
+        Reset password
+      </SubmitButton>
+    </form>
+  );
+}

--- a/src/app/customer/auth/reset-password/page.tsx
+++ b/src/app/customer/auth/reset-password/page.tsx
@@ -9,6 +9,16 @@ import { ResetPasswordForm } from "./_client";
 
 export const metadata: Metadata = { title: "Reset password — Yipyy" };
 
+// This page's entire job is asking "is there a recovery session?", so it can
+// never be prerendered. Without this Next tries to build it statically and the
+// build fails wherever Supabase env vars are absent — which is exactly what
+// happened in CI while passing locally off .env.local.
+//
+// The rule generalises: any page that reads the session needs this. Layouts
+// get away without it because getViewer swallows a missing-config error and
+// falls through to the legacy path; getCurrentUser deliberately does not.
+export const dynamic = "force-dynamic";
+
 // ============================================================================
 // Set a new password after following a recovery link.
 //

--- a/src/app/customer/auth/reset-password/page.tsx
+++ b/src/app/customer/auth/reset-password/page.tsx
@@ -1,305 +1,64 @@
-"use client";
-
-import { useState, useEffect, Suspense } from "react";
-import { useRouter, useSearchParams } from "next/navigation";
-import Image from "next/image";
+import type { Metadata } from "next";
 import Link from "next/link";
-import { toast } from "sonner";
+import { ArrowLeft } from "lucide-react";
+
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
-import { Eye, EyeOff, Lock, Loader2, ArrowLeft } from "lucide-react";
-import { getErrorMessage } from "@/lib/errors";
+import { AuthCard } from "@/components/auth/AuthCard";
+import { getCurrentUser } from "@/lib/supabase/server";
+import { ResetPasswordForm } from "./_client";
 
-function ResetPasswordForm() {
-  const router = useRouter();
-  const searchParams = useSearchParams();
-  const token = searchParams.get("token");
+export const metadata: Metadata = { title: "Reset password — Yipyy" };
 
-  const [isLoading, setIsLoading] = useState(false);
-  const [showPassword, setShowPassword] = useState(false);
-  const [showConfirmPassword, setShowConfirmPassword] = useState(false);
-  const [formData, setFormData] = useState({
-    password: "",
-    confirmPassword: "",
-  });
-  const [errors, setErrors] = useState<Record<string, string>>({});
-  const [isValidToken, setIsValidToken] = useState<boolean | null>(null);
+// ============================================================================
+// Set a new password after following a recovery link.
+//
+// The old version read a `?token=` param and validated it against a stub that
+// resolved after 500ms — every link looked valid, and no link did anything.
+//
+// The real flow does not put a token on this page at all. /auth/callback
+// exchanges the emailed code for a session first and then sends the browser
+// here; possession of that session IS the proof. So the check below is simply
+// "is anyone signed in" — if the link expired, was already used, or someone
+// navigated here directly, there is no session and we say so plainly rather
+// than showing a form that cannot work.
+// ============================================================================
 
-  useEffect(() => {
-    // Validate token on mount
-    if (!token) {
-      setIsValidToken(false);
-      return;
-    }
+export default async function ResetPasswordPage() {
+  const user = await getCurrentUser();
 
-    const validateToken = async (t: string) => {
-      try {
-        // TODO: Replace with actual API call to validate token
-        await checkResetToken(t);
-        setIsValidToken(true);
-      } catch {
-        setIsValidToken(false);
-        toast.error("Invalid or expired reset link");
-      }
-    };
-
-    validateToken(token);
-  }, [token]);
-
-  const validateForm = () => {
-    const newErrors: Record<string, string> = {};
-
-    if (!formData.password) {
-      newErrors.password = "Password is required";
-    } else if (formData.password.length < 8) {
-      newErrors.password = "Password must be at least 8 characters";
-    }
-
-    if (!formData.confirmPassword) {
-      newErrors.confirmPassword = "Please confirm your password";
-    } else if (formData.password !== formData.confirmPassword) {
-      newErrors.confirmPassword = "Passwords do not match";
-    }
-
-    setErrors(newErrors);
-    return Object.keys(newErrors).length === 0;
-  };
-
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-
-    if (!validateForm() || !token) {
-      return;
-    }
-
-    setIsLoading(true);
-
-    try {
-      // TODO: Replace with actual API call
-      await resetPassword(token, formData.password);
-      toast.success("Password reset successfully!");
-      router.push("/customer/auth/login");
-    } catch (error: unknown) {
-      toast.error(
-        getErrorMessage(error) || "Failed to reset password. Please try again.",
-      );
-    } finally {
-      setIsLoading(false);
-    }
-  };
-
-  // Placeholder functions - replace with actual API calls
-  const checkResetToken = async (_token: string) => {
-    // TODO: API call to validate reset token
-    await new Promise((resolve) => setTimeout(resolve, 500));
-  };
-
-  const resetPassword = async (_token: string, _password: string) => {
-    // TODO: API call to reset password
-    await new Promise((resolve) => setTimeout(resolve, 1000));
-  };
-
-  if (isValidToken === null) {
+  if (!user) {
     return (
-      <div className="from-background via-muted/20 to-background flex min-h-screen items-center justify-center bg-linear-to-br p-4">
-        <Card className="w-full max-w-md">
-          <CardContent className="pt-6">
-            <div className="flex items-center justify-center">
-              <Loader2 className="text-muted-foreground size-6 animate-spin" />
-            </div>
-          </CardContent>
-        </Card>
-      </div>
-    );
-  }
-
-  if (isValidToken === false) {
-    return (
-      <div className="from-background via-muted/20 to-background flex min-h-screen items-center justify-center bg-linear-to-br p-4">
-        <Card className="w-full max-w-md">
-          <CardHeader className="space-y-1 text-center">
-            <div className="mb-4 flex justify-center">
-              <Image
-                src="/yipyy-transparent.png"
-                alt="Yipyy"
-                width={120}
-                height={48}
-                className="h-12 w-auto"
-              />
-            </div>
-            <CardTitle className="text-2xl font-bold">
-              Invalid reset link
-            </CardTitle>
-            <CardDescription>
-              This password reset link is invalid or has expired
-            </CardDescription>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            <div className="bg-destructive/10 text-destructive rounded-lg p-4 text-sm">
-              Please request a new password reset link.
-            </div>
-            <div className="flex flex-col gap-2">
-              <Button
-                onClick={() => router.push("/customer/auth/forgot-password")}
-                className="w-full"
-              >
-                Request new reset link
-              </Button>
-              <Button
-                variant="ghost"
-                onClick={() => router.push("/customer/auth/login")}
-                className="w-full"
-              >
-                <ArrowLeft className="mr-2 size-4" />
-                Back to login
-              </Button>
-            </div>
-          </CardContent>
-        </Card>
-      </div>
-    );
-  }
-
-  return (
-    <div className="from-background via-muted/20 to-background flex min-h-screen items-center justify-center bg-linear-to-br p-4">
-      <Card className="w-full max-w-md">
-        <CardHeader className="space-y-1 text-center">
-          <div className="mb-4 flex justify-center">
-            <Image
-              src="/yipyy-transparent.png"
-              alt="Yipyy"
-              width={120}
-              height={48}
-              className="h-12 w-auto"
-            />
-          </div>
-          <CardTitle className="text-2xl font-bold">
-            Reset your password
-          </CardTitle>
-          <CardDescription>Enter your new password below</CardDescription>
-        </CardHeader>
-        <CardContent className="space-y-4">
-          <form onSubmit={handleSubmit} className="space-y-4">
-            <div className="space-y-2">
-              <Label htmlFor="password">New Password</Label>
-              <div className="relative">
-                <Lock className="text-muted-foreground absolute top-1/2 left-3 size-4 -translate-y-1/2" />
-                <Input
-                  id="password"
-                  type={showPassword ? "text" : "password"}
-                  placeholder="••••••••"
-                  value={formData.password}
-                  onChange={(e) =>
-                    setFormData({ ...formData, password: e.target.value })
-                  }
-                  className="px-9"
-                  aria-invalid={errors.password ? "true" : "false"}
-                />
-                <button
-                  type="button"
-                  onClick={() => setShowPassword(!showPassword)}
-                  className="text-muted-foreground hover:text-foreground absolute top-1/2 right-3 -translate-y-1/2"
-                >
-                  {showPassword ? (
-                    <EyeOff className="size-4" />
-                  ) : (
-                    <Eye className="size-4" />
-                  )}
-                </button>
-              </div>
-              {errors.password && (
-                <p className="text-destructive text-sm">{errors.password}</p>
-              )}
-            </div>
-
-            <div className="space-y-2">
-              <Label htmlFor="confirmPassword">Confirm New Password</Label>
-              <div className="relative">
-                <Lock className="text-muted-foreground absolute top-1/2 left-3 size-4 -translate-y-1/2" />
-                <Input
-                  id="confirmPassword"
-                  type={showConfirmPassword ? "text" : "password"}
-                  placeholder="••••••••"
-                  value={formData.confirmPassword}
-                  onChange={(e) =>
-                    setFormData({
-                      ...formData,
-                      confirmPassword: e.target.value,
-                    })
-                  }
-                  className="px-9"
-                  aria-invalid={errors.confirmPassword ? "true" : "false"}
-                />
-                <button
-                  type="button"
-                  onClick={() => setShowConfirmPassword(!showConfirmPassword)}
-                  className="text-muted-foreground hover:text-foreground absolute top-1/2 right-3 -translate-y-1/2"
-                >
-                  {showConfirmPassword ? (
-                    <EyeOff className="size-4" />
-                  ) : (
-                    <Eye className="size-4" />
-                  )}
-                </button>
-              </div>
-              {errors.confirmPassword && (
-                <p className="text-destructive text-sm">
-                  {errors.confirmPassword}
-                </p>
-              )}
-            </div>
-
-            <Button type="submit" className="w-full" disabled={isLoading}>
-              {isLoading ? (
-                <>
-                  <Loader2 className="mr-2 size-4 animate-spin" />
-                  Resetting password...
-                </>
-              ) : (
-                "Reset password"
-              )}
-            </Button>
-          </form>
-
-          <div className="text-center">
-            <Link
-              href="/customer/auth/login"
-              className="text-primary inline-flex items-center text-sm hover:underline"
-            >
-              <ArrowLeft className="mr-1 size-3" />
-              Back to login
-            </Link>
-          </div>
-        </CardContent>
-      </Card>
-    </div>
-  );
-}
-
-export default function ResetPasswordPage() {
-  return (
-    <Suspense
-      fallback={
-        <div className="from-background via-muted/20 to-background flex min-h-screen items-center justify-center bg-linear-to-br p-4">
-          <Card className="w-full max-w-md">
-            <CardContent className="pt-6">
-              <div className="flex items-center justify-center">
-                <Loader2 className="text-muted-foreground size-6 animate-spin" />
-              </div>
-            </CardContent>
-          </Card>
+      <AuthCard
+        title="Invalid reset link"
+        description="This password reset link has expired, was already used, or was opened out of order."
+      >
+        <div className="bg-destructive/10 text-destructive rounded-lg p-4 text-sm">
+          Reset links work once and last one hour. Request a fresh one and open
+          it in the same browser.
         </div>
-      }
+        <div className="flex flex-col gap-2">
+          <Button asChild className="w-full">
+            <Link href="/customer/auth/forgot-password">
+              Request new reset link
+            </Link>
+          </Button>
+          <Button asChild variant="ghost" className="w-full">
+            <Link href="/login">
+              <ArrowLeft className="mr-2 size-4" />
+              Back to sign in
+            </Link>
+          </Button>
+        </div>
+      </AuthCard>
+    );
+  }
+
+  return (
+    <AuthCard
+      title="Reset your password"
+      description={`Choose a new password for ${user.email}`}
     >
       <ResetPasswordForm />
-    </Suspense>
+    </AuthCard>
   );
 }

--- a/src/app/customer/auth/signup/page.tsx
+++ b/src/app/customer/auth/signup/page.tsx
@@ -25,7 +25,6 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
-import { Separator } from "@/components/ui/separator";
 import {
   getEnabledCustomerLanguageOptions,
   getCustomerLanguageLabel,
@@ -33,7 +32,8 @@ import {
   type AppLocale,
 } from "@/lib/language-settings";
 import { Eye, EyeOff, Mail, Lock, User, Loader2 } from "lucide-react";
-import { getErrorMessage } from "@/lib/errors";
+import { signUp } from "@/lib/auth/actions";
+import { AUTH_INITIAL_STATE } from "@/lib/auth/form-state";
 
 const SIGNUP_PREFERRED_LANGUAGE_STORAGE_KEY =
   "customer-signup-preferred-language-by-email";
@@ -131,6 +131,11 @@ export default function SignUpPage() {
     preferredLanguage: "",
   });
   const [errors, setErrors] = useState<Record<string, string>>({});
+  // Set when the account was created but a confirmation email must be opened
+  // before there is a session to redirect into.
+  const [pendingConfirmation, setPendingConfirmation] = useState<string | null>(
+    null,
+  );
 
   useEffect(() => {
     setHasHydrated(true);
@@ -155,28 +160,6 @@ export default function SignUpPage() {
     preferredLanguageEnabledByFacility,
   ]);
 
-  const validatePreferredLanguageSelection = () => {
-    if (!preferredLanguageEnabledByFacility) return true;
-
-    const selectedIsValid = customerLanguageOptions.some(
-      (option) => option.code === formData.preferredLanguage,
-    );
-
-    if (selectedIsValid) {
-      setErrors((current) => ({
-        ...current,
-        preferredLanguage: "",
-      }));
-      return true;
-    }
-
-    setErrors((current) => ({
-      ...current,
-      preferredLanguage: "Please choose a preferred language",
-    }));
-    return false;
-  };
-
   const validateForm = () => {
     const newErrors: Record<string, string> = {};
 
@@ -192,8 +175,10 @@ export default function SignUpPage() {
 
     if (!formData.password) {
       newErrors.password = "Password is required";
-    } else if (formData.password.length < 8) {
-      newErrors.password = "Password must be at least 8 characters";
+    } else if (formData.password.length < 12) {
+      // Matches the server policy in lib/auth/actions. Checking a weaker rule
+      // here would just mean the server rejects what this page accepted.
+      newErrors.password = "Password must be at least 12 characters";
     }
 
     if (!formData.confirmPassword) {
@@ -225,210 +210,85 @@ export default function SignUpPage() {
 
     setIsLoading(true);
 
-    try {
-      // TODO: Replace with actual API call
-      // Check if customer exists with same email
-      const existingCustomer = await checkExistingCustomer(formData.email);
+    const language = preferredLanguageEnabledByFacility
+      ? formData.preferredLanguage
+      : undefined;
 
-      const redirectTo =
-        fromEstimate && estimateToken
-          ? `/customer/estimates/${estimateToken}`
-          : "/customer/dashboard";
+    const redirectTo =
+      fromEstimate && estimateToken
+        ? `/customer/estimates/${estimateToken}`
+        : "/customer/dashboard";
 
-      if (existingCustomer) {
-        await linkAccount(formData.email, formData.password);
-        savePreferredLanguageForEmail(
-          formData.email,
-          preferredLanguageEnabledByFacility
-            ? formData.preferredLanguage
-            : undefined,
-        );
-        applyAccountLocale(
-          preferredLanguageEnabledByFacility
-            ? formData.preferredLanguage
-            : undefined,
-        );
-        toast.success("Account connected successfully!");
-        router.push(redirectTo);
-      } else {
-        await createAccount(formData);
-        savePreferredLanguageForEmail(
-          formData.email,
-          preferredLanguageEnabledByFacility
-            ? formData.preferredLanguage
-            : undefined,
-        );
-        applyAccountLocale(
-          preferredLanguageEnabledByFacility
-            ? formData.preferredLanguage
-            : undefined,
-        );
-        toast.success("Account created successfully!");
-        router.push(redirectTo);
-      }
-    } catch (error: unknown) {
-      toast.error(
-        getErrorMessage(error) || "Something went wrong. Please try again.",
-      );
-    } finally {
+    // Real account creation. The action owns validation, the enumeration-safe
+    // messaging, and the confirmation email pointed at /auth/callback.
+    const payload = new FormData();
+    payload.set("fullName", formData.name);
+    payload.set("email", formData.email);
+    payload.set("password", formData.password);
+    payload.set("redirectTo", redirectTo);
+
+    const result = await signUp(AUTH_INITIAL_STATE, payload);
+
+    if (result.error) {
       setIsLoading(false);
-    }
-  };
-
-  const handleGoogleSignUp = async () => {
-    if (!validatePreferredLanguageSelection()) {
+      toast.error(result.error);
       return;
     }
 
-    setIsLoading(true);
-    try {
-      // TODO: Replace with actual Google OAuth implementation
-      const googleUser = await signInWithGoogle();
+    // Language preference is a local display setting, not account data, so it
+    // is stored regardless of whether confirmation is still pending.
+    savePreferredLanguageForEmail(formData.email, language);
+    applyAccountLocale(language);
+    addLocalClientRecord(formData, language);
 
-      // Check if customer exists with same email
-      const existingCustomer = await checkExistingCustomer(googleUser.email);
+    setIsLoading(false);
 
-      if (existingCustomer) {
-        // Link Google account to existing customer
-        await linkGoogleAccount(googleUser);
-        savePreferredLanguageForEmail(
-          googleUser.email,
-          preferredLanguageEnabledByFacility
-            ? formData.preferredLanguage
-            : undefined,
-        );
-        applyAccountLocale(
-          preferredLanguageEnabledByFacility
-            ? formData.preferredLanguage
-            : undefined,
-        );
-        toast.success("Account connected successfully!");
-      } else {
-        // Create new account with Google
-        await createAccountWithGoogle(
-          googleUser,
-          preferredLanguageEnabledByFacility
-            ? formData.preferredLanguage
-            : undefined,
-        );
-        savePreferredLanguageForEmail(
-          googleUser.email,
-          preferredLanguageEnabledByFacility
-            ? formData.preferredLanguage
-            : undefined,
-        );
-        applyAccountLocale(
-          preferredLanguageEnabledByFacility
-            ? formData.preferredLanguage
-            : undefined,
-        );
-        toast.success("Account created successfully!");
-      }
-
-      router.push("/customer/dashboard");
-    } catch (error: unknown) {
-      toast.error(getErrorMessage(error) || "Failed to sign up with Google");
-    } finally {
-      setIsLoading(false);
-    }
-  };
-
-  // Placeholder functions - replace with actual API calls
-  const checkExistingCustomer = async (_email: string) => {
-    // TODO: API call to check if customer exists
-    await new Promise((resolve) => setTimeout(resolve, 500));
-    return false; // Mock: no existing customer
-  };
-
-  const linkAccount = async (_email: string, _password: string) => {
-    // TODO: API call to link account
-    await new Promise((resolve) => setTimeout(resolve, 1000));
-  };
-
-  const createAccount = async (data: typeof formData) => {
-    // TODO: API call to create account
-    const existingByEmail = clients.some(
-      (client) =>
-        client.email.trim().toLowerCase() === data.email.trim().toLowerCase(),
-    );
-
-    if (!existingByEmail) {
-      const maxId = clients.reduce(
-        (max, client) => Math.max(max, client.id),
-        0,
-      );
-
-      clients.push({
-        id: maxId + 1,
-        name: data.name.trim(),
-        email: data.email.trim(),
-        phone: "",
-        preferredLanguage: data.preferredLanguage,
-        status: "active",
-        facility: targetFacilityName ?? "Example Pet Care Facility",
-        address: {
-          street: "",
-          city: "",
-          state: "",
-          zip: "",
-          country: "",
-        },
-        additionalContacts: [],
-        pets: [],
-      });
+    if (result.success) {
+      // Confirmation is on: no session yet, so there is nowhere to send them.
+      setPendingConfirmation(result.success);
+      return;
     }
 
-    await new Promise((resolve) => setTimeout(resolve, 1000));
+    // Confirmation off — signUp redirected server-side and we never get here.
+    toast.success("Account created successfully!");
+    router.push(redirectTo);
   };
 
-  const signInWithGoogle = async () => {
-    // TODO: Implement Google OAuth
-    await new Promise((resolve) => setTimeout(resolve, 1000));
-    return { email: "user@example.com", name: "User Name" };
-  };
-
-  const linkGoogleAccount = async (_googleUser: unknown) => {
-    // TODO: API call to link Google account
-    await new Promise((resolve) => setTimeout(resolve, 1000));
-  };
-
-  const createAccountWithGoogle = async (
-    googleUser: { email: string; name: string },
-    preferredLanguage?: string,
+  /**
+   * BRIDGE — delete when a `clients` table exists.
+   *
+   * The customer portal reads its client records from the `clients` mock
+   * array, and Postgres has no equivalent table yet (orgs, facilities,
+   * locations, profiles and memberships are real; customers are not). Without
+   * this, a real signup produces a real Supabase account that the customer
+   * pages cannot find anything for.
+   *
+   * It is in-memory only and does not survive a reload — which is precisely
+   * why the clients table is the next schema to land, not something to paper
+   * over further.
+   */
+  const addLocalClientRecord = (
+    data: typeof formData,
+    preferredLanguage: string | undefined,
   ) => {
-    // TODO: API call to create account with Google
-    const existingByEmail = clients.some(
-      (client) =>
-        client.email.trim().toLowerCase() === googleUser.email.toLowerCase(),
-    );
-
-    if (!existingByEmail) {
-      const maxId = clients.reduce(
-        (max, client) => Math.max(max, client.id),
-        0,
-      );
-
-      clients.push({
-        id: maxId + 1,
-        name: googleUser.name,
-        email: googleUser.email,
-        phone: "",
-        preferredLanguage,
-        status: "active",
-        facility: targetFacilityName ?? "Example Pet Care Facility",
-        address: {
-          street: "",
-          city: "",
-          state: "",
-          zip: "",
-          country: "",
-        },
-        additionalContacts: [],
-        pets: [],
-      });
+    const email = data.email.trim().toLowerCase();
+    if (clients.some((client) => client.email.trim().toLowerCase() === email)) {
+      return;
     }
 
-    await new Promise((resolve) => setTimeout(resolve, 1000));
+    const maxId = clients.reduce((max, client) => Math.max(max, client.id), 0);
+    clients.push({
+      id: maxId + 1,
+      name: data.name.trim(),
+      email: data.email.trim(),
+      phone: "",
+      preferredLanguage,
+      status: "active",
+      facility: targetFacilityName ?? "Example Pet Care Facility",
+      address: { street: "", city: "", state: "", zip: "", country: "" },
+      additionalContacts: [],
+      pets: [],
+    });
   };
 
   return (
@@ -508,46 +368,22 @@ export default function SignUpPage() {
                 </div>
               )}
 
-              <div className="space-y-3 rounded-lg border border-slate-200 bg-slate-50/60 p-3">
-                <Button
-                  type="button"
-                  variant="outline"
-                  className="h-11 w-full border-slate-300 bg-white shadow-xs hover:bg-slate-100"
-                  onClick={handleGoogleSignUp}
-                  disabled={isLoading}
-                >
-                  <svg className="mr-2 size-4" viewBox="0 0 24 24">
-                    <path
-                      d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
-                      fill="#4285F4"
-                    />
-                    <path
-                      d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
-                      fill="#34A853"
-                    />
-                    <path
-                      d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
-                      fill="#FBBC05"
-                    />
-                    <path
-                      d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
-                      fill="#EA4335"
-                    />
-                  </svg>
-                  Continue with Google
-                </Button>
+              {/*
+                "Continue with Google" was removed here, as on the login page.
+                It called a stub returning a hardcoded user@example.com and
+                created a local client record for that fake person. Turning it
+                on for real means enabling Google under Authentication >
+                Providers and calling signInWithOAuth against /auth/callback.
+              */}
 
-                <div className="relative py-0.5">
-                  <div className="absolute inset-0 flex items-center">
-                    <Separator />
-                  </div>
-                  <div className="relative flex justify-center text-xs uppercase">
-                    <span className="text-muted-foreground bg-slate-50/80 px-2">
-                      Or continue with email
-                    </span>
-                  </div>
-                </div>
-              </div>
+              {pendingConfirmation && (
+                <p
+                  role="status"
+                  className="rounded-md border border-emerald-600/40 bg-emerald-600/10 px-3 py-2 text-sm text-emerald-700 dark:text-emerald-400"
+                >
+                  {pendingConfirmation}
+                </p>
+              )}
 
               <form onSubmit={handleSubmit} className="space-y-4">
                 <div className="space-y-2">

--- a/src/app/customer/layout.tsx
+++ b/src/app/customer/layout.tsx
@@ -1,59 +1,26 @@
-"use client";
+import { canAccessCustomerPortal } from "@/lib/auth/viewer";
+import { guardPortal } from "@/lib/auth/portal-gate";
+import { CustomerShell } from "./_shell";
 
-import { usePathname } from "next/navigation";
-import Link from "next/link";
-import { MessageCircle } from "lucide-react";
-import { CustomerFacilityProvider } from "@/hooks/use-customer-facility";
-import { SettingsProviderWrapper } from "@/components/providers/ModulesConfigProviderWrapper";
-import { BookingModalProviderWrapper } from "@/components/providers/BookingModalProviderWrapper";
-import { CustomerHeader } from "@/components/customer/CustomerHeader";
-import { SidebarProvider, SidebarInset } from "@/components/ui/sidebar";
-import { CustomerSidebar } from "@/components/customer/CustomerSidebar";
+// ============================================================================
+// Customer portal.
+//
+// Now a Server Component so it can gate. The chrome moved to _shell.tsx, which
+// still needs the pathname on the client.
+//
+// /customer/auth/* is exempt for the obvious reason: gating the login page
+// makes signing in impossible.
+// ============================================================================
 
-export default function CustomerLayout({
+export default async function CustomerLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
-  const pathname = usePathname();
-  const isAuthRoute = pathname?.startsWith("/customer/auth");
+  await guardPortal({
+    allow: canAccessCustomerPortal,
+    publicPrefixes: ["/customer/auth"],
+  });
 
-  return (
-    <SettingsProviderWrapper>
-      <CustomerFacilityProvider>
-        <BookingModalProviderWrapper>
-          {isAuthRoute ? (
-            <div className="flex min-h-screen flex-col">
-              <main className="flex-1">{children}</main>
-            </div>
-          ) : (
-            <SidebarProvider>
-              <>
-                <CustomerSidebar />
-                <SidebarInset className="flex min-h-screen min-w-0 flex-col overflow-x-clip">
-                  <CustomerHeader />
-                  <main className="min-w-0 flex-1 overflow-x-hidden">
-                    {children}
-                  </main>
-
-                  {/* Floating chat bubble */}
-                  {!pathname?.includes("/messages") && (
-                    <Link
-                      href="/customer/messages"
-                      className="fixed right-6 bottom-6 z-50 flex size-14 items-center justify-center rounded-full bg-blue-500 text-white shadow-lg shadow-blue-200 transition-all hover:-translate-y-1 hover:bg-blue-600 hover:shadow-xl"
-                    >
-                      <MessageCircle className="size-6" />
-                      <span className="absolute -top-1 -right-1 flex size-5 items-center justify-center rounded-full bg-red-500 text-[10px] font-bold text-white ring-2 ring-white">
-                        2
-                      </span>
-                    </Link>
-                  )}
-                </SidebarInset>
-              </>
-            </SidebarProvider>
-          )}
-        </BookingModalProviderWrapper>
-      </CustomerFacilityProvider>
-    </SettingsProviderWrapper>
-  );
+  return <CustomerShell>{children}</CustomerShell>;
 }

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -1,9 +1,5 @@
-import { redirect } from "next/navigation";
-import {
-  canAccessAdminPortal,
-  getViewer,
-  isAuthEnforced,
-} from "@/lib/auth/viewer";
+import { canAccessAdminPortal } from "@/lib/auth/viewer";
+import { guardPortal } from "@/lib/auth/portal-gate";
 import { AppSidebar } from "@/components/layout/super-admin-sidebar";
 import { Metadata } from "next";
 import {
@@ -27,18 +23,13 @@ export default async function DashboardLayout({
 }: {
   children: React.ReactNode;
 }) {
-  const viewer = await getViewer();
-
   // Until AUTH_ENFORCED is on this is the old rule verbatim: facility admins
   // get sent to their own portal, everyone else is let through. After it, the
   // only way in is the platform-admin flag on the profile.
-  if (!canAccessAdminPortal(viewer)) {
-    redirect(
-      isAuthEnforced() && viewer.source !== "session"
-        ? "/customer/auth/login"
-        : "/facility/dashboard",
-    );
-  }
+  await guardPortal({
+    allow: canAccessAdminPortal,
+    whenWrongPortal: "/facility/dashboard",
+  });
 
   return (
     <SidebarProvider>

--- a/src/app/employee/layout.tsx
+++ b/src/app/employee/layout.tsx
@@ -1,0 +1,25 @@
+import { canAccessStaffPortal } from "@/lib/auth/viewer";
+import { guardPortal } from "@/lib/auth/portal-gate";
+
+// ============================================================================
+// Employee portal — authentication.
+//
+// The (shell) layout below already refuses to render without an
+// `employee_staff_id` cookie, but that is a "which staff member am I working
+// as" check, not a "who are you" one: it is set by /employee/select, which was
+// itself reachable by anyone. Picking an identity is not proving one.
+//
+// This sits above both, so /employee/select is covered too. No public prefixes
+// — the employee portal has no auth screens of its own; staff sign in at
+// /staff/auth/login or /login.
+// ============================================================================
+
+export default async function EmployeeLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  await guardPortal({ allow: canAccessStaffPortal });
+
+  return <>{children}</>;
+}

--- a/src/app/facility/layout.tsx
+++ b/src/app/facility/layout.tsx
@@ -1,10 +1,5 @@
-import { redirect } from "next/navigation";
-import {
-  canAccessFacilityPortal,
-  canManageCustomers,
-  getViewer,
-  isAuthEnforced,
-} from "@/lib/auth/viewer";
+import { canAccessFacilityPortal, canManageCustomers } from "@/lib/auth/viewer";
+import { guardPortal } from "@/lib/auth/portal-gate";
 import { FacilitySidebar } from "@/components/layout/facility-admin-sidebar";
 import {
   SidebarInset,
@@ -34,20 +29,12 @@ export default async function FacilityLayout({
   children: React.ReactNode;
 }) {
   // One identity for the whole portal, from the signed JWT when there is a
-  // session. The gate itself still answers with the old cookie rule until
+  // session. The gate still answers with the old cookie rule until
   // AUTH_ENFORCED is switched on — see lib/auth/viewer.ts.
-  const viewer = await getViewer();
-
-  if (!canAccessFacilityPortal(viewer)) {
-    // Signed out under enforcement is a different failure from signed in as
-    // the wrong person: one needs a login, the other needs somewhere else to
-    // go. Sending the first case to /dashboard would just bounce them back.
-    redirect(
-      isAuthEnforced() && viewer.source !== "session"
-        ? "/customer/auth/login"
-        : "/dashboard",
-    );
-  }
+  const viewer = await guardPortal({
+    allow: canAccessFacilityPortal,
+    whenWrongPortal: "/dashboard",
+  });
 
   const canCreateCustomer = canManageCustomers(viewer);
 

--- a/src/app/groomer/_shell.tsx
+++ b/src/app/groomer/_shell.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+
+import { SettingsProviderWrapper } from "@/components/providers/ModulesConfigProviderWrapper";
+import { GroomerHeader } from "@/components/groomer/GroomerHeader";
+import { SidebarProvider, SidebarInset } from "@/components/ui/sidebar";
+import { GroomerSidebar } from "@/components/groomer/GroomerSidebar";
+
+/** Groomer chrome. Split from layout.tsx so the layout can gate on the server. */
+export function GroomerShell({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname();
+  const isAuthRoute = pathname?.startsWith("/groomer/auth");
+
+  return (
+    <SettingsProviderWrapper>
+      {isAuthRoute ? (
+        <div className="flex min-h-screen flex-col">
+          <main className="flex-1">{children}</main>
+        </div>
+      ) : (
+        <SidebarProvider>
+          <>
+            <GroomerSidebar />
+            <SidebarInset className="flex min-h-screen flex-col">
+              <GroomerHeader />
+              <main className="flex-1 overflow-x-hidden">{children}</main>
+            </SidebarInset>
+          </>
+        </SidebarProvider>
+      )}
+    </SettingsProviderWrapper>
+  );
+}

--- a/src/app/groomer/auth/forgot-password/page.tsx
+++ b/src/app/groomer/auth/forgot-password/page.tsx
@@ -1,138 +1,38 @@
 "use client";
 
-import { useState } from "react";
-import Link from "next/link";
-import { toast } from "sonner";
-import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
+import { Scissors } from "lucide-react";
+
+import { AuthCard } from "@/components/auth/AuthCard";
 import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
-import { Mail, Loader2, Scissors, ArrowLeft } from "lucide-react";
+  ForgotPasswordForm,
+  ResetLinkSent,
+} from "@/components/auth/ForgotPasswordForm";
 
-export default function ForgotPasswordPage() {
-  const [isLoading, setIsLoading] = useState(false);
-  const [email, setEmail] = useState("");
-  const [isSubmitted, setIsSubmitted] = useState(false);
+// ============================================================================
+// Groomer password reset — the same real flow as everywhere else, with the
+// grooming mark on it. Previously a stub that slept a second and then claimed
+// an email had been sent.
+// ============================================================================
 
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-
-    if (!email.trim()) {
-      toast.error("Email is required");
-      return;
-    }
-
-    setIsLoading(true);
-
-    try {
-      // TODO: Replace with actual API call
-      await new Promise((resolve) => setTimeout(resolve, 1000));
-      setIsSubmitted(true);
-      toast.success("Password reset email sent!");
-    } catch (error: unknown) {
-      toast.error(
-        error instanceof Error ? error.message : "Failed to send reset email",
-      );
-    } finally {
-      setIsLoading(false);
-    }
-  };
-
-  if (isSubmitted) {
-    return (
-      <div className="from-background via-muted/20 to-background flex min-h-screen items-center justify-center bg-linear-to-br p-4">
-        <Card className="w-full max-w-md">
-          <CardHeader className="space-y-1 text-center">
-            <div className="mb-4 flex justify-center">
-              <div className="flex h-16 w-16 items-center justify-center rounded-full bg-linear-to-br from-pink-500 to-rose-500">
-                <Scissors className="size-8 text-white" />
-              </div>
-            </div>
-            <CardTitle className="text-2xl font-bold">
-              Check your email
-            </CardTitle>
-            <CardDescription>
-              We&apos;ve sent a password reset link to {email}
-            </CardDescription>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            <p className="text-muted-foreground text-center text-sm">
-              If you don&apos;t see the email, check your spam folder.
-            </p>
-            <Button asChild className="w-full" variant="outline">
-              <Link href="/groomer/auth/login">
-                <ArrowLeft className="mr-2 size-4" />
-                Back to login
-              </Link>
-            </Button>
-          </CardContent>
-        </Card>
-      </div>
-    );
-  }
-
+export default function GroomerForgotPasswordPage() {
   return (
-    <div className="from-background via-muted/20 to-background flex min-h-screen items-center justify-center bg-linear-to-br p-4">
-      <Card className="w-full max-w-md">
-        <CardHeader className="space-y-1 text-center">
-          <div className="mb-4 flex justify-center">
-            <div className="flex h-16 w-16 items-center justify-center rounded-full bg-linear-to-br from-pink-500 to-rose-500">
-              <Scissors className="size-8 text-white" />
-            </div>
-          </div>
-          <CardTitle className="text-2xl font-bold">Forgot Password</CardTitle>
-          <CardDescription>
-            Enter your email to receive a password reset link
-          </CardDescription>
-        </CardHeader>
-        <CardContent>
-          <form onSubmit={handleSubmit} className="space-y-4">
-            <div className="space-y-2">
-              <Label htmlFor="email">Email</Label>
-              <div className="relative">
-                <Mail className="text-muted-foreground absolute top-3 left-3 size-4" />
-                <Input
-                  id="email"
-                  type="email"
-                  placeholder="your.email@example.com"
-                  value={email}
-                  onChange={(e) => setEmail(e.target.value)}
-                  className="pl-10"
-                  disabled={isLoading}
-                  required
-                />
-              </div>
-            </div>
-
-            <Button type="submit" className="w-full" disabled={isLoading}>
-              {isLoading ? (
-                <>
-                  <Loader2 className="mr-2 size-4 animate-spin" />
-                  Sending...
-                </>
-              ) : (
-                "Send Reset Link"
-              )}
-            </Button>
-          </form>
-
-          <div className="mt-6 text-center">
-            <Link
-              href="/groomer/auth/login"
-              className="text-primary text-sm hover:underline"
-            >
-              <ArrowLeft className="mr-1 inline size-3" />
-              Back to login
-            </Link>
-          </div>
-        </CardContent>
-      </Card>
-    </div>
+    <AuthCard
+      title="Forgot password?"
+      description="We'll email you a link to set a new one"
+      brand={
+        <div className="flex size-16 items-center justify-center rounded-full bg-linear-to-br from-pink-500 to-rose-500">
+          <Scissors className="size-8 text-white" />
+        </div>
+      }
+    >
+      <ForgotPasswordForm
+        redirectTo="/customer/auth/reset-password"
+        backHref="/groomer/auth/login"
+      >
+        {(message) => (
+          <ResetLinkSent message={message} backHref="/groomer/auth/login" />
+        )}
+      </ForgotPasswordForm>
+    </AuthCard>
   );
 }

--- a/src/app/groomer/auth/login/page.tsx
+++ b/src/app/groomer/auth/login/page.tsx
@@ -1,190 +1,37 @@
-"use client";
+import type { Metadata } from "next";
+import { Scissors } from "lucide-react";
 
-import { useState } from "react";
-import { useRouter } from "next/navigation";
-import Link from "next/link";
-import { toast } from "sonner";
-import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
-import { Separator } from "@/components/ui/separator";
-import { Eye, EyeOff, Mail, Lock, Loader2, Scissors } from "lucide-react";
-import { setCurrentUserId } from "@/lib/role-utils";
-import { stylists } from "@/data/grooming";
+import { AuthCard } from "@/components/auth/AuthCard";
+import { SignInForm } from "@/components/auth/SignInForm";
+
+export const metadata: Metadata = { title: "Groomer sign in — Yipyy" };
+
+// ============================================================================
+// Groomer sign-in.
+//
+// This page used to look the caller up in the `stylists` mock array and then
+// accept ANY non-empty password — a comment said "For now, accept any password
+// for demo purposes". Anyone who knew a groomer's email address was that
+// groomer. It now goes through the same Supabase sign-in as every other portal.
+//
+// A groomer reaches their dashboard because their membership role says so
+// (landingPathForClaims), not because they used this URL — so a caretaker who
+// signs in here still lands on the employee schedule rather than a dashboard
+// built for someone else's job.
+// ============================================================================
 
 export default function GroomerLoginPage() {
-  const router = useRouter();
-  const [isLoading, setIsLoading] = useState(false);
-  const [showPassword, setShowPassword] = useState(false);
-  const [formData, setFormData] = useState({
-    email: "",
-    password: "",
-  });
-  const [errors, setErrors] = useState<Record<string, string>>({});
-
-  const validateForm = () => {
-    const newErrors: Record<string, string> = {};
-
-    if (!formData.email.trim()) {
-      newErrors.email = "Email is required";
-    } else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(formData.email)) {
-      newErrors.email = "Please enter a valid email address";
-    }
-
-    if (!formData.password) {
-      newErrors.password = "Password is required";
-    }
-
-    setErrors(newErrors);
-    return Object.keys(newErrors).length === 0;
-  };
-
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-
-    if (!validateForm()) {
-      return;
-    }
-
-    setIsLoading(true);
-
-    try {
-      // Find groomer by email
-      const groomer = stylists.find(
-        (s) => s.email.toLowerCase() === formData.email.toLowerCase(),
-      );
-
-      if (!groomer) {
-        throw new Error("Invalid email or password");
-      }
-
-      // In a real app, verify password with API
-      // For now, accept any password for demo purposes
-      if (!formData.password) {
-        throw new Error("Invalid email or password");
-      }
-
-      // Set the current user ID to the groomer's ID
-      setCurrentUserId(groomer.id);
-
-      toast.success("Welcome back!");
-      router.push("/groomer/dashboard");
-    } catch (error: unknown) {
-      toast.error(
-        error instanceof Error ? error.message : "Invalid email or password",
-      );
-    } finally {
-      setIsLoading(false);
-    }
-  };
-
   return (
-    <div className="from-background via-muted/20 to-background flex min-h-screen items-center justify-center bg-linear-to-br p-4">
-      <Card className="w-full max-w-md">
-        <CardHeader className="space-y-1 text-center">
-          <div className="mb-4 flex justify-center">
-            <div className="flex h-16 w-16 items-center justify-center rounded-full bg-linear-to-br from-pink-500 to-rose-500">
-              <Scissors className="size-8 text-white" />
-            </div>
-          </div>
-          <CardTitle className="text-2xl font-bold">Groomer Login</CardTitle>
-          <CardDescription>
-            Sign in to access your grooming dashboard
-          </CardDescription>
-        </CardHeader>
-        <CardContent>
-          <form onSubmit={handleSubmit} className="space-y-4">
-            <div className="space-y-2">
-              <Label htmlFor="email">Email</Label>
-              <div className="relative">
-                <Mail className="text-muted-foreground absolute top-3 left-3 size-4" />
-                <Input
-                  id="email"
-                  type="email"
-                  placeholder="your.email@example.com"
-                  value={formData.email}
-                  onChange={(e) =>
-                    setFormData({ ...formData, email: e.target.value })
-                  }
-                  className={`pl-10 ${errors.email ? "border-destructive" : ""} `}
-                  disabled={isLoading}
-                />
-              </div>
-              {errors.email && (
-                <p className="text-destructive text-sm">{errors.email}</p>
-              )}
-            </div>
-
-            <div className="space-y-2">
-              <Label htmlFor="password">Password</Label>
-              <div className="relative">
-                <Lock className="text-muted-foreground absolute top-3 left-3 size-4" />
-                <Input
-                  id="password"
-                  type={showPassword ? "text" : "password"}
-                  placeholder="Enter your password"
-                  value={formData.password}
-                  onChange={(e) =>
-                    setFormData({ ...formData, password: e.target.value })
-                  }
-                  className={`px-10 ${errors.password ? "border-destructive" : ""} `}
-                  disabled={isLoading}
-                />
-                <button
-                  type="button"
-                  onClick={() => setShowPassword(!showPassword)}
-                  className="text-muted-foreground hover:text-foreground absolute top-3 right-3"
-                  disabled={isLoading}
-                >
-                  {showPassword ? (
-                    <EyeOff className="size-4" />
-                  ) : (
-                    <Eye className="size-4" />
-                  )}
-                </button>
-              </div>
-              {errors.password && (
-                <p className="text-destructive text-sm">{errors.password}</p>
-              )}
-            </div>
-
-            <div className="flex items-center justify-between text-sm">
-              <Link
-                href="/groomer/auth/forgot-password"
-                className="text-primary hover:underline"
-              >
-                Forgot password?
-              </Link>
-            </div>
-
-            <Button type="submit" className="w-full" disabled={isLoading}>
-              {isLoading ? (
-                <>
-                  <Loader2 className="mr-2 size-4 animate-spin" />
-                  Signing in...
-                </>
-              ) : (
-                "Sign In"
-              )}
-            </Button>
-          </form>
-
-          <div className="mt-6">
-            <Separator />
-            <div className="text-muted-foreground mt-4 text-center text-sm">
-              <p>Demo: Use any groomer email from the system</p>
-              <p className="mt-2 text-xs">Example: jessica@pawsplay.com</p>
-            </div>
-          </div>
-        </CardContent>
-      </Card>
-    </div>
+    <AuthCard
+      title="Groomer Login"
+      description="Sign in to access your grooming dashboard"
+      brand={
+        <div className="flex size-16 items-center justify-center rounded-full bg-linear-to-br from-pink-500 to-rose-500">
+          <Scissors className="size-8 text-white" />
+        </div>
+      }
+    >
+      <SignInForm forgotHref="/groomer/auth/forgot-password" />
+    </AuthCard>
   );
 }

--- a/src/app/groomer/layout.tsx
+++ b/src/app/groomer/layout.tsx
@@ -1,36 +1,28 @@
-"use client";
+import { canAccessStaffPortal } from "@/lib/auth/viewer";
+import { guardPortal } from "@/lib/auth/portal-gate";
+import { legacyStaffIdForEmail } from "@/lib/auth/legacy-identity";
+import { LegacyIdentityBridge } from "@/components/auth/LegacyIdentityBridge";
+import { GroomerShell } from "./_shell";
 
-import { usePathname } from "next/navigation";
-import { SettingsProviderWrapper } from "@/components/providers/ModulesConfigProviderWrapper";
-import { GroomerHeader } from "@/components/groomer/GroomerHeader";
-import { SidebarProvider, SidebarInset } from "@/components/ui/sidebar";
-import { GroomerSidebar } from "@/components/groomer/GroomerSidebar";
+// ============================================================================
+// Groomer portal. Previously ungated entirely — anyone who typed the URL was
+// in, and the login page beneath it accepted any password.
+// ============================================================================
 
-export default function GroomerLayout({
+export default async function GroomerLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
-  const pathname = usePathname();
-  const isAuthRoute = pathname?.startsWith("/groomer/auth");
+  const viewer = await guardPortal({
+    allow: canAccessStaffPortal,
+    publicPrefixes: ["/groomer/auth"],
+  });
 
   return (
-    <SettingsProviderWrapper>
-      {isAuthRoute ? (
-        <div className="flex min-h-screen flex-col">
-          <main className="flex-1">{children}</main>
-        </div>
-      ) : (
-        <SidebarProvider>
-          <>
-            <GroomerSidebar />
-            <SidebarInset className="flex min-h-screen flex-col">
-              <GroomerHeader />
-              <main className="flex-1 overflow-x-hidden">{children}</main>
-            </SidebarInset>
-          </>
-        </SidebarProvider>
-      )}
-    </SettingsProviderWrapper>
+    <>
+      <LegacyIdentityBridge staffId={legacyStaffIdForEmail(viewer.email)} />
+      <GroomerShell>{children}</GroomerShell>
+    </>
   );
 }

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,0 +1,79 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+import { AuthCard } from "@/components/auth/AuthCard";
+import { SignInForm } from "@/components/auth/SignInForm";
+
+export const metadata: Metadata = { title: "Sign in — Yipyy" };
+
+// ============================================================================
+// The canonical sign-in, and the one every portal gate redirects to.
+//
+// It exists because the portals it protects — facility admin, the platform
+// dashboard, the employee schedule — had no login page at all. Denied users
+// were being sent to the *customer* login, which works but is the wrong front
+// door and cannot explain itself.
+//
+// Deliberately portal-neutral: it does not ask who you are, it reads the token
+// afterwards and routes accordingly (see landingPathForClaims). One person may
+// be a groomer at one facility and an owner at another; asking them to pick a
+// portal before signing in asks a question they should not have to answer.
+//
+// A Server Component — only the form inside is interactive.
+// ============================================================================
+
+/** Supabase's own link failures arrive here as prose; keep them readable. */
+function LinkProblem({ reason }: { reason: string }) {
+  return (
+    <p
+      role="alert"
+      className="border-destructive/40 bg-destructive/10 text-destructive rounded-md border px-3 py-2 text-sm"
+    >
+      {reason}
+    </p>
+  );
+}
+
+export default async function LoginPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ error?: string; reset?: string; next?: string }>;
+}) {
+  const params = await searchParams;
+
+  const initialMessage = params.error ? (
+    <LinkProblem reason={params.error} />
+  ) : params.reset ? (
+    <p
+      role="status"
+      className="rounded-md border border-emerald-600/40 bg-emerald-600/10 px-3 py-2 text-sm text-emerald-700 dark:text-emerald-400"
+    >
+      Your password has been updated. Sign in with it below.
+    </p>
+  ) : null;
+
+  return (
+    <AuthCard
+      title="Sign in"
+      description="Use your Yipyy account — we'll take you to the right place."
+    >
+      <SignInForm
+        // No redirectTo: the server picks the portal from the token.
+        redirectTo={params.next}
+        forgotHref="/customer/auth/forgot-password"
+        initialMessage={initialMessage}
+        footer={
+          <p className="text-muted-foreground text-center text-sm">
+            Booking as a pet owner?{" "}
+            <Link
+              href="/customer/auth/signup"
+              className="text-primary font-medium hover:underline"
+            >
+              Create an account
+            </Link>
+          </p>
+        }
+      />
+    </AuthCard>
+  );
+}

--- a/src/app/staff/_shell.tsx
+++ b/src/app/staff/_shell.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+
+import { SettingsProviderWrapper } from "@/components/providers/ModulesConfigProviderWrapper";
+import { StaffHeader } from "@/components/staff/StaffHeader";
+import { SidebarProvider, SidebarInset } from "@/components/ui/sidebar";
+import { StaffSidebar } from "@/components/staff/StaffSidebar";
+
+/** Staff chrome. Split from layout.tsx so the layout can gate on the server. */
+export function StaffShell({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname();
+  const isAuthRoute = pathname?.startsWith("/staff/auth");
+
+  return (
+    <SettingsProviderWrapper>
+      {isAuthRoute ? (
+        <div className="flex min-h-screen flex-col">
+          <main className="flex-1">{children}</main>
+        </div>
+      ) : (
+        <SidebarProvider>
+          <>
+            <StaffSidebar />
+            <SidebarInset className="flex min-h-screen flex-col">
+              <StaffHeader />
+              <main className="flex-1 overflow-x-hidden">{children}</main>
+            </SidebarInset>
+          </>
+        </SidebarProvider>
+      )}
+    </SettingsProviderWrapper>
+  );
+}

--- a/src/app/staff/auth/login/page.tsx
+++ b/src/app/staff/auth/login/page.tsx
@@ -1,125 +1,36 @@
-"use client";
-
-import { useState } from "react";
-import { useRouter } from "next/navigation";
-import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
+import type { Metadata } from "next";
 import { Calendar } from "lucide-react";
-import { setCurrentUserId } from "@/lib/role-utils";
-import { users } from "@/data/users";
-import { toast } from "sonner";
+
+import { AuthCard } from "@/components/auth/AuthCard";
+import { SignInForm } from "@/components/auth/SignInForm";
+
+export const metadata: Metadata = { title: "Staff sign in — Yipyy" };
+
+// ============================================================================
+// Staff sign-in.
+//
+// What was here before: a lookup against the `users` mock array that never
+// checked the password at all, plus a "Quick Login (Demo)" list rendering one
+// button per staff member that signed you in as them with a single click. Both
+// are gone — a password field that is never read is worse than no password
+// field, because it looks like security.
+//
+// Choosing which staff record you are working as is a separate question from
+// proving who you are, and it already has its own screen: /employee/select.
+// ============================================================================
 
 export default function StaffLoginPage() {
-  const router = useRouter();
-  const [email, setEmail] = useState("");
-  const [password, setPassword] = useState("");
-  const [isLoading, setIsLoading] = useState(false);
-
-  const handleLogin = async (e: React.FormEvent) => {
-    e.preventDefault();
-    setIsLoading(true);
-
-    // Simple demo login - in production, this would authenticate with backend
-    const staffMember = users.find(
-      (u) => u.email === email && u.role === "Staff",
-    );
-
-    if (staffMember) {
-      // Set user ID
-      setCurrentUserId(staffMember.id.toString());
-      toast.success(`Welcome back, ${staffMember.name}!`);
-      router.push("/employee/schedule");
-    } else {
-      toast.error("Invalid email or password");
-    }
-
-    setIsLoading(false);
-  };
-
-  // Quick login for demo (bypasses authentication)
-  const handleQuickLogin = (staffId: string) => {
-    setCurrentUserId(staffId);
-    const staffMember = users.find((u) => u.id.toString() === staffId);
-    if (staffMember) {
-      toast.success(`Welcome, ${staffMember.name}!`);
-      router.push("/employee/schedule");
-    }
-  };
-
-  const staffMembers = users.filter((u) => u.role === "Staff");
-
   return (
-    <div className="flex min-h-screen items-center justify-center bg-linear-to-br from-blue-50 to-indigo-50 p-4">
-      <Card className="w-full max-w-md">
-        <CardHeader className="space-y-1 text-center">
-          <div className="mb-4 flex items-center justify-center">
-            <div className="flex size-12 items-center justify-center rounded-lg bg-linear-to-br from-blue-500 to-indigo-500">
-              <Calendar className="size-6 text-white" />
-            </div>
-          </div>
-          <CardTitle className="text-2xl font-bold">Staff Portal</CardTitle>
-          <CardDescription>Sign in to view your schedule</CardDescription>
-        </CardHeader>
-        <CardContent>
-          <form onSubmit={handleLogin} className="space-y-4">
-            <div className="space-y-2">
-              <Label htmlFor="email">Email</Label>
-              <Input
-                id="email"
-                type="email"
-                placeholder="staff@example.com"
-                value={email}
-                onChange={(e) => setEmail(e.target.value)}
-                required
-              />
-            </div>
-            <div className="space-y-2">
-              <Label htmlFor="password">Password</Label>
-              <Input
-                id="password"
-                type="password"
-                placeholder="Enter your password"
-                value={password}
-                onChange={(e) => setPassword(e.target.value)}
-                required
-              />
-            </div>
-            <Button type="submit" className="w-full" disabled={isLoading}>
-              {isLoading ? "Signing in..." : "Sign In"}
-            </Button>
-          </form>
-
-          {/* Quick Login for Demo */}
-          <div className="mt-6 border-t pt-6">
-            <p className="text-muted-foreground mb-3 text-center text-sm">
-              Quick Login (Demo)
-            </p>
-            <div className="space-y-2">
-              {staffMembers.map((staff, index) => (
-                <Button
-                  key={`staff-${staff.id}-${staff.email}-${index}`}
-                  variant="outline"
-                  className="w-full justify-start"
-                  onClick={() => handleQuickLogin(staff.id.toString())}
-                >
-                  <span className="font-medium">{staff.name}</span>
-                  <span className="text-muted-foreground ml-2">
-                    ({staff.email})
-                  </span>
-                </Button>
-              ))}
-            </div>
-          </div>
-        </CardContent>
-      </Card>
-    </div>
+    <AuthCard
+      title="Staff Login"
+      description="Sign in to view your schedule and shifts"
+      brand={
+        <div className="flex size-16 items-center justify-center rounded-full bg-linear-to-br from-blue-500 to-indigo-500">
+          <Calendar className="size-8 text-white" />
+        </div>
+      }
+    >
+      <SignInForm forgotHref="/customer/auth/forgot-password" />
+    </AuthCard>
   );
 }

--- a/src/app/staff/layout.tsx
+++ b/src/app/staff/layout.tsx
@@ -1,36 +1,28 @@
-"use client";
+import { canAccessStaffPortal } from "@/lib/auth/viewer";
+import { guardPortal } from "@/lib/auth/portal-gate";
+import { legacyStaffIdForEmail } from "@/lib/auth/legacy-identity";
+import { LegacyIdentityBridge } from "@/components/auth/LegacyIdentityBridge";
+import { StaffShell } from "./_shell";
 
-import { usePathname } from "next/navigation";
-import { SettingsProviderWrapper } from "@/components/providers/ModulesConfigProviderWrapper";
-import { StaffHeader } from "@/components/staff/StaffHeader";
-import { SidebarProvider, SidebarInset } from "@/components/ui/sidebar";
-import { StaffSidebar } from "@/components/staff/StaffSidebar";
+// ============================================================================
+// Staff portal. Previously ungated, beneath a login that never checked a
+// password and offered one-click sign-in as any staff member.
+// ============================================================================
 
-export default function StaffLayout({
+export default async function StaffLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
-  const pathname = usePathname();
-  const isAuthRoute = pathname?.startsWith("/staff/auth");
+  const viewer = await guardPortal({
+    allow: canAccessStaffPortal,
+    publicPrefixes: ["/staff/auth"],
+  });
 
   return (
-    <SettingsProviderWrapper>
-      {isAuthRoute ? (
-        <div className="flex min-h-screen flex-col">
-          <main className="flex-1">{children}</main>
-        </div>
-      ) : (
-        <SidebarProvider>
-          <>
-            <StaffSidebar />
-            <SidebarInset className="flex min-h-screen flex-col">
-              <StaffHeader />
-              <main className="flex-1 overflow-x-hidden">{children}</main>
-            </SidebarInset>
-          </>
-        </SidebarProvider>
-      )}
-    </SettingsProviderWrapper>
+    <>
+      <LegacyIdentityBridge staffId={legacyStaffIdForEmail(viewer.email)} />
+      <StaffShell>{children}</StaffShell>
+    </>
   );
 }

--- a/src/components/auth/AuthCard.tsx
+++ b/src/components/auth/AuthCard.tsx
@@ -1,0 +1,63 @@
+import Image from "next/image";
+
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+
+// ============================================================================
+// The shell every auth screen sits in.
+//
+// Eight pages had eight copies of this markup, which is how the customer login
+// and the groomer login drifted into using different padding, different icon
+// offsets and different error styling for the same job. One shell, one set of
+// spacing decisions.
+//
+// No "use client": this is presentational, so a Server Component page can use
+// it directly and only the interactive form inside pays for hydration.
+// ============================================================================
+
+export function AuthBrandLogo() {
+  return (
+    <Image
+      src="/yipyy-transparent.png"
+      alt="Yipyy"
+      width={120}
+      height={48}
+      className="h-12 w-auto"
+      // Above the fold on every auth screen, so it is the LCP element.
+      priority
+    />
+  );
+}
+
+export function AuthCard({
+  title,
+  description,
+  brand,
+  children,
+}: {
+  title: string;
+  description?: React.ReactNode;
+  /** Defaults to the Yipyy wordmark; portals with their own mark pass it in. */
+  brand?: React.ReactNode;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="from-background via-muted/20 to-background flex min-h-screen items-center justify-center bg-linear-to-br p-4">
+      <Card className="w-full max-w-md">
+        <CardHeader className="space-y-1 text-center">
+          <div className="mb-4 flex justify-center">
+            {brand ?? <AuthBrandLogo />}
+          </div>
+          <CardTitle className="text-2xl font-bold">{title}</CardTitle>
+          {description && <CardDescription>{description}</CardDescription>}
+        </CardHeader>
+        <CardContent className="space-y-4">{children}</CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/components/auth/AuthFormParts.tsx
+++ b/src/components/auth/AuthFormParts.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import { useState } from "react";
+import { useFormStatus } from "react-dom";
+import { Eye, EyeOff, Loader2, Lock } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import type { AuthResult } from "@/lib/auth/form-state";
+
+// ============================================================================
+// The interactive parts of an auth form.
+//
+// Split from AuthCard so the shell stays server-rendered and only these pay
+// for hydration.
+// ============================================================================
+
+/**
+ * Renders whichever of error/success is set.
+ *
+ * `role="alert"` matters beyond accessibility here: a sign-in failure replaces
+ * no visible content, so without it a screen reader announces nothing at all
+ * and the user is left wondering whether the button worked.
+ */
+export function AuthMessage({ state }: { state: AuthResult }) {
+  if (state.error) {
+    return (
+      <p
+        role="alert"
+        className="border-destructive/40 bg-destructive/10 text-destructive rounded-md border px-3 py-2 text-sm"
+      >
+        {state.error}
+      </p>
+    );
+  }
+  if (state.success) {
+    return (
+      <p
+        role="status"
+        className="rounded-md border border-emerald-600/40 bg-emerald-600/10 px-3 py-2 text-sm text-emerald-700 dark:text-emerald-400"
+      >
+        {state.success}
+      </p>
+    );
+  }
+  return null;
+}
+
+/**
+ * Password input with a reveal toggle.
+ *
+ * `useFormStatus` rather than a prop for the disabled state — the button lives
+ * inside the form, so it can read the pending status itself instead of every
+ * page threading it down.
+ */
+export function PasswordField({
+  id,
+  name = id,
+  label,
+  autoComplete,
+  placeholder = "••••••••",
+  invalid,
+}: {
+  id: string;
+  name?: string;
+  label: React.ReactNode;
+  autoComplete: "current-password" | "new-password";
+  placeholder?: string;
+  invalid?: boolean;
+}) {
+  const [visible, setVisible] = useState(false);
+
+  return (
+    <div className="space-y-2">
+      {typeof label === "string" ? <Label htmlFor={id}>{label}</Label> : label}
+      <div className="relative">
+        <Lock className="text-muted-foreground absolute top-1/2 left-3 size-4 -translate-y-1/2" />
+        <Input
+          id={id}
+          name={name}
+          type={visible ? "text" : "password"}
+          autoComplete={autoComplete}
+          required
+          placeholder={placeholder}
+          className="px-9"
+          aria-invalid={invalid ? "true" : "false"}
+        />
+        <button
+          type="button"
+          onClick={() => setVisible((v) => !v)}
+          className="text-muted-foreground hover:text-foreground absolute top-1/2 right-3 -translate-y-1/2"
+          aria-label={visible ? "Hide password" : "Show password"}
+        >
+          {visible ? <EyeOff className="size-4" /> : <Eye className="size-4" />}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export function SubmitButton({
+  children,
+  pendingLabel,
+  className = "w-full",
+}: {
+  children: React.ReactNode;
+  pendingLabel: string;
+  className?: string;
+}) {
+  const { pending } = useFormStatus();
+
+  return (
+    <Button type="submit" className={className} disabled={pending}>
+      {pending ? (
+        <>
+          <Loader2 className="mr-2 size-4 animate-spin" />
+          {pendingLabel}
+        </>
+      ) : (
+        children
+      )}
+    </Button>
+  );
+}

--- a/src/components/auth/ForgotPasswordForm.tsx
+++ b/src/components/auth/ForgotPasswordForm.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import { useActionState } from "react";
+import Link from "next/link";
+import { ArrowLeft, Mail } from "lucide-react";
+
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { requestPasswordReset } from "@/lib/auth/actions";
+import { AUTH_INITIAL_STATE } from "@/lib/auth/form-state";
+import { AuthMessage, SubmitButton } from "./AuthFormParts";
+
+/**
+ * Shared by every portal's "forgot password" screen.
+ *
+ * `onSent` lets the page swap to its own confirmation view — the form owns the
+ * submission, the page owns the layout around it.
+ */
+export function ForgotPasswordForm({
+  redirectTo,
+  backHref = "/login",
+  children,
+}: {
+  /** Where the emailed link should land after the callback exchanges it. */
+  redirectTo?: string;
+  backHref?: string;
+  /** Rendered instead of the form once the request succeeds. */
+  children?: (message: string) => React.ReactNode;
+}) {
+  const [state, formAction] = useActionState(
+    requestPasswordReset,
+    AUTH_INITIAL_STATE,
+  );
+
+  if (state.success && children) return <>{children(state.success)}</>;
+
+  return (
+    <>
+      <form action={formAction} className="space-y-4">
+        <AuthMessage state={state} />
+
+        {redirectTo && (
+          <input type="hidden" name="redirectTo" value={redirectTo} />
+        )}
+
+        <div className="space-y-2">
+          <Label htmlFor="email">Email</Label>
+          <div className="relative">
+            <Mail className="text-muted-foreground absolute top-1/2 left-3 size-4 -translate-y-1/2" />
+            <Input
+              id="email"
+              name="email"
+              type="email"
+              autoComplete="email"
+              required
+              placeholder="you@example.com"
+              className="pl-9"
+            />
+          </div>
+        </div>
+
+        <SubmitButton pendingLabel="Sending...">
+          <Mail className="mr-2 size-4" />
+          Send reset link
+        </SubmitButton>
+      </form>
+
+      <div className="text-center">
+        <Link
+          href={backHref}
+          className="text-primary inline-flex items-center text-sm hover:underline"
+        >
+          <ArrowLeft className="mr-1 size-3" />
+          Back to sign in
+        </Link>
+      </div>
+    </>
+  );
+}
+
+/** The "we've sent it" panel — identical wording wherever it appears. */
+export function ResetLinkSent({
+  message,
+  backHref = "/login",
+}: {
+  message: string;
+  backHref?: string;
+}) {
+  return (
+    <>
+      <p role="status" className="text-muted-foreground text-center text-sm">
+        {message}
+      </p>
+      <div className="bg-muted text-muted-foreground rounded-lg p-4 text-sm">
+        <p className="mb-2">
+          The link is valid for one hour and can only be used once.
+        </p>
+        <p>Didn&apos;t receive it? Check your spam folder, then try again.</p>
+      </div>
+      <Link
+        href={backHref}
+        className="text-primary inline-flex w-full items-center justify-center text-sm hover:underline"
+      >
+        <ArrowLeft className="mr-1 size-3" />
+        Back to sign in
+      </Link>
+    </>
+  );
+}

--- a/src/components/auth/LegacyIdentityBridge.tsx
+++ b/src/components/auth/LegacyIdentityBridge.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { useEffect } from "react";
+
+import { getCurrentUserId, setCurrentUserId } from "@/lib/role-utils";
+
+/**
+ * Writes the mock-record id for the signed-in user into localStorage, where
+ * the groomer and staff surfaces still look for it.
+ *
+ * See lib/auth/legacy-identity.ts for why this exists and when it dies. The
+ * id is resolved on the server from a verified session email — this component
+ * only stores it, so nothing here decides who anyone is.
+ */
+export function LegacyIdentityBridge({ staffId }: { staffId: string | null }) {
+  useEffect(() => {
+    if (!staffId) return;
+    // Don't fight /employee/select, which deliberately lets someone work as a
+    // different staff member. Only fill the gap when nothing is set.
+    if (getCurrentUserId()) return;
+    setCurrentUserId(staffId);
+  }, [staffId]);
+
+  return null;
+}

--- a/src/components/auth/SignInForm.tsx
+++ b/src/components/auth/SignInForm.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import { useActionState } from "react";
+import Link from "next/link";
+import { Mail } from "lucide-react";
+
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { signIn } from "@/lib/auth/actions";
+import { AUTH_INITIAL_STATE } from "@/lib/auth/form-state";
+import { AuthMessage, PasswordField, SubmitButton } from "./AuthFormParts";
+
+// ============================================================================
+// The one sign-in form. Every portal renders this; only the branding and the
+// post-login destination differ.
+//
+// Four portals previously had four different login implementations — one real,
+// one that accepted any password for a known email, one that looked users up
+// in a mock array, and one that did not exist. Sharing the form is what stops
+// that happening again: a fix to the real one cannot miss the others.
+// ============================================================================
+
+export function SignInForm({
+  redirectTo,
+  forgotHref,
+  /** Rendered under the form — sign-up prompts, demo hints, portal switches. */
+  footer,
+  /** Server-side message from a redirect, e.g. an expired link on /login. */
+  initialMessage,
+}: {
+  /** Omit to let the server route by role — admin, facility, groomer, staff. */
+  redirectTo?: string;
+  forgotHref: string;
+  footer?: React.ReactNode;
+  initialMessage?: React.ReactNode;
+}) {
+  const [state, formAction] = useActionState(signIn, AUTH_INITIAL_STATE);
+
+  return (
+    <>
+      <form action={formAction} className="space-y-4">
+        {redirectTo && (
+          <input type="hidden" name="redirectTo" value={redirectTo} />
+        )}
+
+        {/* The action's own result supersedes whatever brought us here. */}
+        {state.error || state.success ? (
+          <AuthMessage state={state} />
+        ) : (
+          initialMessage
+        )}
+
+        <div className="space-y-2">
+          <Label htmlFor="email">Email</Label>
+          <div className="relative">
+            <Mail className="text-muted-foreground absolute top-1/2 left-3 size-4 -translate-y-1/2" />
+            <Input
+              id="email"
+              name="email"
+              type="email"
+              autoComplete="email"
+              required
+              placeholder="you@example.com"
+              className="pl-9"
+              aria-invalid={state.error ? "true" : "false"}
+            />
+          </div>
+        </div>
+
+        <PasswordField
+          id="password"
+          autoComplete="current-password"
+          invalid={Boolean(state.error)}
+          label={
+            <div className="flex items-center justify-between">
+              <Label htmlFor="password">Password</Label>
+              <Link
+                href={forgotHref}
+                className="text-primary text-sm hover:underline"
+              >
+                Forgot password?
+              </Link>
+            </div>
+          }
+        />
+
+        <SubmitButton pendingLabel="Signing in...">Sign in</SubmitButton>
+      </form>
+
+      {footer}
+    </>
+  );
+}

--- a/src/components/customer/CustomerHeader.tsx
+++ b/src/components/customer/CustomerHeader.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { signOutEverywhere } from "@/lib/auth/sign-out-client";
 import { useEffect } from "react";
 import { useCustomerFacility } from "@/hooks/use-customer-facility";
 import { FacilitySwitcher } from "./FacilitySwitcher";
@@ -273,8 +274,7 @@ export function CustomerHeader() {
             <DropdownMenuSeparator />
             <DropdownMenuItem
               onClick={() => {
-                // TODO: Implement logout
-                window.location.href = "/customer/auth/login";
+                void signOutEverywhere();
               }}
               className="text-destructive focus:text-destructive cursor-pointer"
             >

--- a/src/components/employee/EmployeeHeader.tsx
+++ b/src/components/employee/EmployeeHeader.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { signOutEverywhere } from "@/lib/auth/sign-out-client";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { SidebarTrigger } from "@/components/ui/sidebar";
@@ -143,7 +144,9 @@ export function EmployeeHeader({ staffId }: { staffId: string }) {
       }
     }
     clearEmployeeStaffId();
-    window.location.href = "/employee/select";
+    // Ends the Supabase session too, rather than only forgetting which staff
+    // record was selected — this is the Logout item, not a staff switcher.
+    void signOutEverywhere();
   };
 
   // Secondary items (Calling · Booking Requests · Messages · language). Inline

--- a/src/components/groomer/GroomerHeader.tsx
+++ b/src/components/groomer/GroomerHeader.tsx
@@ -5,21 +5,19 @@ import { SidebarTrigger } from "@/components/ui/sidebar";
 import { Scissors } from "lucide-react";
 import { getCurrentUserId } from "@/lib/role-utils";
 import { stylists } from "@/data/grooming";
-import { useRouter } from "next/navigation";
+import { signOutEverywhere } from "@/lib/auth/sign-out-client";
 
 export function GroomerHeader() {
-  const router = useRouter();
   const userId = getCurrentUserId();
   const groomer = userId
     ? stylists.find((s) => s.id === userId)
     : stylists[0] || null;
 
+  // Was: clear a `current_user_id` cookie that nothing ever set, then route to
+  // the login page. No session was ended, and the key it cleared was not even
+  // the one in use (`facility_current_user_id`).
   const handleLogout = () => {
-    // Clear user ID
-    if (typeof document !== "undefined") {
-      document.cookie = "current_user_id=; path=/; max-age=0";
-    }
-    router.push("/groomer/auth/login");
+    void signOutEverywhere();
   };
 
   return (

--- a/src/components/layout/UserProfileSheet.tsx
+++ b/src/components/layout/UserProfileSheet.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { signOutEverywhere } from "@/lib/auth/sign-out-client";
 import { useState, useEffect, useTransition } from "react";
 
 import Link from "next/link";
@@ -232,8 +233,7 @@ export function UserProfileSheet({
   };
 
   const handleLogout = () => {
-    // Implement logout logic here
-    console.log("Logout clicked");
+    void signOutEverywhere();
   };
 
   return (

--- a/src/components/layout/facility-admin-sidebar.tsx
+++ b/src/components/layout/facility-admin-sidebar.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { signOutEverywhere } from "@/lib/auth/sign-out-client";
 import { useMemo } from "react";
 import Image from "next/image";
 import { useQuery } from "@tanstack/react-query";
@@ -61,7 +62,7 @@ export function FacilitySidebar() {
   }, [highPriorityCount, permissions]);
 
   const handleLogout = () => {
-    // TODO: Implement logout logic
+    void signOutEverywhere();
   };
 
   const facility = facilities.find((f) => f.id === facilityId);

--- a/src/components/layout/super-admin-sidebar.tsx
+++ b/src/components/layout/super-admin-sidebar.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { signOutEverywhere } from "@/lib/auth/sign-out-client";
 import {
   Activity,
   AlertTriangle,
@@ -343,7 +344,7 @@ export function AppSidebar() {
   ];
 
   const handleLogout = () => {
-    // TODO: Implement logout logic
+    void signOutEverywhere();
   };
 
   return (

--- a/src/components/staff/StaffHeader.tsx
+++ b/src/components/staff/StaffHeader.tsx
@@ -5,22 +5,19 @@ import { SidebarTrigger } from "@/components/ui/sidebar";
 import { Calendar } from "lucide-react";
 import { getCurrentUserId } from "@/lib/role-utils";
 import { users } from "@/data/users";
-import { useRouter } from "next/navigation";
+import { signOutEverywhere } from "@/lib/auth/sign-out-client";
 
 export function StaffHeader() {
-  const router = useRouter();
   const userId = getCurrentUserId();
   const staffMember = userId
     ? users.find((u) => u.id.toString() === userId || u.email === userId)
     : users.find((u) => u.role === "Staff") || null;
 
+  // Was: clear a `current_user_id` cookie and localStorage key that nothing
+  // ever set — the real one is `facility_current_user_id` — and route to the
+  // login page without ending any session.
   const handleLogout = () => {
-    // Clear user ID
-    if (typeof document !== "undefined") {
-      document.cookie = "current_user_id=; path=/; max-age=0";
-      localStorage.removeItem("current_user_id");
-    }
-    router.push("/staff/auth/login");
+    void signOutEverywhere();
   };
 
   return (

--- a/src/lib/auth/actions.ts
+++ b/src/lib/auth/actions.ts
@@ -1,49 +1,72 @@
 "use server";
 
+import { cookies, headers } from "next/headers";
 import { redirect } from "next/navigation";
 import { z } from "zod";
 
 import { createServerClient } from "@/lib/supabase/server";
+import { landingPathForClaims, type ViewerMembership } from "@/lib/auth/viewer";
+import type { AuthResult } from "@/lib/auth/form-state";
 
 // ============================================================================
 // Auth server actions — email + password.
 //
 // Server Actions rather than client-side supabase.auth calls, so the session
-// cookie is set by the server on a real response. A browser-side sign-in cannot
-// write an httpOnly cookie, which is what every Server Component read depends
-// on.
+// cookie and any navigation land in the same response. A client-side sign-in
+// followed by router.push can paint the destination before the cookie is
+// readable, which looks exactly like "signed in, but everything is empty".
 //
-// Every action returns a plain `{ error }` shape rather than throwing, because
-// these are consumed by form state on pages that must re-render with a message
-// rather than hit an error boundary.
+// Every action is shaped for `useActionState` — (prevState, formData) — which
+// is also what lets the forms work before React hydrates: the browser posts to
+// the action natively, so buttons are live on first paint.
+//
+// Results are a plain object rather than a throw, because these render back
+// into the form rather than an error boundary.
 // ============================================================================
 
+// Sign-in only needs enough to look up an account. Anything that chooses a NEW
+// password is held to the real policy — hence two schemas, not one.
+const emailField = z
+  .string()
+  .trim()
+  .toLowerCase()
+  .email("Enter a valid email address.");
+
+const newPasswordField = z
+  .string()
+  .min(12, "Use at least 12 characters.")
+  // Supabase/bcrypt truncates past 72 bytes; rejecting is honest, silently
+  // ignoring the tail is not.
+  .max(72, "Passwords are limited to 72 characters.");
+
 const credentialsSchema = z.object({
-  email: z.string().trim().toLowerCase().email("Enter a valid email address."),
+  email: emailField,
   password: z.string().min(1, "Enter your password."),
 });
 
-// Sign-up is stricter than sign-in: on the way in we only need enough to look
-// up an account, but on the way out we are choosing what a password may be.
-const signUpSchema = credentialsSchema.extend({
-  password: z
-    .string()
-    .min(12, "Use at least 12 characters.")
-    .max(72, "Passwords are limited to 72 characters."),
+const signUpSchema = z.object({
+  email: emailField,
+  password: newPasswordField,
   fullName: z.string().trim().min(1, "Enter your name.").max(120),
 });
-
-export type AuthResult = { error: string | null };
 
 function firstIssue(error: z.ZodError): string {
   return error.issues[0]?.message ?? "Check the details and try again.";
 }
 
+function fail(message: string): AuthResult {
+  return { error: message, success: null };
+}
+
+function succeed(message: string): AuthResult {
+  return { error: null, success: message };
+}
+
 /**
- * Where to land after signing in. Validated here rather than on the client:
- * the client computes a suggestion, the server decides. Anything that could
- * leave the origin — an absolute URL, a protocol-relative `//evil.com`, a
- * backslash Windows/older browsers normalise to a slash — falls back.
+ * Where to land after an action. Validated on the server rather than trusted
+ * from the client: the page computes a suggestion, this decides. Anything that
+ * could leave the origin — an absolute URL, a protocol-relative `//evil.com`,
+ * a backslash that browsers normalise to a slash — falls back.
  */
 function safeInternalPath(value: FormDataEntryValue | null, fallback: string) {
   if (typeof value !== "string") return fallback;
@@ -53,10 +76,31 @@ function safeInternalPath(value: FormDataEntryValue | null, fallback: string) {
 }
 
 /**
- * Shaped for `useActionState`, which is what lets the form work before React
- * hydrates: the browser posts to the action directly, so the sign-in button is
- * live on first paint instead of silently doing nothing until the JS lands.
+ * Absolute origin for links inside emails.
+ *
+ * Derived from the request rather than read from an env var alone, because a
+ * missing NEXT_PUBLIC_APP_URL would otherwise produce a relative redirect that
+ * Supabase silently rejects — and the failure surfaces as "the reset email
+ * never works", days later, with nothing in the logs.
+ *
+ * Whatever this resolves to must also be listed under Authentication > URL
+ * Configuration > Redirect URLs in the Supabase dashboard.
  */
+async function appOrigin(): Promise<string> {
+  const configured = process.env.NEXT_PUBLIC_APP_URL?.replace(/\/+$/, "");
+  if (configured) return configured;
+
+  const h = await headers();
+  const host = h.get("x-forwarded-host") ?? h.get("host");
+  if (!host) return "";
+  const proto =
+    h.get("x-forwarded-proto") ??
+    (host.startsWith("localhost") ? "http" : "https");
+  return `${proto}://${host}`;
+}
+
+// ── Sign in ────────────────────────────────────────────────────────────────
+
 export async function signIn(
   _prevState: AuthResult,
   formData: FormData,
@@ -65,63 +109,287 @@ export async function signIn(
     email: formData.get("email"),
     password: formData.get("password"),
   });
-  if (!parsed.success) return { error: firstIssue(parsed.error) };
+  if (!parsed.success) return fail(firstIssue(parsed.error));
 
   const supabase = await createServerClient();
   const { error } = await supabase.auth.signInWithPassword(parsed.data);
 
   // Deliberately not distinguishing "no such account" from "wrong password" —
-  // that difference is an account-enumeration oracle.
-  if (error) return { error: "Those details don't match an account." };
+  // that difference is an account-enumeration oracle. The one exception worth
+  // making is an unconfirmed address, because the user cannot act on the
+  // generic message and it reveals nothing they don't already know.
+  if (error) {
+    if (error.code === "email_not_confirmed") {
+      return fail("Confirm your email address first — check your inbox.");
+    }
+    return fail("Those details don't match an account.");
+  }
 
-  // Redirect from the server so the session cookie and the navigation land in
-  // the same response; a client-side push can race the cookie write.
-  redirect(safeInternalPath(formData.get("redirectTo"), "/customer/dashboard"));
+  // An explicit destination wins — it is how "you were sent here from X" works.
+  const explicit = formData.get("redirectTo");
+  if (typeof explicit === "string" && explicit.length > 0) {
+    redirect(safeInternalPath(explicit, await landingForSession(supabase)));
+  }
+
+  redirect(await landingForSession(supabase));
 }
 
-export async function signUp(formData: FormData): Promise<AuthResult> {
+/**
+ * Which portal this session belongs in.
+ *
+ * Read from the freshly minted token rather than from `user.app_metadata` —
+ * those are different things. The access token hook injects memberships into
+ * the TOKEN; the stored user record only ever holds provider details, so
+ * reading it here would send every staff member to the customer dashboard.
+ */
+async function landingForSession(
+  supabase: Awaited<ReturnType<typeof createServerClient>>,
+): Promise<string> {
+  const { data } = await supabase.auth.getClaims();
+  const appMetadata = (data?.claims as { app_metadata?: unknown } | null)
+    ?.app_metadata as
+    | { is_platform_admin?: boolean; memberships?: unknown }
+    | undefined;
+
+  const memberships = Array.isArray(appMetadata?.memberships)
+    ? (appMetadata.memberships as Array<Record<string, unknown>>).flatMap(
+        (m): ViewerMembership[] =>
+          typeof m?.facility_id === "string" && typeof m?.role === "string"
+            ? [
+                {
+                  membershipId: String(m.membership_id ?? ""),
+                  facilityId: m.facility_id,
+                  role: m.role as ViewerMembership["role"],
+                },
+              ]
+            : [],
+      )
+    : [];
+
+  return landingPathForClaims(
+    appMetadata?.is_platform_admin === true,
+    memberships,
+  );
+}
+
+// ── Sign up ────────────────────────────────────────────────────────────────
+
+export async function signUp(
+  _prevState: AuthResult,
+  formData: FormData,
+): Promise<AuthResult> {
   const parsed = signUpSchema.safeParse({
     email: formData.get("email"),
     password: formData.get("password"),
     fullName: formData.get("fullName"),
   });
-  if (!parsed.success) return { error: firstIssue(parsed.error) };
+  if (!parsed.success) return fail(firstIssue(parsed.error));
 
   const supabase = await createServerClient();
-  const { error } = await supabase.auth.signUp({
+  const next = safeInternalPath(
+    formData.get("redirectTo"),
+    "/customer/dashboard",
+  );
+
+  const { data, error } = await supabase.auth.signUp({
     email: parsed.data.email,
     password: parsed.data.password,
-    // Display fields only. Never authorisation data: user_metadata is
-    // user-editable and surfaces in auth.jwt(). Facility membership is granted
-    // server-side, and reaches the token via the custom access token hook.
-    options: { data: { full_name: parsed.data.fullName } },
+    options: {
+      // Display fields only. NEVER authorisation data: user_metadata is
+      // user-editable and surfaces in auth.jwt(), so a role written here would
+      // be a role the user can grant themselves. Facility membership is
+      // granted server-side and reaches the token via the access token hook.
+      data: { full_name: parsed.data.fullName },
+      emailRedirectTo: `${await appOrigin()}/auth/callback?next=${encodeURIComponent(next)}`,
+    },
   });
 
-  if (error) return { error: error.message };
-  return { error: null };
+  if (error) return fail(error.message);
+
+  // With email confirmation off, Supabase returns a live session and the user
+  // is already signed in. With it on, session is null and a mail is sent.
+  if (data.session) redirect(next);
+
+  // Supabase deliberately returns a normal-looking response when the address
+  // is already registered (it mails the existing account instead of erroring),
+  // so this same message covers both cases. Do not "helpfully" detect the
+  // difference — that rebuilds the enumeration oracle sign-in avoids.
+  return succeed(
+    "Check your email for a confirmation link to finish setting up your account.",
+  );
 }
 
+export async function resendConfirmation(
+  _prevState: AuthResult,
+  formData: FormData,
+): Promise<AuthResult> {
+  const parsed = z.object({ email: emailField }).safeParse({
+    email: formData.get("email"),
+  });
+  if (!parsed.success) return fail(firstIssue(parsed.error));
+
+  const supabase = await createServerClient();
+  await supabase.auth.resend({
+    type: "signup",
+    email: parsed.data.email,
+    options: {
+      emailRedirectTo: `${await appOrigin()}/auth/callback`,
+    },
+  });
+
+  // Unconditional success, same reasoning as password reset below.
+  return succeed("If that address needs confirming, a new link is on its way.");
+}
+
+// ── Sign out ───────────────────────────────────────────────────────────────
+
+/**
+ * Ends the session AND clears the legacy identity cookies.
+ *
+ * Both halves matter. `user_role`, `facility_role` and `employee_staff_id`
+ * still steer parts of the app, and while AUTH_ENFORCED is off `user_role`
+ * alone is enough to get into a portal. Dropping the Supabase session but
+ * leaving those behind would produce the worst possible outcome on a shared
+ * machine: a logout that reports success and leaves the next person holding
+ * the previous person's access.
+ */
 export async function signOut(): Promise<never> {
   const supabase = await createServerClient();
   await supabase.auth.signOut();
-  redirect("/");
+
+  const cookieStore = await cookies();
+  for (const name of ["user_role", "facility_role", "employee_staff_id"]) {
+    cookieStore.delete(name);
+  }
+
+  redirect("/login");
 }
 
+// ── Password reset (forgotten — no session) ────────────────────────────────
+
 export async function requestPasswordReset(
+  _prevState: AuthResult,
+  formData: FormData,
+): Promise<AuthResult> {
+  const parsed = z.object({ email: emailField }).safeParse({
+    email: formData.get("email"),
+  });
+
+  // Report success whether or not the address parses or exists. The response
+  // must not reveal which emails have accounts — including by failing faster
+  // for ones that don't.
+  if (!parsed.success) {
+    return succeed(
+      "If that address has an account, a reset link is on its way.",
+    );
+  }
+
+  const supabase = await createServerClient();
+  const next = safeInternalPath(
+    formData.get("redirectTo"),
+    "/customer/auth/reset-password",
+  );
+
+  await supabase.auth.resetPasswordForEmail(parsed.data.email, {
+    // Recovery links must land on the callback, not on the reset page. The
+    // link carries a code that has to be exchanged for a session first;
+    // pointing it straight at the form gives you a page with no session and a
+    // "reset" button that cannot work.
+    redirectTo: `${await appOrigin()}/auth/callback?next=${encodeURIComponent(next)}`,
+  });
+
+  return succeed("If that address has an account, a reset link is on its way.");
+}
+
+/**
+ * Sets a new password using the recovery session established by the callback
+ * route. There is no "current password" here by design — possession of the
+ * emailed link IS the proof.
+ */
+export async function updatePassword(
+  _prevState: AuthResult,
   formData: FormData,
 ): Promise<AuthResult> {
   const parsed = z
-    .object({ email: z.string().trim().toLowerCase().email() })
-    .safeParse({ email: formData.get("email") });
-
-  // Always report success, whether or not the address exists — the response
-  // must not reveal which emails have accounts.
-  if (!parsed.success) return { error: null };
+    .object({ password: newPasswordField, confirmPassword: z.string() })
+    .refine((v) => v.password === v.confirmPassword, {
+      message: "Both passwords must match.",
+      path: ["confirmPassword"],
+    })
+    .safeParse({
+      password: formData.get("password"),
+      confirmPassword: formData.get("confirmPassword"),
+    });
+  if (!parsed.success) return fail(firstIssue(parsed.error));
 
   const supabase = await createServerClient();
-  await supabase.auth.resetPasswordForEmail(parsed.data.email, {
-    redirectTo: `${process.env.NEXT_PUBLIC_APP_URL ?? ""}/customer/auth/reset-password`,
-  });
 
-  return { error: null };
+  // Without a session the link was never exchanged, or it expired. Say so
+  // plainly — this is the single most confusing failure in a reset flow.
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) {
+    return fail(
+      "This reset link has expired or was already used. Request a new one.",
+    );
+  }
+
+  const { error } = await supabase.auth.updateUser({
+    password: parsed.data.password,
+  });
+  if (error) return fail(error.message);
+
+  redirect(safeInternalPath(formData.get("redirectTo"), "/login?reset=1"));
+}
+
+// ── Password change (signed in — current password required) ────────────────
+
+export async function changePassword(
+  _prevState: AuthResult,
+  formData: FormData,
+): Promise<AuthResult> {
+  const parsed = z
+    .object({
+      currentPassword: z.string().min(1, "Enter your current password."),
+      password: newPasswordField,
+      confirmPassword: z.string(),
+    })
+    .refine((v) => v.password === v.confirmPassword, {
+      message: "Both new passwords must match.",
+      path: ["confirmPassword"],
+    })
+    .refine((v) => v.password !== v.currentPassword, {
+      message: "Choose a password different from your current one.",
+      path: ["password"],
+    })
+    .safeParse({
+      currentPassword: formData.get("currentPassword"),
+      password: formData.get("password"),
+      confirmPassword: formData.get("confirmPassword"),
+    });
+  if (!parsed.success) return fail(firstIssue(parsed.error));
+
+  const supabase = await createServerClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user?.email) return fail("Sign in again to change your password.");
+
+  // Supabase has no "verify this password" call, so re-authenticate with the
+  // current one. Without this, anyone with a borrowed session — an unlocked
+  // laptop, a stolen cookie — could set a new password and take the account
+  // over permanently.
+  const { error: reauthError } = await supabase.auth.signInWithPassword({
+    email: user.email,
+    password: parsed.data.currentPassword,
+  });
+  if (reauthError) return fail("Your current password is incorrect.");
+
+  const { error } = await supabase.auth.updateUser({
+    password: parsed.data.password,
+  });
+  if (error) return fail(error.message);
+
+  return succeed("Your password has been changed.");
 }

--- a/src/lib/auth/form-state.ts
+++ b/src/lib/auth/form-state.ts
@@ -1,0 +1,16 @@
+// ============================================================================
+// Shared shape for every auth form's result.
+//
+// This lives apart from actions.ts because a "use server" module may only
+// export async functions — a plain constant there is a build error, not a
+// style issue. Types are erased so they could stay, but keeping the pair
+// together is what makes the rule obvious to the next person.
+// ============================================================================
+
+export type AuthResult = {
+  error: string | null;
+  /** Set when the action succeeded and the page should show a confirmation. */
+  success: string | null;
+};
+
+export const AUTH_INITIAL_STATE: AuthResult = { error: null, success: null };

--- a/src/lib/auth/legacy-identity.ts
+++ b/src/lib/auth/legacy-identity.ts
@@ -1,0 +1,38 @@
+import "server-only";
+
+import { users } from "@/data/users";
+import { stylists } from "@/data/grooming";
+
+// ============================================================================
+// BRIDGE — delete when staff move from src/data into Postgres.
+//
+// The groomer and staff surfaces (GroomerHeader, StaffHeader, the groomer
+// dashboard, the retail pages, use-facility-role) identify the current person
+// by a mock-record id kept in localStorage under `facility_current_user_id`.
+//
+// That id used to be written by the fake logins: "find this email in the
+// `users` array, and you are them" — no password involved. Those logins are
+// now real Supabase sign-ins, which produce a UUID that means nothing to any
+// of those surfaces.
+//
+// So this maps a verified email onto the mock record it corresponds to. The
+// authentication is real; only the identifier handed to the mock data layer is
+// legacy. When staff become rows in Postgres, this file and every reader of
+// `facility_current_user_id` go together.
+//
+// Server-only so the mock arrays stay out of the client bundle — the layout
+// resolves the id and passes just the string down.
+// ============================================================================
+
+export function legacyStaffIdForEmail(email: string | null): string | null {
+  if (!email) return null;
+  const target = email.trim().toLowerCase();
+
+  const stylist = stylists.find((s) => s.email?.toLowerCase() === target);
+  if (stylist) return String(stylist.id);
+
+  const user = users.find((u) => u.email?.toLowerCase() === target);
+  if (user) return String(user.id);
+
+  return null;
+}

--- a/src/lib/auth/portal-gate.ts
+++ b/src/lib/auth/portal-gate.ts
@@ -1,0 +1,95 @@
+import "server-only";
+
+import { headers } from "next/headers";
+import { redirect } from "next/navigation";
+
+import {
+  getViewer,
+  isAuthEnforced,
+  landingPathFor,
+  type Viewer,
+} from "./viewer";
+
+// ============================================================================
+// One gate, used by every portal layout.
+//
+// Six layouts were each about to grow the same four decisions: fetch the
+// viewer, leave the portal's own auth screens alone, allow or deny, and pick
+// between "you need to sign in" and "you're signed in as the wrong person".
+// Six copies is how they drift apart, and an auth gate that drifts is worse
+// than one that is merely strict.
+//
+// WHAT THIS IS AND ISN'T: routing. `redirect()` from a streaming layout is a
+// soft redirect — HTTP 200 with NEXT_REDIRECT in the payload, executed by the
+// client router — so this keeps people out of the wrong UI. It is not what
+// keeps them out of the data. RLS does that, on the database, from the JWT.
+// ============================================================================
+
+/**
+ * The path being rendered, stamped onto the request by src/proxy.ts.
+ *
+ * Empty when the proxy did not run — currently only the routes its matcher
+ * excludes (api/twilio, api/health, static assets), none of which render a
+ * portal layout. An empty path matches no public prefix, so the gate fails
+ * closed rather than open.
+ */
+async function currentPathname(): Promise<string> {
+  const requestHeaders = await headers();
+  return requestHeaders.get("x-pathname") ?? "";
+}
+
+export async function guardPortal({
+  allow,
+  publicPrefixes = [],
+  whenWrongPortal,
+}: {
+  /** Gate for this portal, from viewer.ts — already flag-aware. */
+  allow: (viewer: Viewer) => boolean;
+  /**
+   * Paths inside this portal that must stay reachable while signed out —
+   * its own /auth/* screens. Gating those makes signing in impossible, which
+   * is a redirect loop rather than a login page.
+   */
+  publicPrefixes?: string[];
+  /**
+   * Legacy-only fallback for a denied viewer while AUTH_ENFORCED is off, where
+   * there are no claims to route by. Under enforcement the destination is
+   * computed from the viewer instead — see below.
+   */
+  whenWrongPortal?: string;
+}): Promise<Viewer> {
+  const viewer = await getViewer();
+  const pathname = await currentPathname();
+
+  if (publicPrefixes.some((prefix) => pathname.startsWith(prefix))) {
+    return viewer;
+  }
+
+  if (allow(viewer)) return viewer;
+
+  // Signed out and signed in as the wrong person are different problems: one
+  // needs a login, the other needs somewhere else to go.
+  if (isAuthEnforced()) {
+    if (viewer.source !== "session") {
+      const next = pathname ? `?next=${encodeURIComponent(pathname)}` : "";
+      redirect(`/login${next}`);
+    }
+
+    // Send them where they DO belong, computed from their own claims.
+    //
+    // This must not be a fixed path per portal. It was, briefly, and it
+    // produced a redirect loop: a customer hitting /facility/dashboard was
+    // sent to /dashboard, which denied them and sent them back. Every value
+    // landingPathFor can return is a portal its own gate admits — a
+    // membership implies the facility/staff portals, its absence implies the
+    // customer one — so routing by the viewer cannot ping-pong.
+    const home = landingPathFor(viewer);
+    redirect(home === pathname ? "/login" : home);
+  }
+
+  // Flag off: no claims to route by, so fall back to the portal's own guess.
+  // Safe from loops because the legacy rules are complementary — a
+  // facility_admin is admitted to /facility and refused /dashboard, and a
+  // super_admin is admitted to both.
+  redirect(whenWrongPortal ?? "/login");
+}

--- a/src/lib/auth/sign-out-client.ts
+++ b/src/lib/auth/sign-out-client.ts
@@ -1,0 +1,38 @@
+"use client";
+
+import { signOut } from "@/lib/auth/actions";
+
+// ============================================================================
+// The one way to sign out of this app.
+//
+// Every portal had its own logout button and every one of them was a stub —
+// `// TODO: Implement logout logic`, and in one case `console.log("Logout
+// clicked")`. A logout that reports success without ending the session is
+// worse than no logout at all: it is the button people press on a shared
+// machine before walking away.
+//
+// Two halves, and both are required:
+//   • the server action ends the Supabase session and clears the legacy
+//     identity COOKIES (user_role, facility_role, employee_staff_id)
+//   • this clears the legacy identity in localStorage, which the server
+//     cannot touch and which the groomer/staff surfaces read to decide whose
+//     schedule and clients to show
+// ============================================================================
+
+/** localStorage keys that identify a person. See lib/role-utils.ts. */
+const LEGACY_IDENTITY_KEYS = [
+  "facility_current_user_id",
+  "scheduling-current-user-role",
+];
+
+export async function signOutEverywhere(): Promise<void> {
+  if (typeof window !== "undefined") {
+    for (const key of LEGACY_IDENTITY_KEYS) {
+      localStorage.removeItem(key);
+    }
+    sessionStorage.removeItem("yipyy-employee-welcome-ts");
+  }
+
+  // Redirects to /login, so nothing after this runs.
+  await signOut();
+}

--- a/src/lib/auth/viewer.ts
+++ b/src/lib/auth/viewer.ts
@@ -165,6 +165,43 @@ export function belongsToFacility(viewer: Viewer, facilityId: string): boolean {
   );
 }
 
+// ── Where a given identity belongs ──────────────────────────────────────────
+// One sign-in serves every kind of account, so something has to decide which
+// portal a person lands in. That decision is here rather than in the sign-in
+// action so the gates and the action cannot disagree about it.
+
+/** Roles that run the business and get the full facility admin portal. */
+const FACILITY_ADMIN_ROLES = new Set<string>([
+  "owner",
+  "admin",
+  "manager",
+  "supervisor",
+]);
+
+export function landingPathForClaims(
+  isPlatformAdmin: boolean,
+  memberships: ViewerMembership[],
+): string {
+  if (isPlatformAdmin) return "/dashboard";
+
+  // No membership means this is a pet owner, not staff.
+  const primary = memberships[0];
+  if (!primary) return "/customer/dashboard";
+
+  if (memberships.some((m) => FACILITY_ADMIN_ROLES.has(m.role))) {
+    return "/facility/dashboard";
+  }
+  if (primary.role === "groomer") return "/groomer/dashboard";
+
+  // Everyone else on staff — caretakers, reception, trainers, retail — works
+  // out of the employee schedule.
+  return "/employee/schedule";
+}
+
+export function landingPathFor(viewer: Viewer): string {
+  return landingPathForClaims(viewer.isPlatformAdmin, viewer.memberships);
+}
+
 // ── Portal gates ────────────────────────────────────────────────────────────
 // One gate per portal, so the rule lives next to the identity rather than being
 // re-derived from cookies in each layout.
@@ -208,6 +245,27 @@ export function canAccessFacilityPortal(viewer: Viewer): boolean {
 export function canAccessAdminPortal(viewer: Viewer): boolean {
   if (!isAuthEnforced()) return viewer.legacyRole !== "facility_admin";
   return viewer.isPlatformAdmin;
+}
+
+/**
+ * Customer portal. Any signed-in identity qualifies — a pet owner has no
+ * membership by design, and staff are often customers of their own facility,
+ * so requiring the ABSENCE of a membership would lock them out of their own
+ * bookings.
+ */
+export function canAccessCustomerPortal(viewer: Viewer): boolean {
+  if (!isAuthEnforced()) return true;
+  return viewer.source === "session";
+}
+
+/**
+ * Staff-facing portals: groomer, staff and employee. Any active membership,
+ * whatever the role — these are the day-to-day work surfaces, and which one
+ * you land on is decided by landingPathForClaims, not by who may enter.
+ */
+export function canAccessStaffPortal(viewer: Viewer): boolean {
+  if (!isAuthEnforced()) return true;
+  return viewer.isPlatformAdmin || viewer.memberships.length > 0;
 }
 
 /**

--- a/src/lib/supabase/proxy.ts
+++ b/src/lib/supabase/proxy.ts
@@ -20,8 +20,31 @@ import { supabaseConfig } from "./env";
 // membership claims. This does one job: keep the session alive.
 // ============================================================================
 
+/**
+ * Copy the request headers and stamp the current path onto them.
+ *
+ * Layouts cannot see the pathname — Next deliberately does not pass it — but a
+ * portal gate needs it for two things: to leave its own /auth/* screens
+ * reachable (gating them would make signing in impossible), and to build a
+ * `?next=` so a bounced user returns where they were headed.
+ *
+ * `set` rather than `append`, so a client that sends its own x-pathname header
+ * cannot smuggle a value past the gate.
+ *
+ * Rebuilt on each call rather than captured once: request.cookies.set() writes
+ * back through to the cookie header, so headers snapshotted before the refresh
+ * would carry the OLD session and undo the token rotation.
+ */
+function headersWithPathname(request: NextRequest): Headers {
+  const headers = new Headers(request.headers);
+  headers.set("x-pathname", request.nextUrl.pathname);
+  return headers;
+}
+
 export async function updateSession(request: NextRequest) {
-  let response = NextResponse.next({ request });
+  let response = NextResponse.next({
+    request: { headers: headersWithPathname(request) },
+  });
 
   // This runs on every request, so an unconfigured environment must not take
   // the whole site down — it should behave exactly as it did before auth
@@ -45,7 +68,9 @@ export async function updateSession(request: NextRequest) {
         for (const { name, value } of cookiesToSet) {
           request.cookies.set(name, value);
         }
-        response = NextResponse.next({ request });
+        response = NextResponse.next({
+          request: { headers: headersWithPathname(request) },
+        });
         for (const { name, value, options } of cookiesToSet) {
           response.cookies.set(name, value, options);
         }

--- a/supabase/seed/dev-accounts.sql
+++ b/supabase/seed/dev-accounts.sql
@@ -1,0 +1,123 @@
+-- ============================================================================
+-- DEVELOPMENT ACCOUNTS — never run this against production.
+--
+-- Every login in the app is now a real Supabase sign-in, which means an empty
+-- auth.users table makes the whole product unreachable: correct, and useless.
+-- This creates one real account per role so each portal can actually be
+-- opened, and so the role-based landing (landingPathForClaims) has something
+-- to route.
+--
+-- Shared password for all of them:  YipyyDev!2026
+--
+-- Apply with:  supabase db execute --file supabase/seed/dev-accounts.sql
+--   (or paste into the SQL editor). Re-running is safe — every insert is
+--   guarded, so it tops up whatever is missing rather than erroring.
+--
+-- Deliberately NOT in supabase/migrations/: migrations run everywhere,
+-- including production, and a known-password account that ships to production
+-- is a back door with a changelog entry.
+--
+-- ── The trap this file exists to encode ────────────────────────────────────
+-- auth.users declares confirmation_token, recovery_token, email_change,
+-- email_change_token_new, email_change_token_current, phone_change,
+-- phone_change_token and reauthentication_token as NULLABLE, but GoTrue scans
+-- them into non-nullable Go strings. Insert a user leaving them NULL and every
+-- sign-in fails with a completely EMPTY error — no code, no message, nothing
+-- in the client or the logs. Hence the '' on every one of them below.
+-- ============================================================================
+
+do $$
+declare
+  v_org_id  uuid := 'a0000000-0000-4000-8000-000000000001';
+  v_fac_id  uuid := 'a0000000-0000-4000-8000-0000000000f1';
+  v_loc_id  uuid := 'a0000000-0000-4000-8000-0000000000c1';
+  v_pwd     text := 'YipyyDev!2026';
+  v_user_id uuid;
+  r         record;
+begin
+  -- ── Tenancy ──────────────────────────────────────────────────────────────
+  insert into public.orgs (id, name, slug, legacy_id)
+  values (v_org_id, 'Yipyy Demo Group', 'yipyy-demo', 'demo')
+  on conflict (id) do nothing;
+
+  -- legacy_id '11' is the demo facility the mock data references throughout.
+  insert into public.facilities (id, org_id, name, slug, legacy_id, timezone)
+  values (v_fac_id, v_org_id, 'Yipyy Demo Facility', 'yipyy-demo-facility', '11', 'America/Toronto')
+  on conflict (id) do nothing;
+
+  insert into public.locations (id, facility_id, name, is_primary, timezone, legacy_id)
+  values (v_loc_id, v_fac_id, 'Main Location', true, 'America/Toronto', '11-1')
+  on conflict (id) do nothing;
+
+  -- ── Accounts ─────────────────────────────────────────────────────────────
+  -- One per portal the app exposes, so every gate can be exercised:
+  --   platform admin -> /dashboard
+  --   owner/manager  -> /facility/dashboard
+  --   groomer        -> /groomer/dashboard
+  --   caretaker      -> /employee/schedule
+  --   customer       -> /customer/dashboard  (no membership, by design)
+  for r in
+    select * from (values
+      ('admin@yipyy.dev',     'Platform Admin',  true,  null),
+      ('owner@yipyy.dev',     'Dana Okafor',     false, 'owner'),
+      ('manager@yipyy.dev',   'Priya Raman',     false, 'manager'),
+      ('groomer@yipyy.dev',   'Jessica Alvarez', false, 'groomer'),
+      ('caretaker@yipyy.dev', 'Marcus Bell',     false, 'caretaker'),
+      ('reception@yipyy.dev', 'Iris Nakamura',   false, 'reception'),
+      ('customer@yipyy.dev',  'Sam Whitlock',    false, null)
+    ) as t(email, full_name, is_admin, role)
+  loop
+    select id into v_user_id from auth.users where email = r.email;
+
+    if v_user_id is null then
+      v_user_id := gen_random_uuid();
+
+      insert into auth.users (
+        instance_id, id, aud, role, email, encrypted_password,
+        email_confirmed_at, created_at, updated_at,
+        raw_app_meta_data, raw_user_meta_data,
+        -- All eight of these must be '' and not NULL. See the header.
+        confirmation_token, recovery_token, email_change,
+        email_change_token_new, email_change_token_current,
+        phone_change, phone_change_token, reauthentication_token
+      ) values (
+        '00000000-0000-0000-0000-000000000000',
+        v_user_id,
+        'authenticated', 'authenticated',
+        r.email,
+        extensions.crypt(v_pwd, extensions.gen_salt('bf')),
+        -- Pre-confirmed: dev inboxes do not exist, and the built-in SMTP is
+        -- rate-limited to a couple of mails an hour.
+        now(), now(), now(),
+        '{"provider":"email","providers":["email"]}'::jsonb,
+        jsonb_build_object('full_name', r.full_name),
+        '', '', '', '', '', '', '', ''
+      );
+    end if;
+
+    -- profiles is created by the on_auth_user_created trigger; only the admin
+    -- flag needs setting here.
+    update public.profiles
+       set is_platform_admin = r.is_admin,
+           full_name         = coalesce(full_name, r.full_name)
+     where id = v_user_id;
+
+    if r.role is not null then
+      insert into public.facility_memberships
+        (profile_id, facility_id, role, home_location_id, is_active)
+      values
+        (v_user_id, v_fac_id, r.role::public.facility_staff_role, v_loc_id, true)
+      on conflict do nothing;
+    end if;
+  end loop;
+end $$;
+
+-- Verification — every row here should be non-zero, and each account should
+-- show the role its portal expects.
+select p.email,
+       p.is_platform_admin,
+       coalesce(m.role::text, '(customer — no membership)') as membership
+  from public.profiles p
+  left join public.facility_memberships m on m.profile_id = p.id
+ where p.email like '%@yipyy.dev'
+ order by p.is_platform_admin desc, m.role nulls last, p.email;


### PR DESCRIPTION
One of eight auth pages was real. The rest were stubs that slept a second and resolved. Three of six portals had no gate at all. This closes both, and adds the pieces that were simply missing.

## The stubs, and what they actually did

| Page | Before |
|---|---|
| `staff/auth/login` | Looked the email up in the `users` mock array and **never checked the password**. Plus a "Quick Login (Demo)" list — one button per staff member, one click to become them. |
| `groomer/auth/login` | `// For now, accept any password for demo purposes`. Anyone who knew a groomer's email address was that groomer. |
| `customer/auth/signup` | Created a local client record; no account existed anywhere. |
| `forgot-password` ×2 | Slept 1s, then showed "Check your email". No email. |
| `reset-password` | Validated the token against a stub that always resolved. Every link looked valid; none did anything. |
| `change-password` | Slept 1s, reported success. |
| **every logout** | `// TODO: Implement logout logic` — and in one case `console.log("Logout clicked")`. |

A password field that is never read is worse than no password field, because it looks like security. Same for a logout button: that's the one people press on a shared machine before walking away.

## Missing pieces, now added

**`/auth/callback`** — the code-exchange route. Without it every emailed link was a dead end in a way that is genuinely hard to diagnose: the mail arrives, the link opens a real page, and nothing works, because the code in the URL was never exchanged for a session. Handles both link shapes (PKCE `?code` and OTP `?token_hash`) — handling only the first is the common half-fix.

**`/login`** — a portal-neutral sign-in. Facility admin, the platform dashboard and the employee portal had no login page, so denied users were being sent to the *customer* one. It doesn't ask which portal you want; it reads the token afterwards and routes. One person can be a groomer at one facility and an owner at another — asking them to choose up front asks a question they shouldn't have to answer.

**Gates on customer, groomer, staff and employee.** The employee shell already refused to render without a staff-picker cookie, but picking an identity is not proving one — and `/employee/select`, which sets it, was reachable by anyone.

**`supabase/seed/dev-accounts.sql`** — seven real accounts, one per role. Real logins against an empty `auth.users` table are correct and completely useless.

## The bug the first version of the test missed

Denial used a **fixed** redirect target per portal. A customer hitting `/facility/dashboard` was sent to `/dashboard`, which denied them and sent them back — an infinite bounce.

The test passed. It asked *"did you leave the forbidden page?"* — which a loop satisfies. It now asserts you **arrived somewhere you're allowed to stay**, then re-reads the URL to catch a second bounce. Denial routes by the viewer's own claims via `landingPathFor`, which can only return a portal that admits them.

## Verified in a browser, both flag states

33 checks enforced, 29 with the flag off. Highlights:

```
admin@yipyy.dev      → /dashboard
owner@yipyy.dev      → /facility/dashboard
groomer@yipyy.dev    → /groomer/dashboard
caretaker@yipyy.dev  → /employee/schedule
customer@yipyy.dev   → /customer/dashboard

anonymous bounced from all 5 protected portals
all 7 auth screens still reachable signed out
customer refused /facility/dashboard → /customer/dashboard …and stays there
groomer login no longer accepts any password
reset response identical for real and unknown addresses
bad callback code → /login, no session created
logout → cookie gone, protected page unreachable
```

## Nothing changes on merge

`AUTH_ENFORCED` is still off, so every gate answers with today's cookie rule — including for someone who has signed in.

## Two things worth your attention

**The dev accounts share a known password (`YipyyDev!2026`) and are in the live Supabase project.** That's deliberate — it's the only project, and the app is unusable without accounts. They must be removed or rotated before real customers exist. The file is in `supabase/seed/`, *not* `migrations/`, so it never runs automatically: a known-password account that ships to production is a back door with a changelog entry.

**One mock remains in the signup path, deliberately.** There is no `clients` table in Postgres yet, so a new signup still pushes an in-memory client record for the customer pages to find. It's labelled as a bridge and doesn't survive a reload — which is the argument for the clients/pets schema being next, not for papering over it further.