### PR TITLE
feat(rbac): resolve permissions in the database, not the browser

### DIFF
--- a/src/app/api/permissions/route.ts
+++ b/src/app/api/permissions/route.ts
@@ -1,0 +1,43 @@
+import { NextResponse } from "next/server";
+
+import { createServerClient, getCurrentUser } from "@/lib/supabase/server";
+import type { AccessScope, PermissionKey } from "@/types/facility-staff";
+
+// ============================================================================
+// The signed-in viewer's effective permissions, as the DATABASE resolves them.
+//
+// Until now the browser computed this itself, from a mock staff array plus
+// overrides held in localStorage. Two independent implementations of the same
+// three-layer cascade — and the one the client could edit was the one the UI
+// obeyed.
+//
+// This returns the map the database will actually enforce, so the two can no
+// longer disagree. Note the direction of trust: this is a convenience for
+// drawing the right UI, not the enforcement. RLS refuses the row regardless of
+// what any client believes about its own permissions.
+// ============================================================================
+
+export const dynamic = "force-dynamic";
+
+export type PermissionMap = Partial<Record<PermissionKey, AccessScope>>;
+
+export async function GET() {
+  const user = await getCurrentUser().catch(() => null);
+  if (!user) {
+    return NextResponse.json({ error: "Not signed in." }, { status: 401 });
+  }
+
+  const supabase = await createServerClient();
+  const { data, error } = await supabase.rpc("my_permissions");
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  const map: PermissionMap = {};
+  for (const row of data ?? []) {
+    map[row.permission_key as PermissionKey] = row.scope;
+  }
+
+  return NextResponse.json(map);
+}

--- a/src/hooks/use-db-permissions.ts
+++ b/src/hooks/use-db-permissions.ts
@@ -1,0 +1,67 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+
+import type {
+  AccessScope,
+  EffectivePermissions,
+  PermissionKey,
+} from "@/types/facility-staff";
+
+// ============================================================================
+// The viewer's permissions, as the database resolves them.
+//
+// This is the seam that lets the client stop being the authority on what it
+// may do. The provider in use-facility-rbac.tsx computes the same cascade from
+// a mock staff array plus overrides in localStorage — editable from devtools,
+// and a second implementation of rules that already exist in SQL.
+//
+// WHILE IT LOADS, AND WHEN SIGNED OUT, callers keep the legacy answer. That is
+// deliberate: switching hard would blank guarded UI for anyone browsing
+// signed-out, which is most of the app until AUTH_ENFORCED flips. Returning
+// `null` rather than an empty map is what makes "not known yet" distinguishable
+// from "denied" — an empty map would read as "you may do nothing" and hide
+// every guarded control for a frame.
+//
+// None of this is enforcement. RLS refuses the row whatever the client thinks.
+// This only decides which controls are worth drawing.
+// ============================================================================
+
+type PermissionMap = Partial<Record<PermissionKey, AccessScope>>;
+
+async function fetchPermissions(): Promise<PermissionMap | null> {
+  const response = await fetch("/api/permissions");
+  // Signed out — the caller falls back to the legacy client-side cascade.
+  if (response.status === 401) return null;
+  if (!response.ok) {
+    throw new Error(`Failed to load permissions (${response.status})`);
+  }
+  return (await response.json()) as PermissionMap;
+}
+
+export const permissionQueries = {
+  mine: () => ({
+    queryKey: ["permissions", "mine"] as const,
+    queryFn: fetchPermissions,
+    // Permissions change when an admin edits a role, not between renders.
+    staleTime: 5 * 60_000,
+  }),
+};
+
+/**
+ * The database's answer, or `null` when there is no session / it has not
+ * arrived yet. Callers treat `null` as "use the legacy path".
+ */
+export function useDbPermissions(): EffectivePermissions | null {
+  const { data } = useQuery(permissionQueries.mine());
+  if (!data) return null;
+
+  // 'none' is how the database says "not granted"; the client type says
+  // `false`. Translated here so no consumer has to know both spellings.
+  const out = {} as EffectivePermissions;
+  for (const [key, scope] of Object.entries(data)) {
+    out[key as PermissionKey] =
+      scope === "none" ? false : (scope as AccessScope);
+  }
+  return out;
+}

--- a/src/hooks/use-facility-rbac.tsx
+++ b/src/hooks/use-facility-rbac.tsx
@@ -26,6 +26,7 @@ import {
 } from "@/types/facility-staff";
 import { facilityStaff } from "@/data/facility-staff";
 import { setFacilityRoleCookie } from "@/lib/facility-role";
+import { useDbPermissions } from "@/hooks/use-db-permissions";
 import {
   roleQueries,
   useCreateCustomRole,
@@ -494,21 +495,37 @@ export function useFacilityViewer() {
 /**
  * The full effective permission map for the acting viewer. Guards, the dynamic
  * sidebar, and field-masking read from this single source of truth.
+ *
+ * The DATABASE is that source when there is a session — see
+ * use-db-permissions.ts. The client-side cascade below it computes the same
+ * rules from a mock staff array and overrides held in localStorage, which is
+ * both a second implementation and an editable one.
+ *
+ * The legacy path stays as the fallback while AUTH_ENFORCED is off, because
+ * most of the app is still browsed signed-out and blanking every guarded
+ * control would look like a bug rather than a policy.
  */
 export function useEffectivePermissions(): EffectivePermissions {
   const { viewer, resolvePermissions } = useFacilityRbac();
-  return useMemo(
+  const fromDb = useDbPermissions();
+
+  const legacy = useMemo(
     () => resolvePermissions(viewer.id),
     [resolvePermissions, viewer.id],
   );
+
+  return fromDb ?? legacy;
 }
 
 /**
  * Does the acting viewer have `key` (with any scope)? The ergonomic check every
- * guard/sidebar/mask should call. Delegates to the provider's single resolver.
+ * guard/sidebar/mask should call.
  */
 export function usePermission(key: PermissionKey): boolean {
   const { can } = useFacilityRbac();
+  const fromDb = useDbPermissions();
+
+  if (fromDb) return fromDb[key] !== false && fromDb[key] !== undefined;
   return can(key);
 }
 
@@ -519,6 +536,10 @@ export function usePermission(key: PermissionKey): boolean {
  */
 export function useCan(key: PermissionKey): AccessScope | false {
   const { viewer, resolveFor } = useFacilityRbac();
+  const fromDb = useDbPermissions();
+
+  if (fromDb) return fromDb[key] ?? false;
+
   const { granted, scope } = resolveFor(viewer, key);
   return granted ? scope : false;
 }

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -751,6 +751,13 @@ export type Database = {
         Args: Record<PropertyKey, never>;
         Returns: string | null;
       };
+      my_permissions: {
+        Args: Record<PropertyKey, never>;
+        Returns: {
+          permission_key: string;
+          scope: Database["public"]["Enums"]["access_scope"];
+        }[];
+      };
     };
     Enums: {
       access_scope: "anytime" | "operating_hours" | "assigned_shifts" | "none";

--- a/supabase/migrations/20260801160000_my_permissions.sql
+++ b/supabase/migrations/20260801160000_my_permissions.sql
@@ -1,0 +1,60 @@
+-- ============================================================================
+-- The caller's effective permissions, resolved by the database.
+--
+-- The three-layer cascade (role preset -> facility override -> per-staff
+-- override) already exists in private.resolve_permission, but only one key at
+-- a time. The client needs the whole map: guards, the dynamic sidebar and
+-- field masking all read every key, and 168 round trips is not an option.
+--
+-- This is the function that lets the browser stop computing permissions from a
+-- mock array and start reading the ones the database will actually enforce.
+-- Until now those were two independent implementations of the same rules,
+-- which is a disagreement waiting to happen — and the client's copy is the one
+-- an attacker can edit.
+--
+-- Returns a scope per key, never a boolean: "granted" is not the question, the
+-- question is "granted WHEN" — anytime, operating_hours, assigned_shifts, or
+-- none.
+--
+-- Sanity check at the time of writing, per role preset:
+--   owner 168/168 · manager 141 · reception 65 · caretaker 45 · groomer 36
+-- ============================================================================
+
+create or replace function public.my_permissions()
+returns table (permission_key text, scope public.access_scope)
+language sql
+stable
+security definer
+set search_path = ''
+as $$
+  -- Platform admins are not staff anywhere and hold no membership, so the
+  -- cascade has nothing to resolve for them. They get everything.
+  select p.key, 'anytime'::public.access_scope
+    from public.permissions p
+   where private.is_platform_admin()
+
+  union all
+
+  select p.key,
+         coalesce(
+           private.resolve_permission(m.id, p.key),
+           'none'::public.access_scope
+         )
+    from public.permissions p
+    cross join (
+      -- The caller's membership. `order by created_at` makes the choice
+      -- deterministic for someone who works at two facilities; picking a
+      -- facility properly is the multi-location follow-up, not something to
+      -- guess at here.
+      select fm.id
+        from public.facility_memberships fm
+       where fm.profile_id = (select auth.uid())
+         and fm.is_active
+       order by fm.created_at
+       limit 1
+    ) m
+   where not private.is_platform_admin();
+$$;
+
+grant execute on function public.my_permissions() to authenticated;
+revoke execute on function public.my_permissions() from anon, public;


### PR DESCRIPTION
The UI decided what it was allowed to do by computing the three-layer cascade **in the browser** — from a mock staff array plus overrides held in `localStorage`. The same rules already existed in SQL.

Two implementations of one policy, and the authoritative-looking one was the one you could edit from devtools.

## `public.my_permissions()`

Returns every permission key with its resolved `access_scope` for the caller, through `private.resolve_permission` — the same cascade RLS uses. One call rather than 168, because guards, the dynamic sidebar and field masking all read the whole map.

A **scope per key, never a boolean**: the question isn't *"granted"* but *"granted when"* — `anytime`, `operating_hours`, `assigned_shifts`, `none`. Platform admins hold no membership, so the cascade has nothing to resolve for them; they're special-cased to everything.

## `useDbPermissions`

`usePermission` / `useCan` / `useEffectivePermissions` now prefer the database answer. The legacy client-side path stays as the fallback while `AUTH_ENFORCED` is off — most of the app is still browsed signed-out, and blanking every guarded control would read as a bug rather than a policy.

It returns `null` rather than an empty map while loading. An empty map means *"you may do nothing"* and would hide every guarded control for a frame; `null` means *"not known yet"*, which is a different question with a different answer.

## What this is **not**

Enforcement. RLS refuses the row whatever the client believes. This decides which controls are worth *drawing* — and now draws them from the same source that will refuse the request, so the two can't disagree.

## Verified in a browser — 18 checks

Each role resolves a genuinely different map:

```
platform admin  168 / 168        caretaker    45
owner           168 / 168        groomer      36
manager         141              signed out   401 → legacy path
reception        65
```

More than one scope is in play — a groomer's `view_bookings` resolves to `assigned_shifts`, not `true`. `manage_staff` is denied.

And the one that matters:

```
writing viewerId "fs-owner-01" into localStorage — which used to grant
owner access — now changes nothing. The groomer still resolves 36, not 168.
```

## Still outstanding, and worth knowing

**The role editor is currently cosmetic.** The legacy provider still owns custom roles and preset overrides, which live in `localStorage` and are **not** reflected in the database cascade. A facility editing a role preset in the UI changes what the browser draws, not what Postgres enforces.

Writing those through to `facility_role_permissions` / `membership_permissions` is the follow-up — and it's what makes that editor real. Worth doing before anyone relies on it.

`AUTH_ENFORCED` is still off, so nothing changes on merge.