### PR TITLE
feat(api): write bookings to Postgres, read clients and pets from it

### DIFF
--- a/scripts/lib/operational-rows.ts
+++ b/scripts/lib/operational-rows.ts
@@ -33,6 +33,7 @@ import { bookings } from "../../src/data/bookings";
 import type { Booking } from "../../src/types/booking";
 import type { Client } from "../../src/types/client";
 import type { Pet } from "../../src/types/pet";
+import { instantFromWallClock } from "../../src/lib/time/facility-time";
 
 export const DEMO_FACILITY_LEGACY_ID = "11";
 const DEMO_FACILITY_NAME = "Example Pet Care Facility";
@@ -63,63 +64,6 @@ function omit<T extends object>(
     if (!keys.includes(k) && v !== undefined) out[k] = v;
   }
   return out;
-}
-
-/**
- * How far `timeZone` is from UTC at a given instant, in minutes.
- * Derived from Intl rather than hardcoded so DST is handled for free.
- */
-function offsetMinutes(instant: Date, timeZone: string): number {
-  const parts = Object.fromEntries(
-    new Intl.DateTimeFormat("en-US", {
-      timeZone,
-      hour12: false,
-      year: "numeric",
-      month: "2-digit",
-      day: "2-digit",
-      hour: "2-digit",
-      minute: "2-digit",
-      second: "2-digit",
-    })
-      .formatToParts(instant)
-      .map((p) => [p.type, p.value]),
-  );
-  const asIfUtc = Date.UTC(
-    Number(parts.year),
-    Number(parts.month) - 1,
-    Number(parts.day),
-    Number(parts.hour),
-    Number(parts.minute),
-    Number(parts.second),
-  );
-  return (asIfUtc - instant.getTime()) / 60000;
-}
-
-/**
- * Mock "YYYY-MM-DD" + "HH:MM" -> an ISO instant.
- *
- * The mock times are the FACILITY's wall clock: "check in at 14:00" means two
- * in the afternoon where the dogs are, not 14:00 UTC. Sending the naive string
- * let Postgres read it as UTC, and a 14:00 booking came back as 15:00 — every
- * appointment silently shifted by the server's offset.
- *
- * Two passes because the first offset is measured at the wrong instant; the
- * second corrects it when the guess landed on the other side of a DST change.
- */
-function timestamp(
-  date: string,
-  time: string | undefined,
-  fallback: string,
-  timeZone: string,
-): string {
-  const wallClock = new Date(`${date}T${time ?? fallback}:00Z`);
-  const first = offsetMinutes(wallClock, timeZone);
-  let instant = new Date(wallClock.getTime() - first * 60000);
-  const second = offsetMinutes(instant, timeZone);
-  if (second !== first) {
-    instant = new Date(wallClock.getTime() - second * 60000);
-  }
-  return instant.toISOString();
 }
 
 export type ClientRow = Record<string, unknown>;
@@ -288,11 +232,14 @@ export function buildSeedRows(opts: {
       service_type: b.serviceType ?? null,
       status: b.status,
       payment_status: b.paymentStatus,
-      start_at: timestamp(b.startDate, b.checkInTime, "00:00", opts.timeZone),
-      end_at: timestamp(
+      start_at: instantFromWallClock(
+        b.startDate,
+        b.checkInTime ?? "00:00",
+        opts.timeZone,
+      ),
+      end_at: instantFromWallClock(
         b.endDate,
-        b.checkOutTime ?? b.checkInTime,
-        "23:59",
+        b.checkOutTime ?? b.checkInTime ?? "23:59",
         opts.timeZone,
       ),
       assigned_staff_name: b.assignedStaff ?? null,

--- a/src/app/api/bookings/[ref]/route.ts
+++ b/src/app/api/bookings/[ref]/route.ts
@@ -1,0 +1,100 @@
+import { NextResponse, type NextRequest } from "next/server";
+
+import { createServerClient, getCurrentUser } from "@/lib/supabase/server";
+import {
+  BOOKING_SELECT,
+  bookingToRow,
+  rowToBooking,
+} from "@/lib/api/mappers/booking";
+import { getFacilityContext } from "@/lib/api/facility-context";
+import type { NewBooking } from "@/types/booking";
+
+// ============================================================================
+// A single booking, by its app-facing numeric ref.
+//
+// PATCH rather than PUT: callers send the fields they changed, and
+// bookingToRow maps only what it was given. A full replace would blank every
+// column the caller omitted — which for a booking means losing the feeding
+// schedule because someone edited the price.
+// ============================================================================
+
+export const dynamic = "force-dynamic";
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ ref: string }> },
+) {
+  const user = await getCurrentUser().catch(() => null);
+  if (!user) {
+    return NextResponse.json({ error: "Not signed in." }, { status: 401 });
+  }
+
+  const { ref } = await params;
+  const bookingRef = Number(ref);
+  if (!Number.isFinite(bookingRef)) {
+    return NextResponse.json({ error: "Invalid booking id." }, { status: 400 });
+  }
+
+  const input = (await request.json()) as Partial<NewBooking>;
+  const supabase = await createServerClient();
+
+  const facility = await getFacilityContext();
+  if (!facility) {
+    return NextResponse.json({ error: "Facility not found." }, { status: 500 });
+  }
+
+  // `details` is replaced wholesale rather than merged, so a partial update
+  // carrying any long-tail field must carry all of them. Read the current row
+  // first and merge, otherwise editing the price would drop the invoice.
+  const { data: current } = await supabase
+    .from("bookings")
+    .select(BOOKING_SELECT)
+    .eq("ref", bookingRef)
+    .maybeSingle();
+
+  if (!current) {
+    return NextResponse.json({ error: "Booking not found." }, { status: 404 });
+  }
+
+  const existing = rowToBooking(current);
+  const merged = { ...existing, ...input } as Partial<NewBooking>;
+
+  const row = bookingToRow(merged, {
+    facilityId: facility.facilityId,
+    timeZone: facility.timeZone,
+  });
+
+  const { data: written, error } = await supabase
+    .from("bookings")
+    .update(row as never)
+    .eq("ref", bookingRef)
+    .select("id");
+
+  if (error) {
+    const denied = error.code === "42501";
+    return NextResponse.json(
+      { error: denied ? "Not allowed to edit bookings." : error.message },
+      { status: denied ? 403 : 500 },
+    );
+  }
+
+  // An UPDATE filtered out by RLS is not an error in Postgres — it affects
+  // zero rows and reports success. Without this check the route returns 200
+  // and the unchanged booking, so a caller who is not allowed to edit gets
+  // told their edit worked. A write that silently does nothing is worse than
+  // one that fails loudly.
+  if (!written || written.length === 0) {
+    return NextResponse.json(
+      { error: "Not allowed to edit this booking." },
+      { status: 403 },
+    );
+  }
+
+  const { data: updated } = await supabase
+    .from("bookings")
+    .select(BOOKING_SELECT)
+    .eq("ref", bookingRef)
+    .single();
+
+  return NextResponse.json(updated ? rowToBooking(updated) : null);
+}

--- a/src/app/api/bookings/route.ts
+++ b/src/app/api/bookings/route.ts
@@ -1,20 +1,27 @@
 import { NextResponse, type NextRequest } from "next/server";
 
 import { createServerClient, getCurrentUser } from "@/lib/supabase/server";
-import { BOOKING_SELECT, rowToBooking } from "@/lib/api/mappers/booking";
+import {
+  BOOKING_SELECT,
+  bookingToRow,
+  rowToBooking,
+} from "@/lib/api/mappers/booking";
+import { getFacilityContext } from "@/lib/api/facility-context";
+import type { NewBooking } from "@/types/booking";
 
 // ============================================================================
-// Bookings, read from Postgres.
+// Bookings.
 //
 // A Route Handler rather than a browser query, deliberately — see the note in
-// lib/supabase/client.ts. Business reads go through the server client so RLS
-// evaluates against the session cookie, and so the domain invariants RLS
-// cannot express (capacity, ledger balance, handover) have somewhere to live
-// when writes follow.
+// lib/supabase/client.ts. Business reads and writes go through the server
+// client so RLS evaluates against the session cookie, and so the domain
+// invariants RLS cannot express (capacity, ledger balance, handover) have
+// somewhere to live.
 //
 // Scoped entirely by RLS: staff see their facility's bookings, a customer sees
 // their own, and nobody has to pass a facility id for that to hold. A filter
-// here narrows what you asked for; it is not what keeps you out.
+// here narrows what you asked for; it is not what keeps you out. Likewise the
+// POST below is authorised by the `bookings_insert` policy, not by this file.
 // ============================================================================
 
 export const dynamic = "force-dynamic";
@@ -47,4 +54,84 @@ export async function GET(request: NextRequest) {
   }
 
   return NextResponse.json(data.map(rowToBooking));
+}
+
+export async function POST(request: NextRequest) {
+  const user = await getCurrentUser().catch(() => null);
+  if (!user) {
+    return NextResponse.json({ error: "Not signed in." }, { status: 401 });
+  }
+
+  const input = (await request.json()) as NewBooking;
+  const supabase = await createServerClient();
+
+  const facility = await getFacilityContext();
+  if (!facility) {
+    return NextResponse.json({ error: "Facility not found." }, { status: 500 });
+  }
+
+  // The client arrives as the app's numeric ref; the row needs the uuid.
+  // Resolved through RLS, so a caller who cannot see a client cannot book for
+  // them — the lookup simply returns nothing.
+  const { data: client } = await supabase
+    .from("clients")
+    .select("id")
+    .eq("ref", input.clientId)
+    .maybeSingle();
+
+  if (!client) {
+    return NextResponse.json(
+      { error: `No client ${input.clientId} you can book for.` },
+      { status: 422 },
+    );
+  }
+
+  const row = bookingToRow(input, {
+    facilityId: facility.facilityId,
+    clientRowId: client.id,
+    locationId: facility.locationId,
+    timeZone: facility.timeZone,
+  });
+
+  const { data: created, error } = await supabase
+    .from("bookings")
+    .insert(row as never)
+    .select("id, ref")
+    .single();
+
+  if (error) {
+    // 403 for a policy refusal, because "you may not do this" is not a bug in
+    // the request body and should not read as one in the client.
+    const denied = error.code === "42501";
+    return NextResponse.json(
+      { error: denied ? "Not allowed to create bookings." : error.message },
+      { status: denied ? 403 : 500 },
+    );
+  }
+
+  // Pets are a join table. Written after the booking so a rejected insert
+  // above leaves nothing behind.
+  const petRefs = Array.isArray(input.petId) ? input.petId : [input.petId];
+  const wanted = petRefs.filter((ref): ref is number => ref != null);
+
+  if (wanted.length > 0) {
+    const { data: pets } = await supabase
+      .from("pets")
+      .select("id")
+      .in("ref", wanted);
+
+    if (pets?.length) {
+      await supabase
+        .from("booking_pets")
+        .insert(pets.map((p) => ({ booking_id: created.id, pet_id: p.id })));
+    }
+  }
+
+  const { data: full } = await supabase
+    .from("bookings")
+    .select(BOOKING_SELECT)
+    .eq("id", created.id)
+    .single();
+
+  return NextResponse.json(full ? rowToBooking(full) : null, { status: 201 });
 }

--- a/src/app/api/clients/route.ts
+++ b/src/app/api/clients/route.ts
@@ -1,0 +1,49 @@
+import { NextResponse } from "next/server";
+
+import { createServerClient, getCurrentUser } from "@/lib/supabase/server";
+import { CLIENT_SELECT, rowToClient } from "@/lib/api/mappers/client";
+
+// ============================================================================
+// Clients, with their pets nested — the shape Client already has.
+//
+// One query with a join rather than two and a stitch: `client.pets` is how
+// every consumer reads it, and doing the join per caller is the same work done
+// worse, N times.
+//
+// RLS decides what comes back. Staff need `view_clients`; a customer sees the
+// single record linked to their account. Neither is enforced here.
+// ============================================================================
+
+export const dynamic = "force-dynamic";
+
+/** The mock Client identifies its facility by NAME, so resolve it once. */
+async function facilityName(
+  supabase: Awaited<ReturnType<typeof createServerClient>>,
+): Promise<string> {
+  const { data } = await supabase
+    .from("facilities")
+    .select("name")
+    .eq("legacy_id", "11")
+    .maybeSingle();
+  return data?.name ?? "Example Pet Care Facility";
+}
+
+export async function GET() {
+  const user = await getCurrentUser().catch(() => null);
+  if (!user) {
+    return NextResponse.json({ error: "Not signed in." }, { status: 401 });
+  }
+
+  const supabase = await createServerClient();
+
+  const [{ data, error }, name] = await Promise.all([
+    supabase.from("clients").select(CLIENT_SELECT).order("ref"),
+    facilityName(supabase),
+  ]);
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  return NextResponse.json(data.map((row) => rowToClient(row, name)));
+}

--- a/src/app/api/pets/route.ts
+++ b/src/app/api/pets/route.ts
@@ -1,0 +1,50 @@
+import { NextResponse, type NextRequest } from "next/server";
+
+import { createServerClient, getCurrentUser } from "@/lib/supabase/server";
+import { PET_SELECT, rowToPet } from "@/lib/api/mappers/client";
+
+// ============================================================================
+// Pets.
+//
+// Separate from /api/clients even though clients carry their pets nested: the
+// pet screens want a flat list, and asking them to flatten a client list to
+// get it would pull every client's billing details along for the ride.
+//
+// RLS decides what comes back — staff need `view_pet_records`, a customer sees
+// only their own animals.
+// ============================================================================
+
+export const dynamic = "force-dynamic";
+
+export async function GET(request: NextRequest) {
+  const user = await getCurrentUser().catch(() => null);
+  if (!user) {
+    return NextResponse.json({ error: "Not signed in." }, { status: 401 });
+  }
+
+  const supabase = await createServerClient();
+  const { searchParams } = new URL(request.url);
+
+  let query = supabase.from("pets").select(PET_SELECT).order("ref");
+
+  const clientRef = searchParams.get("clientRef");
+  if (clientRef) {
+    const { data: client } = await supabase
+      .from("clients")
+      .select("id")
+      .eq("ref", Number(clientRef))
+      .maybeSingle();
+
+    // No readable client means no readable pets — an empty list, not an error:
+    // the caller asked a legitimate question and the answer is "none".
+    if (!client) return NextResponse.json([]);
+    query = query.eq("client_id", client.id);
+  }
+
+  const { data, error } = await query;
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  return NextResponse.json(data.map(rowToPet));
+}

--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -54,9 +54,26 @@ export async function GET(request: NextRequest) {
 
   const supabase = await createServerClient();
 
+  /**
+   * Once the address is verified, attach the account to any client record the
+   * facility already holds for it. Idempotent and a no-op when there is no
+   * match, so it is safe on every callback — including password recovery.
+   *
+   * Failure here must not break the flow: the link is a convenience, and a
+   * user who cannot sign in because a lookup failed is a far worse outcome
+   * than one whose history takes a little longer to appear.
+   */
+  async function linkClientRecord() {
+    const { error } = await supabase.rpc("link_client_record");
+    if (error) {
+      console.warn(`[auth/callback] client link skipped: ${error.message}`);
+    }
+  }
+
   if (code) {
     const { error } = await supabase.auth.exchangeCodeForSession(code);
     if (error) return failure(request, error.message);
+    await linkClientRecord();
     return NextResponse.redirect(new URL(next, request.url));
   }
 
@@ -66,6 +83,7 @@ export async function GET(request: NextRequest) {
       token_hash: tokenHash,
     });
     if (error) return failure(request, error.message);
+    await linkClientRecord();
     return NextResponse.redirect(new URL(next, request.url));
   }
 

--- a/src/app/customer/auth/signup/page.tsx
+++ b/src/app/customer/auth/signup/page.tsx
@@ -5,7 +5,6 @@ import { useRouter, useSearchParams } from "next/navigation";
 import Image from "next/image";
 import Link from "next/link";
 import { toast } from "sonner";
-import { clients } from "@/data/clients";
 import { facilities } from "@/data/facilities";
 import { useSettings } from "@/hooks/use-settings";
 import { Button } from "@/components/ui/button";
@@ -239,7 +238,6 @@ export default function SignUpPage() {
     // is stored regardless of whether confirmation is still pending.
     savePreferredLanguageForEmail(formData.email, language);
     applyAccountLocale(language);
-    addLocalClientRecord(formData, language);
 
     setIsLoading(false);
 
@@ -252,43 +250,6 @@ export default function SignUpPage() {
     // Confirmation off — signUp redirected server-side and we never get here.
     toast.success("Account created successfully!");
     router.push(redirectTo);
-  };
-
-  /**
-   * BRIDGE — delete when a `clients` table exists.
-   *
-   * The customer portal reads its client records from the `clients` mock
-   * array, and Postgres has no equivalent table yet (orgs, facilities,
-   * locations, profiles and memberships are real; customers are not). Without
-   * this, a real signup produces a real Supabase account that the customer
-   * pages cannot find anything for.
-   *
-   * It is in-memory only and does not survive a reload — which is precisely
-   * why the clients table is the next schema to land, not something to paper
-   * over further.
-   */
-  const addLocalClientRecord = (
-    data: typeof formData,
-    preferredLanguage: string | undefined,
-  ) => {
-    const email = data.email.trim().toLowerCase();
-    if (clients.some((client) => client.email.trim().toLowerCase() === email)) {
-      return;
-    }
-
-    const maxId = clients.reduce((max, client) => Math.max(max, client.id), 0);
-    clients.push({
-      id: maxId + 1,
-      name: data.name.trim(),
-      email: data.email.trim(),
-      phone: "",
-      preferredLanguage,
-      status: "active",
-      facility: targetFacilityName ?? "Example Pet Care Facility",
-      address: { street: "", city: "", state: "", zip: "", country: "" },
-      additionalContacts: [],
-      pets: [],
-    });
   };
 
   return (

--- a/src/lib/api/booking.ts
+++ b/src/lib/api/booking.ts
@@ -3,6 +3,7 @@ import { BOOKING_REQUESTS } from "@/data/booking-requests";
 import { facilityStaff } from "@/data/facility-staff";
 import type { Booking, NewBooking } from "@/types/booking";
 import type { ServiceModule } from "@/types/facility-staff";
+import { liveFetch, liveWrite } from "./live-fetch";
 
 // ============================================================================
 // Section 8B — viewer scoping (assigned_only)
@@ -110,31 +111,18 @@ export function isPetAssignedTo(petId: number, staffId: string): boolean {
 // there is no signed-out case left to serve.
 // ============================================================================
 
-let warnedAboutFallback = false;
-
 async function fetchBookings(params?: {
   clientRef?: number;
 }): Promise<Booking[]> {
   const search = params?.clientRef ? `?clientRef=${params.clientRef}` : "";
-  const response = await fetch(`/api/bookings${search}`);
-
-  if (response.status === 401) {
-    if (!warnedAboutFallback) {
-      warnedAboutFallback = true;
-      console.info(
-        "[bookings] not signed in — serving mock data. Sign in to read the real rows.",
-      );
-    }
-    return params?.clientRef
-      ? bookings.filter((b) => b.clientId === params.clientRef)
-      : bookings;
-  }
-
-  if (!response.ok) {
-    throw new Error(`Failed to load bookings (${response.status})`);
-  }
-
-  return (await response.json()) as Booking[];
+  return liveFetch<Booking[]>(
+    `/api/bookings${search}`,
+    () =>
+      params?.clientRef
+        ? bookings.filter((b) => b.clientId === params.clientRef)
+        : bookings,
+    "bookings",
+  );
 }
 
 export const bookingQueries = {
@@ -174,19 +162,12 @@ export const bookingQueries = {
 };
 
 export const bookingMutations = {
-  create: async (data: NewBooking): Promise<Booking> => {
-    const newId = Math.max(...bookings.map((b) => b.id), 0) + 1;
-    const booking: Booking = { ...data, id: newId };
-    bookings.push(booking);
-    return booking;
-  },
+  create: async (data: NewBooking): Promise<Booking> =>
+    liveWrite<Booking>("/api/bookings", "POST", data),
+
   update: async (
     id: number,
     data: Partial<NewBooking>,
-  ): Promise<Booking | undefined> => {
-    const index = bookings.findIndex((b) => b.id === id);
-    if (index === -1) return undefined;
-    bookings[index] = { ...bookings[index], ...data };
-    return bookings[index];
-  },
+  ): Promise<Booking | undefined> =>
+    liveWrite<Booking>(`/api/bookings/${id}`, "PATCH", data),
 };

--- a/src/lib/api/client.ts
+++ b/src/lib/api/client.ts
@@ -2,6 +2,7 @@ import { clients } from "@/data/clients";
 import { bookings } from "@/data/bookings";
 import { resolveBookingStaffId } from "./booking";
 import type { Client } from "@/types/client";
+import { liveFetch } from "./live-fetch";
 
 // ============================================================================
 // Section 8B — viewer scoping (assigned_only). A client is "assigned to" a
@@ -30,6 +31,11 @@ export function isClientAssignedTo(client: Client, staffId: string): boolean {
   return assignedClientIds(staffId).has(client.id);
 }
 
+/** Real clients, with their pets nested; mocks only when signed out. */
+async function fetchClients(): Promise<Client[]> {
+  return liveFetch<Client[]>("/api/clients", () => clients, "clients");
+}
+
 export const clientQueries = {
   /**
    * All clients, or — when `assignedStaffId` is passed (the viewer's id when
@@ -38,20 +44,23 @@ export const clientQueries = {
    */
   all: (opts?: { assignedStaffId?: string }) => ({
     queryKey: ["clients", opts?.assignedStaffId ?? "all"] as const,
-    queryFn: async (): Promise<Client[]> =>
-      opts?.assignedStaffId
-        ? scopeClientsToStaff(clients, opts.assignedStaffId)
-        : clients,
+    queryFn: async (): Promise<Client[]> => {
+      const list = await fetchClients();
+      return opts?.assignedStaffId
+        ? scopeClientsToStaff(list, opts.assignedStaffId)
+        : list;
+    },
   }),
   detail: (id: number) => ({
     queryKey: ["clients", id] as const,
-    queryFn: async () => clients.find((c) => c.id === id) ?? null,
+    queryFn: async () =>
+      (await fetchClients()).find((c) => c.id === id) ?? null,
   }),
   search: (query: string) => ({
     queryKey: ["clients", "search", query] as const,
     queryFn: async () => {
       const q = query.toLowerCase();
-      return clients.filter(
+      return (await fetchClients()).filter(
         (c) =>
           c.name.toLowerCase().includes(q) || c.email.toLowerCase().includes(q),
       );

--- a/src/lib/api/facility-context.ts
+++ b/src/lib/api/facility-context.ts
@@ -1,0 +1,51 @@
+import "server-only";
+
+import { createServerClient } from "@/lib/supabase/server";
+import { DEFAULT_TIMEZONE } from "@/lib/time/facility-time";
+
+// ============================================================================
+// The demo facility, resolved once per request.
+//
+// Every route needs the same three things — the facility uuid, its primary
+// location and its timezone — and all three come from one row. Resolved by
+// `legacy_id` rather than hardcoded, so the same code runs against any project.
+//
+// TEMPORARY in one specific way: the facility is fixed to legacy id "11"
+// because the front end still passes `facilityId: 11` everywhere. When the app
+// learns about real facility ids, this takes the id from the viewer's
+// membership instead. It is NOT a security boundary either way — RLS scopes
+// rows to the caller regardless of what this returns.
+// ============================================================================
+
+export const DEMO_FACILITY_LEGACY_ID = "11";
+
+export type FacilityContext = {
+  facilityId: string;
+  locationId: string | null;
+  timeZone: string;
+};
+
+export async function getFacilityContext(): Promise<FacilityContext | null> {
+  const supabase = await createServerClient();
+
+  const { data: facility } = await supabase
+    .from("facilities")
+    .select("id, timezone")
+    .eq("legacy_id", DEMO_FACILITY_LEGACY_ID)
+    .maybeSingle();
+
+  if (!facility) return null;
+
+  const { data: location } = await supabase
+    .from("locations")
+    .select("id")
+    .eq("facility_id", facility.id)
+    .eq("is_primary", true)
+    .maybeSingle();
+
+  return {
+    facilityId: facility.id,
+    locationId: location?.id ?? null,
+    timeZone: facility.timezone ?? DEFAULT_TIMEZONE,
+  };
+}

--- a/src/lib/api/live-fetch.ts
+++ b/src/lib/api/live-fetch.ts
@@ -1,0 +1,64 @@
+// ============================================================================
+// Fetching real data with a signed-out fallback.
+//
+// The rows are real, but RLS scopes them to the signed-in caller. With
+// AUTH_ENFORCED off, most of the app is still browsed signed-out, and
+// switching hard would turn every list blank — indistinguishable from a bug.
+//
+// So: ask the API, and fall back to the mocks on 401 ONLY. Any other failure
+// propagates, because a 500 or a broken shape must not be silently papered
+// over with fixtures that look plausible. That distinction is the whole point
+// of this helper existing rather than a try/catch per call site.
+//
+// This dies with AUTH_ENFORCED. When every portal requires a session, there is
+// no signed-out case left to serve.
+// ============================================================================
+
+const warned = new Set<string>();
+
+export async function liveFetch<T>(
+  path: string,
+  fallback: () => T,
+  label = path,
+): Promise<T> {
+  const response = await fetch(path);
+
+  if (response.status === 401) {
+    if (!warned.has(label)) {
+      warned.add(label);
+      console.info(
+        `[${label}] not signed in — serving mock data. Sign in to read the real rows.`,
+      );
+    }
+    return fallback();
+  }
+
+  if (!response.ok) {
+    throw new Error(`Failed to load ${label} (${response.status})`);
+  }
+
+  return (await response.json()) as T;
+}
+
+/** POST/PATCH helper — no fallback, because a write must never silently no-op. */
+export async function liveWrite<T>(
+  path: string,
+  method: "POST" | "PATCH",
+  body: unknown,
+): Promise<T> {
+  const response = await fetch(path, {
+    method,
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+
+  if (!response.ok) {
+    const detail = await response
+      .json()
+      .then((b: { error?: string }) => b.error)
+      .catch(() => null);
+    throw new Error(detail ?? `Request failed (${response.status})`);
+  }
+
+  return (await response.json()) as T;
+}

--- a/src/lib/api/mappers/booking.ts
+++ b/src/lib/api/mappers/booking.ts
@@ -1,5 +1,10 @@
-import type { Booking } from "@/types/booking";
-import type { Tables } from "@/types/database";
+import type { Booking, NewBooking } from "@/types/booking";
+import type { Tables, TablesInsert } from "@/types/database";
+import {
+  DEFAULT_TIMEZONE,
+  instantFromWallClock,
+  wallClockParts,
+} from "@/lib/time/facility-time";
 
 // ============================================================================
 // Database row -> the Booking object the app already expects.
@@ -23,38 +28,6 @@ type BookingRow = Tables<"bookings"> & {
   facilities?: { timezone: string } | null;
   booking_pets?: { pets: { ref: number } | null }[] | null;
 };
-
-const DEFAULT_TIMEZONE = "America/Toronto";
-
-/**
- * Split a stored instant into the facility's wall-clock date and time.
- *
- * The zone must be the FACILITY's, not the server's and not the viewer's. A
- * booking is "2pm at the kennel" — it does not become 3pm because the person
- * looking at the roster is in another country, and it must not shift because a
- * build ran in a different region. Getting this wrong is invisible in
- * development and moves every appointment in production.
- */
-function wallClockParts(timestamp: string, timeZone: string) {
-  const parts = Object.fromEntries(
-    new Intl.DateTimeFormat("en-CA", {
-      timeZone,
-      hour12: false,
-      year: "numeric",
-      month: "2-digit",
-      day: "2-digit",
-      hour: "2-digit",
-      minute: "2-digit",
-    })
-      .formatToParts(new Date(timestamp))
-      .map((p) => [p.type, p.value]),
-  );
-  return {
-    date: `${parts.year}-${parts.month}-${parts.day}`,
-    // Intl renders midnight as "24" in some locales/engines under hour12:false.
-    time: `${parts.hour === "24" ? "00" : parts.hour}:${parts.minute}`,
-  };
-}
 
 export type BookingWithRowId = Booking & {
   /** The uuid primary key. Needed to write; ignored by everything that reads. */
@@ -119,3 +92,106 @@ export const BOOKING_SELECT = `
   facilities!inner ( timezone ),
   booking_pets ( pets ( ref ) )
 ` as const;
+
+// ── Writing ─────────────────────────────────────────────────────────────────
+
+/** Fields hoisted into columns; everything else on a booking becomes `details`. */
+const COLUMN_FIELDS = [
+  "id",
+  "rowId",
+  "clientId",
+  "petId",
+  "facilityId",
+  "service",
+  "serviceType",
+  "status",
+  "paymentStatus",
+  "startDate",
+  "endDate",
+  "checkInTime",
+  "checkOutTime",
+  "basePrice",
+  "discount",
+  "totalCost",
+  "tipAmount",
+  "specialRequests",
+  "assignedStaff",
+];
+
+/**
+ * The inverse of rowToBooking, for inserts and updates.
+ *
+ * The caller resolves the ids — this deliberately does not look anything up.
+ * A mapper that queries is a mapper you cannot reason about, and the route
+ * already has to resolve the facility and client to authorise the write.
+ *
+ * `partial` matters for PATCH: an update must not blank every column the
+ * caller left out, which is what a full mapping of a Partial<NewBooking>
+ * would do.
+ */
+export function bookingToRow(
+  input: Partial<NewBooking>,
+  context: {
+    facilityId: string;
+    clientRowId?: string;
+    locationId?: string | null;
+    timeZone: string;
+  },
+): Partial<TablesInsert<"bookings">> {
+  const row: Partial<TablesInsert<"bookings">> = {};
+
+  if (context.clientRowId) row.client_id = context.clientRowId;
+  if (context.locationId !== undefined) row.location_id = context.locationId;
+  row.facility_id = context.facilityId;
+
+  if (input.service !== undefined) row.service = input.service;
+  if (input.serviceType !== undefined) row.service_type = input.serviceType;
+  if (input.status !== undefined) {
+    row.status = input.status as TablesInsert<"bookings">["status"];
+  }
+  if (input.paymentStatus !== undefined) {
+    row.payment_status = input.paymentStatus;
+  }
+  if (input.assignedStaff !== undefined) {
+    row.assigned_staff_name = input.assignedStaff;
+  }
+  if (input.basePrice !== undefined) row.base_price = input.basePrice;
+  if (input.discount !== undefined) row.discount = input.discount;
+  if (input.totalCost !== undefined) row.total_cost = input.totalCost;
+  if (input.tipAmount !== undefined) row.tip_amount = input.tipAmount;
+  if (input.specialRequests !== undefined) {
+    row.special_requests = input.specialRequests;
+  }
+
+  // Dates are the facility's wall clock on the way in, exactly as on the way
+  // out — see lib/time/facility-time.ts for why that is not negotiable.
+  if (input.startDate) {
+    row.start_at = instantFromWallClock(
+      input.startDate,
+      input.checkInTime ?? "00:00",
+      context.timeZone,
+    );
+  }
+  if (input.endDate) {
+    row.end_at = instantFromWallClock(
+      input.endDate,
+      input.checkOutTime ?? input.checkInTime ?? "23:59",
+      context.timeZone,
+    );
+  }
+
+  const details: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(input)) {
+    if (!COLUMN_FIELDS.includes(key) && value !== undefined) {
+      details[key] = value;
+    }
+  }
+  // Cast to the generated Json type: the long tail is genuinely arbitrary
+  // JSON-serialisable product data, and enumerating it here would just be the
+  // Booking type written twice.
+  if (Object.keys(details).length > 0) {
+    row.details = details as TablesInsert<"bookings">["details"];
+  }
+
+  return row;
+}

--- a/src/lib/api/mappers/client.ts
+++ b/src/lib/api/mappers/client.ts
@@ -1,0 +1,79 @@
+import type { Client } from "@/types/client";
+import type { Pet } from "@/types/pet";
+import type { Tables } from "@/types/database";
+
+// ============================================================================
+// Database rows -> the Client and Pet objects the app already expects.
+//
+// Same split as bookings: queryable fields are columns, the long tail lives in
+// `details`, and this is the one place that knows which is which.
+//
+// Client carries its pets nested, because that is how the type is shaped and
+// how every consumer reads it (`client.pets`). Fetching them separately and
+// stitching in each caller would be the same join done worse, N times.
+// ============================================================================
+
+type PetRow = Tables<"pets">;
+type ClientRow = Tables<"clients"> & { pets?: PetRow[] | null };
+
+export function rowToPet(row: PetRow): Pet {
+  const details = (row.details ?? {}) as Record<string, unknown>;
+
+  return {
+    ...(details as Partial<Pet>),
+    id: row.ref,
+    name: row.name,
+    type: row.species,
+    breed: row.breed ?? "",
+    age: row.age_years ?? 0,
+    dateOfBirth: row.date_of_birth ?? undefined,
+    weight: row.weight === null ? 0 : Number(row.weight),
+    color: row.color ?? "",
+    microchip: row.microchip ?? "",
+    allergies: row.allergies ?? "",
+    specialNeeds: row.special_needs ?? "",
+    sex: (row.sex as Pet["sex"]) ?? undefined,
+    spayedNeutered: row.spayed_neutered ?? undefined,
+    coatType: (row.coat_type as Pet["coatType"]) ?? undefined,
+    energyLevel: (row.energy_level as Pet["energyLevel"]) ?? undefined,
+    petStatus: row.status as Pet["petStatus"],
+    imageUrl: row.image_url ?? undefined,
+  } as Pet;
+}
+
+export function rowToClient(row: ClientRow, facilityName: string): Client {
+  const details = (row.details ?? {}) as Record<string, unknown>;
+
+  return {
+    ...(details as Partial<Client>),
+    id: row.ref,
+    name: row.name,
+    email: row.email,
+    phone: row.phone ?? undefined,
+    status: row.status,
+    // The mock Client identifies its facility by NAME, not id. Resolved by the
+    // caller rather than stored per row — one lookup instead of one per client.
+    facility: facilityName,
+    preferredLanguage: row.preferred_language ?? undefined,
+    imageUrl: row.image_url ?? undefined,
+    address: (row.address as Client["address"]) ?? undefined,
+    isBlocked: row.is_blocked,
+    blockedAt: row.blocked_at ?? undefined,
+    blockedReason: row.blocked_reason ?? undefined,
+    lastVisitDate: row.last_visit_date ?? undefined,
+    outstandingBalance: Number(row.outstanding_balance),
+    noShowCount: row.no_show_count,
+    pets: (row.pets ?? []).map(rowToPet),
+  } as Client;
+}
+
+/**
+ * Selects that satisfy the mappers above.
+ *
+ * Kept beside them because the two must agree: a column dropped from the
+ * select becomes `undefined` in the mapped object rather than a type error,
+ * which is exactly the failure that reaches production looking like missing
+ * data rather than a bug.
+ */
+export const CLIENT_SELECT = `*, pets ( * )` as const;
+export const PET_SELECT = `*` as const;

--- a/src/lib/api/pet.ts
+++ b/src/lib/api/pet.ts
@@ -7,27 +7,40 @@ import {
   careInstructions,
 } from "@/data/pet-data";
 import type { Pet } from "@/types/pet";
+import { liveFetch } from "./live-fetch";
 
 const allPets: Pet[] = clients.flatMap((c) => c.pets as Pet[]);
+
+/** Real pets; mocks only when signed out. */
+async function fetchPets(clientRef?: number): Promise<Pet[]> {
+  const search = clientRef ? `?clientRef=${clientRef}` : "";
+  return liveFetch<Pet[]>(
+    `/api/pets${search}`,
+    () =>
+      clientRef
+        ? ((clients.find((c) => c.id === clientRef)?.pets as Pet[]) ?? [])
+        : allPets,
+    "pets",
+  );
+}
 
 export const petQueries = {
   all: () => ({
     queryKey: ["pets"] as const,
-    queryFn: async () => allPets,
+    queryFn: async () => fetchPets(),
   }),
   detail: (id: number) => ({
     queryKey: ["pets", id] as const,
-    queryFn: async () => allPets.find((p) => p.id === id),
+    queryFn: async () => (await fetchPets()).find((p) => p.id === id),
   }),
   byClient: (clientId: number) => ({
     queryKey: ["pets", "by-client", clientId] as const,
-    queryFn: async () =>
-      clients.find((c) => c.id === clientId)?.pets as Pet[] | undefined,
+    queryFn: async () => fetchPets(clientId),
   }),
   evaluations: (petId: number) => ({
     queryKey: ["pets", petId, "evaluations"] as const,
     queryFn: async () => {
-      const pet = allPets.find((p) => p.id === petId);
+      const pet = (await fetchPets()).find((p) => p.id === petId);
       return pet?.evaluations ?? [];
     },
   }),

--- a/src/lib/time/facility-time.ts
+++ b/src/lib/time/facility-time.ts
@@ -1,0 +1,92 @@
+// ============================================================================
+// Facility wall-clock time <-> stored instants.
+//
+// A booking is "2pm at the kennel". It does not become 3pm because the person
+// looking at the roster is in another country, and it must not shift because a
+// build ran in a different region. So every conversion in both directions goes
+// through the FACILITY's zone — never the server's, never the viewer's.
+//
+// This was not a hypothetical: a booking seeded at 14:00 came back as 15:00,
+// because the write sent a naive timestamp (read as UTC) and the read rendered
+// it in the local zone. Invisible in development, wrong for every appointment
+// in production. One module so the two directions cannot disagree again.
+// ============================================================================
+
+/** How far `timeZone` is from UTC at a given instant, in minutes. */
+function offsetMinutes(instant: Date, timeZone: string): number {
+  const parts = Object.fromEntries(
+    new Intl.DateTimeFormat("en-US", {
+      timeZone,
+      hour12: false,
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+    })
+      .formatToParts(instant)
+      .map((p) => [p.type, p.value]),
+  );
+
+  const asIfUtc = Date.UTC(
+    Number(parts.year),
+    Number(parts.month) - 1,
+    Number(parts.day),
+    // Intl renders midnight as "24" in some engines under hour12:false.
+    Number(parts.hour) % 24,
+    Number(parts.minute),
+    Number(parts.second),
+  );
+  return (asIfUtc - instant.getTime()) / 60000;
+}
+
+/**
+ * "YYYY-MM-DD" + "HH:MM" in `timeZone` -> the ISO instant it names.
+ *
+ * Two passes: the first offset is measured at the wrong instant, and the
+ * second corrects it when the guess landed on the far side of a DST change.
+ */
+export function instantFromWallClock(
+  date: string,
+  time: string,
+  timeZone: string,
+): string {
+  const wallClock = new Date(`${date}T${time}:00Z`);
+  const first = offsetMinutes(wallClock, timeZone);
+  let instant = new Date(wallClock.getTime() - first * 60000);
+
+  const second = offsetMinutes(instant, timeZone);
+  if (second !== first) {
+    instant = new Date(wallClock.getTime() - second * 60000);
+  }
+  return instant.toISOString();
+}
+
+/** A stored instant -> the date and time it reads as on the facility's clock. */
+export function wallClockParts(
+  timestamp: string,
+  timeZone: string,
+): { date: string; time: string } {
+  const parts = Object.fromEntries(
+    new Intl.DateTimeFormat("en-CA", {
+      timeZone,
+      hour12: false,
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+      hour: "2-digit",
+      minute: "2-digit",
+    })
+      .formatToParts(new Date(timestamp))
+      .map((p) => [p.type, p.value]),
+  );
+
+  return {
+    date: `${parts.year}-${parts.month}-${parts.day}`,
+    time: `${parts.hour === "24" ? "00" : parts.hour}:${parts.minute}`,
+  };
+}
+
+/** The demo facility's zone, used only when a row carries none. */
+export const DEFAULT_TIMEZONE = "America/Toronto";

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -654,7 +654,10 @@ export type Database = {
       [_ in never]: never;
     };
     Functions: {
-      [_ in never]: never;
+      link_client_record: {
+        Args: Record<PropertyKey, never>;
+        Returns: string | null;
+      };
     };
     Enums: {
       access_scope: "anytime" | "operating_hours" | "assigned_shifts" | "none";

--- a/supabase/migrations/20260801140000_link_client_record.sql
+++ b/supabase/migrations/20260801140000_link_client_record.sql
@@ -1,0 +1,61 @@
+-- ============================================================================
+-- Attach a newly-verified account to the client record a facility already has.
+--
+-- Facilities create client records for people who have never logged in — that
+-- is the normal case, and it is why clients.profile_id is nullable. When that
+-- person later signs up with the same address, the two must become one thing,
+-- or they get an empty portal while their history sits next to it.
+--
+-- SECURITY DEFINER because the caller cannot see the row yet: before the link
+-- exists, `clients_read` does not match them. It only ever claims a record
+-- whose email matches the caller's OWN verified address and which nobody has
+-- claimed, so it cannot be used to attach to someone else's account.
+--
+-- Deliberately does NOT create a client record when there is no match.
+-- Whether signing up should itself create a customer relationship — and with
+-- which facility — is a product decision, not something to infer here.
+-- ============================================================================
+
+create or replace function public.link_client_record()
+returns uuid
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_user_id uuid := (select auth.uid());
+  v_email   text;
+  v_client  uuid;
+begin
+  if v_user_id is null then
+    return null;
+  end if;
+
+  -- The address from the auth record, not from an argument: a caller-supplied
+  -- email would let anyone claim any unclaimed client record.
+  select u.email into v_email from auth.users u where u.id = v_user_id;
+  if v_email is null then
+    return null;
+  end if;
+
+  -- Already linked — idempotent, so this is safe to call on every sign-in.
+  select c.id into v_client
+    from public.clients c
+   where c.profile_id = v_user_id
+   limit 1;
+  if v_client is not null then
+    return v_client;
+  end if;
+
+  update public.clients c
+     set profile_id = v_user_id
+   where lower(c.email) = lower(v_email)
+     and c.profile_id is null
+  returning c.id into v_client;
+
+  return v_client;
+end;
+$$;
+
+grant execute on function public.link_client_record() to authenticated;
+revoke execute on function public.link_client_record() from anon, public;


### PR DESCRIPTION
Closes the loop the previous PR opened. Reads moved first so the swap was reversible; this makes the database the **system of record** rather than a read replica of the mocks.

## Writes

`POST /api/bookings` and `PATCH /api/bookings/[ref]`, behind the `bookings_insert` / `bookings_update` policies. `bookingMutations.create` and `.update` now call them instead of pushing to an in-memory array.

**PATCH, not PUT.** `details` is replaced wholesale, so a partial update reads the current row and merges first — otherwise editing a price would drop the feeding schedule and the invoice.

The client arrives as the app's numeric `ref` and is resolved to its uuid **through RLS**, so a caller who cannot see a client cannot book for them: the lookup simply returns nothing.

## Reads

`/api/clients` (pets nested, as the `Client` type is shaped) and `/api/pets`. The 401-fallback logic was repeating across three factories, so it's now one helper — fall back to mocks on **401 only**; any other failure propagates, because a 500 must not be papered over with plausible-looking fixtures.

## The signup bridge is gone

The in-memory `clients.push` is deleted. In its place, `public.link_client_record()` attaches a newly-verified account to the client record a facility **already holds** for that address — the normal case, since facilities create client records for people who have never logged in.

`SECURITY DEFINER` because the caller can't see the row until the link exists, and it only ever claims an *unclaimed* record matching the caller's own *verified* email.

It deliberately does **not create** a client record when there's no match. Whether signing up should itself establish a customer relationship, and with which facility, is a product decision — not something to infer in a migration. **That one's yours to make.**

## One bug this caught, and it's the interesting kind

A customer PATCHing someone else's booking got **HTTP 200 and the unchanged booking back.**

Postgres doesn't error on an `UPDATE` filtered out by RLS — it affects zero rows and reports success. The data was never at risk, but the API was telling an unauthorised caller their edit had worked. The route now asks for the updated rows back and returns 403 when none come.

The first version of the test missed it too — it asserted the status code, not the value. It now re-reads the row as staff and confirms it's unchanged.

## Verified in a browser — 24 checks

```
clients   -> 14, pets nested, membership long tail intact
pets      -> 20, type/breed present
create    -> ref 27; 08:30 and the date round-trip exactly;
             pet linked; long tail in details; present on a fresh read
update    -> status + price change, walkSchedule + specialRequests preserved
customer  -> refused for another client (422)
          -> CAN book for themselves (201)
          -> refused an edit (403), row verified unchanged
```

Test rows removed; the database is back to 14 clients / 20 pets / 26 bookings.

## Still outstanding

The **legacy staff identity bridge** stays. It maps a verified email to a mock staff record for the groomer/staff surfaces, and staff are not in Postgres yet — `facility_staff` is still a mock array. That's the next migration, not something this PR could remove.

`src/lib/api/booking.ts` still invents staff assignment by rotating bookings across a staff pool. Real rows carry `assigned_staff_name`, so that becomes dead code once staff are real.