### PR TITLE
feat(rbac): the role editor edits what Postgres enforces

### DIFF
--- a/src/app/api/roles/overrides/route.ts
+++ b/src/app/api/roles/overrides/route.ts
@@ -1,0 +1,242 @@
+import { NextResponse, type NextRequest } from "next/server";
+import type { PostgrestError } from "@supabase/supabase-js";
+
+import { createServerClient, getCurrentUser } from "@/lib/supabase/server";
+import type {
+  AccessScope,
+  FacilityStaffRole,
+  PermissionKey,
+  PermissionSetting,
+  RolePresetOverrides,
+} from "@/types/facility-staff";
+
+// ============================================================================
+// The role editor's write path.
+//
+// Until now every edit made here went to localStorage: private to one browser,
+// editable from devtools, and — since the database started answering
+// `my_permissions()` — discarded on the next load. The editor was drawing a
+// control that did nothing.
+//
+// Two layers of the cascade are writable here:
+//
+//   facility-role  →  facility_role_permissions   "what Groomer means HERE"
+//   staff          →  staff_permissions           "except for this person"
+//
+// Authorisation is the `manage_roles` permission, enforced by RLS on both
+// tables, not by this file. What this file owns is the translation between the
+// client's vocabulary and the database's:
+//
+//   "revoked" / { granted: false }   ->  scope 'none'   (an explicit denial)
+//   null                             ->  DELETE the row (inherit again)
+//
+// The distinction matters: a stored 'none' outranks every role the person
+// holds, while an absent row means the roles decide. Writing 'none' where the
+// UI meant "reset" would silently deny instead of inherit.
+// ============================================================================
+
+export const dynamic = "force-dynamic";
+
+export type RoleOverrides = {
+  /** Per-role overrides for the caller's facility. */
+  facilityRoles: RolePresetOverrides;
+  /** Per-person overrides, keyed by the staff legacy id ("fs-groom-01"). */
+  staff: Record<string, Partial<Record<PermissionKey, PermissionSetting>>>;
+};
+
+export type RoleOverrideWrite =
+  | {
+      kind: "facility-role";
+      role: FacilityStaffRole;
+      key: PermissionKey;
+      /** `null` clears the override; "revoked" denies it outright. */
+      scope: AccessScope | "revoked" | null;
+    }
+  | {
+      kind: "staff";
+      /** The staff legacy id, e.g. "fs-groom-01". */
+      staffId: string;
+      key: PermissionKey;
+      /** `null` clears the override. */
+      setting: PermissionSetting | null;
+    };
+
+const unauthorised = () =>
+  NextResponse.json({ error: "Not signed in." }, { status: 401 });
+
+const denied = () =>
+  NextResponse.json(
+    { error: "You do not have permission to edit roles here." },
+    { status: 403 },
+  );
+
+const ok = () => NextResponse.json({ ok: true });
+
+/**
+ * An RLS refusal on INSERT raises 42501 rather than returning no rows, so an
+ * upsert fails loudly. 23503 is a foreign-key violation — an unknown
+ * permission key, which is the client's fault, not ours.
+ */
+function failure(error: PostgrestError): NextResponse {
+  if (error.code === "42501") return denied();
+  return NextResponse.json(
+    { error: error.message },
+    { status: error.code === "23503" ? 400 : 500 },
+  );
+}
+
+/** A stored 'none' is a denial; anything else is a grant at that scope. */
+function toSetting(scope: AccessScope): PermissionSetting {
+  return scope === "none"
+    ? { granted: false, scope: "none" }
+    : { granted: true, scope };
+}
+
+// ── Read ────────────────────────────────────────────────────────────────────
+
+export async function GET() {
+  const user = await getCurrentUser().catch(() => null);
+  if (!user) return unauthorised();
+
+  const supabase = await createServerClient();
+
+  // RLS scopes both selects to the caller's facility; no filter is needed for
+  // correctness, and adding one would not be what keeps other tenants out.
+  const [roleRows, staffRows] = await Promise.all([
+    supabase
+      .from("facility_role_permissions")
+      .select("role, permission_key, scope"),
+    supabase
+      .from("staff_permissions")
+      .select("permission_key, scope, staff:staff_id (legacy_id)"),
+  ]);
+
+  if (roleRows.error ?? staffRows.error) {
+    return NextResponse.json(
+      { error: (roleRows.error ?? staffRows.error)?.message },
+      { status: 500 },
+    );
+  }
+
+  const facilityRoles: RolePresetOverrides = {};
+  for (const row of roleRows.data ?? []) {
+    const role = row.role as FacilityStaffRole;
+    // "revoked" is the client's spelling of a denial. Translated back here so
+    // no component has to know the database stores it as a scope.
+    (facilityRoles[role] ??= {})[row.permission_key as PermissionKey] =
+      row.scope === "none" ? "revoked" : row.scope;
+  }
+
+  const staff: RoleOverrides["staff"] = {};
+  for (const row of staffRows.data ?? []) {
+    const legacyId = row.staff?.legacy_id;
+    if (!legacyId) continue;
+    (staff[legacyId] ??= {})[row.permission_key as PermissionKey] = toSetting(
+      row.scope,
+    );
+  }
+
+  return NextResponse.json({ facilityRoles, staff } satisfies RoleOverrides);
+}
+
+// ── Write ───────────────────────────────────────────────────────────────────
+
+export async function PUT(request: NextRequest) {
+  const user = await getCurrentUser().catch(() => null);
+  if (!user) return unauthorised();
+
+  const body = (await request.json()) as RoleOverrideWrite;
+  const supabase = await createServerClient();
+
+  if (body.kind === "facility-role") {
+    // The caller's facility comes from their own membership, never from a
+    // request field — otherwise this route would let anyone name a tenant.
+    const { data: membership } = await supabase
+      .from("facility_memberships")
+      .select("facility_id")
+      .eq("is_active", true)
+      .order("created_at")
+      .limit(1)
+      .maybeSingle();
+
+    if (!membership) {
+      return NextResponse.json(
+        { error: "You do not belong to a facility." },
+        { status: 403 },
+      );
+    }
+
+    const match = {
+      facility_id: membership.facility_id,
+      role: body.role,
+      permission_key: body.key,
+    };
+
+    if (body.scope === null) {
+      const { error } = await supabase
+        .from("facility_role_permissions")
+        .delete()
+        .match(match);
+      if (error) return failure(error);
+
+      const { data: survivor } = await supabase
+        .from("facility_role_permissions")
+        .select("permission_key")
+        .match(match)
+        .maybeSingle();
+      return survivor ? denied() : ok();
+    }
+
+    const { error } = await supabase.from("facility_role_permissions").upsert({
+      ...match,
+      scope: body.scope === "revoked" ? "none" : body.scope,
+    });
+    return error ? failure(error) : ok();
+  }
+
+  if (body.kind === "staff") {
+    const { data: staffRow } = await supabase
+      .from("staff")
+      .select("id")
+      .eq("legacy_id", body.staffId)
+      .maybeSingle();
+
+    if (!staffRow) {
+      return NextResponse.json(
+        { error: `No staff record for "${body.staffId}".` },
+        { status: 404 },
+      );
+    }
+
+    const match = { staff_id: staffRow.id, permission_key: body.key };
+
+    if (body.setting === null) {
+      const { error } = await supabase
+        .from("staff_permissions")
+        .delete()
+        .match(match);
+      if (error) return failure(error);
+
+      // A DELETE the policy refuses matches zero rows rather than failing, so
+      // "denied" and "there was nothing there" look identical from the result.
+      // Reading the row back is what tells them apart.
+      const { data: survivor } = await supabase
+        .from("staff_permissions")
+        .select("permission_key")
+        .match(match)
+        .maybeSingle();
+      return survivor ? denied() : ok();
+    }
+
+    const { error } = await supabase.from("staff_permissions").upsert({
+      ...match,
+      scope: body.setting.granted ? body.setting.scope : "none",
+    });
+    return error ? failure(error) : ok();
+  }
+
+  return NextResponse.json(
+    { error: "Unknown override kind." },
+    { status: 400 },
+  );
+}

--- a/src/hooks/use-facility-rbac.tsx
+++ b/src/hooks/use-facility-rbac.tsx
@@ -32,6 +32,8 @@ import {
   useCreateCustomRole,
   useDeleteCustomRole,
   useSetCustomRolePermission,
+  useSetFacilityRolePermission,
+  useSetStaffPermission,
   useUpdateCustomRole,
 } from "@/lib/api/roles";
 
@@ -160,14 +162,24 @@ export function FacilityRbacProvider({
   const [hydrated, setHydrated] = useState(false);
 
   // Custom roles are read through the roles query layer; their writes go through
-  // the mutations below. viewerId + presetOverrides stay local to this provider.
+  // the mutations below. viewerId stays local to this provider.
   const { data: customRolesData } = useQuery(roleQueries.customRoles());
   const customRoles = customRolesData ?? EMPTY_CUSTOM_ROLES;
+
+  // The two DB-backed layers of the cascade. `undefined` while loading and
+  // `null` when signed out; in both cases the local state below is what the UI
+  // shows, for the same reason use-db-permissions falls back — most of the app
+  // is still browsed signed-out until AUTH_ENFORCED flips, and blanking the
+  // editor would look like a bug rather than a sign-in prompt.
+  const { data: dbOverrides } = useQuery(roleQueries.overrides());
 
   const { mutate: createRoleMutate } = useCreateCustomRole();
   const { mutate: updateRoleMutate } = useUpdateCustomRole();
   const { mutate: deleteRoleMutate } = useDeleteCustomRole();
   const { mutate: setRolePermissionMutate } = useSetCustomRolePermission();
+  const { mutate: setFacilityRolePermissionMutate } =
+    useSetFacilityRolePermission();
+  const { mutate: setStaffPermissionMutate } = useSetStaffPermission();
 
   useEffect(() => {
     if (typeof window === "undefined") return;
@@ -217,17 +229,27 @@ export function FacilityRbacProvider({
     setFacilityRoleCookie(viewer.primaryRole);
   }, [viewer.primaryRole, hydrated]);
 
-  // A staff member's effective override map: the provider's edited overrides if
-  // an entry exists, otherwise the profile's baked seed.
+  // What a role means at this facility. The database's answer wins when there
+  // is one, because that is what RLS will enforce; the local blob is only the
+  // signed-out fallback.
+  const presetOverrides = dbOverrides?.facilityRoles ?? state.presetOverrides;
+
+  // A staff member's effective override map, most authoritative first: the
+  // database, then this browser's edits, then the profile's baked seed.
   const staffOverridesFor = useCallback(
     (staffId: string): Partial<Record<PermissionKey, PermissionSetting>> => {
-      const edited = state.staffOverrides[staffId];
+      const stored = dbOverrides?.staff[staffId];
+      if (stored) return stored;
+      // Deliberately NOT consulted once the database has answered: a stale
+      // local edit that Postgres does not know about must not resurface as
+      // though it were in force.
+      const edited = dbOverrides ? undefined : state.staffOverrides[staffId];
       if (edited) return edited;
       return (
         facilityStaff.find((s) => s.id === staffId)?.permissionOverrides ?? {}
       );
     },
-    [state.staffOverrides],
+    [dbOverrides, state.staffOverrides],
   );
 
   // Overlay the provider's per-staff overrides onto the profile before resolving
@@ -252,10 +274,10 @@ export function FacilityRbacProvider({
       }
       return resolvePermission(withOverrides(staff), key, {
         customRoles,
-        presetOverrides: state.presetOverrides,
+        presetOverrides,
       });
     },
-    [customRoles, state.presetOverrides, withOverrides, previewPermissions],
+    [customRoles, presetOverrides, withOverrides, previewPermissions],
   );
 
   const can = useCallback(
@@ -276,10 +298,10 @@ export function FacilityRbacProvider({
       }
       return resolveAllPermissions(withOverrides(staff), {
         customRoles,
-        presetOverrides: state.presetOverrides,
+        presetOverrides,
       });
     },
-    [customRoles, state.presetOverrides, withOverrides, previewPermissions],
+    [customRoles, presetOverrides, withOverrides, previewPermissions],
   );
 
   const setStaffPermission = useCallback(
@@ -288,6 +310,11 @@ export function FacilityRbacProvider({
       key: PermissionKey,
       setting: PermissionSetting | null,
     ) => {
+      // Postgres is where this has to land — staff_permissions is layer 3 of
+      // the cascade RLS evaluates. The local edit below is what the editor
+      // shows while signed out.
+      setStaffPermissionMutate({ staffId, key, setting });
+
       setState((prev) => {
         // Seed a fresh entry from the profile's baked overrides so edits build
         // on top of any pre-existing seed rather than wiping it.
@@ -307,15 +334,25 @@ export function FacilityRbacProvider({
         };
       });
     },
-    [],
+    [setStaffPermissionMutate],
   );
 
-  const resetStaffOverrides = useCallback((staffId: string) => {
-    setState((prev) => ({
-      ...prev,
-      staffOverrides: { ...prev.staffOverrides, [staffId]: {} },
-    }));
-  }, []);
+  const resetStaffOverrides = useCallback(
+    (staffId: string) => {
+      // Only the keys the database actually holds — the baked mock seed has no
+      // row to delete, and issuing deletes for it would be noise.
+      for (const key of Object.keys(
+        dbOverrides?.staff[staffId] ?? {},
+      ) as PermissionKey[]) {
+        setStaffPermissionMutate({ staffId, key, setting: null });
+      }
+      setState((prev) => ({
+        ...prev,
+        staffOverrides: { ...prev.staffOverrides, [staffId]: {} },
+      }));
+    },
+    [dbOverrides, setStaffPermissionMutate],
+  );
 
   const createCustomRole = useCallback(
     (
@@ -364,6 +401,10 @@ export function FacilityRbacProvider({
       key: PermissionKey,
       scope: AccessScope | "revoked" | null,
     ) => {
+      // The edit that counts: facility_role_permissions is what
+      // private.resolve_permission reads. Everything below is presentation.
+      setFacilityRolePermissionMutate({ role, key, scope });
+
       setState((prev) => {
         const current = { ...(prev.presetOverrides[role] ?? {}) };
         if (scope === null) {
@@ -380,20 +421,41 @@ export function FacilityRbacProvider({
         return { ...prev, presetOverrides: nextOverrides };
       });
     },
-    [],
+    [setFacilityRolePermissionMutate],
   );
 
-  const resetPresetRole = useCallback((role: FacilityStaffRole) => {
-    setState((prev) => {
-      const next = { ...prev.presetOverrides };
-      delete next[role];
-      return { ...prev, presetOverrides: next };
-    });
-  }, []);
+  // Resetting is a delete per key rather than one call, because the override
+  // tables are keyed per permission. Clearing them only in local state would
+  // leave the row in Postgres still in force — the same lie this change exists
+  // to remove, just behind a different button.
+  const resetPresetRole = useCallback(
+    (role: FacilityStaffRole) => {
+      for (const key of Object.keys(
+        presetOverrides[role] ?? {},
+      ) as PermissionKey[]) {
+        setFacilityRolePermissionMutate({ role, key, scope: null });
+      }
+      setState((prev) => {
+        const next = { ...prev.presetOverrides };
+        delete next[role];
+        return { ...prev, presetOverrides: next };
+      });
+    },
+    [presetOverrides, setFacilityRolePermissionMutate],
+  );
 
   const resetAllPresets = useCallback(() => {
+    for (const [role, keys] of Object.entries(presetOverrides)) {
+      for (const key of Object.keys(keys) as PermissionKey[]) {
+        setFacilityRolePermissionMutate({
+          role: role as FacilityStaffRole,
+          key,
+          scope: null,
+        });
+      }
+    }
     setState((prev) => ({ ...prev, presetOverrides: {} }));
-  }, []);
+  }, [presetOverrides, setFacilityRolePermissionMutate]);
 
   const setViewerId = useCallback((id: string) => {
     setState((prev) => ({ ...prev, viewerId: id }));
@@ -405,7 +467,7 @@ export function FacilityRbacProvider({
       viewerId: state.viewerId,
       setViewerId,
       customRoles,
-      presetOverrides: state.presetOverrides,
+      presetOverrides,
       can,
       resolveFor,
       resolvePermissions,
@@ -424,7 +486,7 @@ export function FacilityRbacProvider({
       viewer,
       state.viewerId,
       customRoles,
-      state.presetOverrides,
+      presetOverrides,
       setViewerId,
       can,
       resolveFor,

--- a/src/lib/api/live-fetch.ts
+++ b/src/lib/api/live-fetch.ts
@@ -40,10 +40,10 @@ export async function liveFetch<T>(
   return (await response.json()) as T;
 }
 
-/** POST/PATCH helper — no fallback, because a write must never silently no-op. */
+/** Write helper — no fallback, because a write must never silently no-op. */
 export async function liveWrite<T>(
   path: string,
-  method: "POST" | "PATCH",
+  method: "POST" | "PATCH" | "PUT",
   body: unknown,
 ): Promise<T> {
   const response = await fetch(path, {

--- a/src/lib/api/roles.ts
+++ b/src/lib/api/roles.ts
@@ -6,27 +6,57 @@ import {
   type QueryClient,
 } from "@tanstack/react-query";
 import { facilityRolesStore } from "@/lib/facility-roles-store";
+import { liveWrite } from "@/lib/api/live-fetch";
+import { permissionQueries } from "@/hooks/use-db-permissions";
+import type {
+  RoleOverrides,
+  RoleOverrideWrite,
+} from "@/app/api/roles/overrides/route";
 import type {
   AccessScope,
   CustomFacilityRole,
   CustomRolesById,
+  FacilityStaffRole,
   PermissionKey,
+  PermissionSetting,
 } from "@/types/facility-staff";
 
 // Roles domain query layer. Facility custom roles are read through
 // `roleQueries.customRoles()` and written through the mutation hooks below, so
 // the TanStack Query cache is the single source of truth. The underlying
 // persistence lives in @/lib/facility-roles-store (the mock "backend").
+//
+// The two DB-backed layers are separate: `roleQueries.overrides()` reads what
+// Postgres will actually enforce, and the override mutations write it. Custom
+// roles are still browser-local — they have no home in the schema yet, because
+// facility_role_permissions.role is an enum. See the migration for why.
 
 export const roleKeys = {
   all: ["facility-roles"] as const,
   custom: () => [...roleKeys.all, "custom"] as const,
+  overrides: () => [...roleKeys.all, "overrides"] as const,
 };
+
+/** `null` when signed out — the caller keeps the legacy client-side state. */
+async function fetchOverrides(): Promise<RoleOverrides | null> {
+  const response = await fetch("/api/roles/overrides");
+  if (response.status === 401) return null;
+  if (!response.ok) {
+    throw new Error(`Failed to load role overrides (${response.status})`);
+  }
+  return (await response.json()) as RoleOverrides;
+}
 
 export const roleQueries = {
   customRoles: () => ({
     queryKey: roleKeys.custom(),
     queryFn: async (): Promise<CustomRolesById> => facilityRolesStore.getAll(),
+  }),
+  /** What the database will enforce, as opposed to what this browser remembers. */
+  overrides: () => ({
+    queryKey: roleKeys.overrides(),
+    queryFn: fetchOverrides,
+    staleTime: 5 * 60_000,
   }),
 };
 
@@ -100,6 +130,98 @@ export function useDeleteCustomRole() {
       });
     },
     onSettled: () => invalidate(queryClient),
+  });
+}
+
+// ── The DB-backed cascade ───────────────────────────────────────────────────
+// Both mutations invalidate the viewer's own permission map as well as the
+// override list: editing what Groomer means changes what a groomer may do, and
+// the guard drawing the screen reads the resolved map, not this one.
+
+function patchOverrides(
+  queryClient: QueryClient,
+  updater: (prev: RoleOverrides) => RoleOverrides,
+): void {
+  queryClient.setQueryData<RoleOverrides | null>(
+    roleKeys.overrides(),
+    // Null means signed out. Don't invent a map the server never sent — the
+    // legacy client-side state is what the UI is showing in that case.
+    (prev) => (prev ? updater(prev) : prev),
+  );
+}
+
+function invalidateResolved(queryClient: QueryClient) {
+  return Promise.all([
+    queryClient.invalidateQueries({ queryKey: roleKeys.overrides() }),
+    queryClient.invalidateQueries({
+      queryKey: permissionQueries.mine().queryKey,
+    }),
+  ]);
+}
+
+export type SetFacilityRolePermissionVars = {
+  role: FacilityStaffRole;
+  key: PermissionKey;
+  /** `null` resets to the global preset; "revoked" denies it here. */
+  scope: AccessScope | "revoked" | null;
+};
+
+/** Layer 2 — what a preset role means at this facility. */
+export function useSetFacilityRolePermission() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (vars: SetFacilityRolePermissionVars) =>
+      liveWrite<{ ok: true }>("/api/roles/overrides", "PUT", {
+        kind: "facility-role",
+        ...vars,
+      } satisfies RoleOverrideWrite),
+    onMutate: ({ role, key, scope }) => {
+      patchOverrides(queryClient, (prev) => {
+        const forRole = { ...(prev.facilityRoles[role] ?? {}) };
+        if (scope === null) {
+          delete forRole[key];
+        } else {
+          forRole[key] = scope;
+        }
+        return {
+          ...prev,
+          facilityRoles: { ...prev.facilityRoles, [role]: forRole },
+        };
+      });
+    },
+    onSettled: () => invalidateResolved(queryClient),
+  });
+}
+
+export type SetStaffPermissionVars = {
+  /** The staff legacy id, e.g. "fs-groom-01". */
+  staffId: string;
+  key: PermissionKey;
+  /** `null` clears the override so their roles decide again. */
+  setting: PermissionSetting | null;
+};
+
+/** Layer 3 — one person, regardless of the roles they hold. */
+export function useSetStaffPermission() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (vars: SetStaffPermissionVars) =>
+      liveWrite<{ ok: true }>("/api/roles/overrides", "PUT", {
+        kind: "staff",
+        ...vars,
+      } satisfies RoleOverrideWrite),
+    onMutate: ({ staffId, key, setting }) => {
+      patchOverrides(queryClient, (prev) => {
+        const forStaff = { ...(prev.staff[staffId] ?? {}) };
+        if (setting === null) {
+          delete forStaff[key];
+        } else {
+          forStaff[key] = setting;
+        }
+        return { ...prev, staff: { ...prev.staff, [staffId]: forStaff } };
+      });
+    },
+    onSettled: () => invalidateResolved(queryClient),
   });
 }
 

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -686,6 +686,42 @@ export type Database = {
           },
         ];
       };
+      staff_permissions: {
+        Row: {
+          permission_key: string;
+          scope: Database["public"]["Enums"]["access_scope"];
+          staff_id: string;
+          updated_at: string;
+        };
+        Insert: {
+          permission_key: string;
+          scope: Database["public"]["Enums"]["access_scope"];
+          staff_id: string;
+          updated_at?: string;
+        };
+        Update: {
+          permission_key?: string;
+          scope?: Database["public"]["Enums"]["access_scope"];
+          staff_id?: string;
+          updated_at?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "staff_permissions_permission_key_fkey";
+            columns: ["permission_key"];
+            isOneToOne: false;
+            referencedRelation: "permissions";
+            referencedColumns: ["key"];
+          },
+          {
+            foreignKeyName: "staff_permissions_staff_id_fkey";
+            columns: ["staff_id"];
+            isOneToOne: false;
+            referencedRelation: "staff";
+            referencedColumns: ["id"];
+          },
+        ];
+      };
       profiles: {
         Row: {
           avatar_url: string | null;

--- a/supabase/migrations/20260801170000_role_editor_writes.sql
+++ b/supabase/migrations/20260801170000_role_editor_writes.sql
@@ -1,0 +1,279 @@
+-- ============================================================================
+-- Make the role editor real.
+--
+-- The three-layer cascade has existed since the tenancy migration, but only
+-- layer 1 (the global presets) has ever had rows. `facility_role_permissions`
+-- and `membership_permissions` were created, indexed, RLS'd — and left empty,
+-- because nothing could write to them.
+--
+-- Meanwhile the UI let a facility owner edit role permissions and told them it
+-- had saved. It had: to localStorage. Since PR #99 the database answers
+-- `my_permissions()`, so that edit is not merely private to one browser, it is
+-- discarded on the next load. The editor has been drawing a control that does
+-- nothing.
+--
+-- This migration gives those edits somewhere to land, and fixes two things
+-- found on the way.
+--
+-- ── 1. The write policies gate on the wrong permission ──────────────────────
+-- Every write policy on the permission tables checks `scheduling_view_all` —
+-- "View all staff schedules". The comment above them says "written only by
+-- someone holding the staff-management permission", so the intent was clear
+-- and the key was a placeholder nobody replaced.
+--
+-- The consequence is a live privilege escalation: `supervisor` holds
+-- scheduling_view_all, therefore any supervisor can rewrite their facility's
+-- permission table and grant themselves anything, including manage_roles.
+-- `manage_roles` ("Manage roles & permissions") is granted to owner and admin
+-- only, and is the key these policies meant all along.
+--
+-- Membership writes get `manage_staff` for the same reason — adding and
+-- removing people is staff management, not schedule viewing.
+--
+-- ── 2. Per-staff overrides had nowhere to live ──────────────────────────────
+-- Layer 3 is `membership_permissions`, keyed on membership_id. But a
+-- membership is an ACCOUNT, and 0 of the 18 staff records have one — a staff
+-- record is created when someone is hired, a membership only when they accept
+-- an invite. Keying the override on the account means it cannot be written
+-- until the person signs in, and is destroyed if their access is later
+-- revoked and re-granted.
+--
+-- `staff_permissions` keys on the durable HR record instead, which is what
+-- StaffProfile.permissionOverrides has always meant. An override can be set
+-- for a new hire on their first day and takes effect the moment they have an
+-- account.
+--
+-- membership_permissions is kept, above it in precedence: it is the right home
+-- for an override that belongs to the login rather than the person (a
+-- temporary elevation, a contractor's account). It has no writer yet.
+--
+-- ── 3. The cascade only ever read one role ─────────────────────────────────
+-- resolvePermission() in TypeScript unions across primaryRole, additionalRoles
+-- and custom roles, widest scope winning. The SQL read `facility_memberships.
+-- role` — one role, singular. A groomer who is also a supervisor resolved as a
+-- groomer alone.
+--
+-- Rewritten below to union the same way. Note this makes a REVOKE at the
+-- facility layer non-absolute, exactly as the TypeScript has it: revoking a
+-- permission for Groomer removes the groomer's claim to it, but if they also
+-- hold Supervisor and Supervisor grants it, they keep it. A revoke that must
+-- bind regardless is a per-staff override, which is the layer above.
+--
+-- ── Not in scope: custom roles ─────────────────────────────────────────────
+-- CustomFacilityRole lets a facility invent a role ("Senior Groomer"). It has
+-- no home here because `facility_role_permissions.role` is the
+-- facility_staff_role ENUM — a fixed list — and memberships carry one enum
+-- value. Giving custom roles a real home means a table, a join table, and a
+-- fourth branch in the union below. It is a bigger change than this one and
+-- it needs a product answer first (are they roles, or are they saved bundles
+-- of per-staff overrides?). Until then they remain browser-local, and the
+-- preset editor — the surface facilities actually use — is real.
+-- ============================================================================
+
+-- ── 1. Correct the privilege gate ───────────────────────────────────────────
+
+drop policy if exists facility_role_permissions_insert on public.facility_role_permissions;
+drop policy if exists facility_role_permissions_update on public.facility_role_permissions;
+drop policy if exists facility_role_permissions_delete on public.facility_role_permissions;
+
+create policy facility_role_permissions_insert on public.facility_role_permissions
+  for insert to authenticated
+  with check (private.has_permission(facility_id, 'manage_roles'));
+create policy facility_role_permissions_update on public.facility_role_permissions
+  for update to authenticated
+  using (private.has_permission(facility_id, 'manage_roles'))
+  with check (private.has_permission(facility_id, 'manage_roles'));
+create policy facility_role_permissions_delete on public.facility_role_permissions
+  for delete to authenticated
+  using (private.has_permission(facility_id, 'manage_roles'));
+
+drop policy if exists membership_permissions_insert on public.membership_permissions;
+drop policy if exists membership_permissions_update on public.membership_permissions;
+drop policy if exists membership_permissions_delete on public.membership_permissions;
+
+create policy membership_permissions_insert on public.membership_permissions
+  for insert to authenticated
+  with check (exists (
+    select 1 from public.facility_memberships m
+     where m.id = membership_permissions.membership_id
+       and private.has_permission(m.facility_id, 'manage_roles')));
+create policy membership_permissions_update on public.membership_permissions
+  for update to authenticated
+  using (exists (
+    select 1 from public.facility_memberships m
+     where m.id = membership_permissions.membership_id
+       and private.has_permission(m.facility_id, 'manage_roles')))
+  with check (exists (
+    select 1 from public.facility_memberships m
+     where m.id = membership_permissions.membership_id
+       and private.has_permission(m.facility_id, 'manage_roles')));
+create policy membership_permissions_delete on public.membership_permissions
+  for delete to authenticated
+  using (exists (
+    select 1 from public.facility_memberships m
+     where m.id = membership_permissions.membership_id
+       and private.has_permission(m.facility_id, 'manage_roles')));
+
+-- Adding or removing a person is staff management. The read policy is
+-- unchanged.
+drop policy if exists memberships_insert on public.facility_memberships;
+drop policy if exists memberships_update on public.facility_memberships;
+drop policy if exists memberships_delete on public.facility_memberships;
+
+create policy memberships_insert on public.facility_memberships
+  for insert to authenticated
+  with check (private.has_permission(facility_id, 'manage_staff'));
+create policy memberships_update on public.facility_memberships
+  for update to authenticated
+  using (private.has_permission(facility_id, 'manage_staff'))
+  with check (private.has_permission(facility_id, 'manage_staff'));
+create policy memberships_delete on public.facility_memberships
+  for delete to authenticated
+  using (private.has_permission(facility_id, 'manage_staff'));
+
+-- ── 2. Per-staff overrides, keyed on the person ─────────────────────────────
+
+create table public.staff_permissions (
+  staff_id       uuid not null references public.staff (id) on delete cascade,
+  permission_key text not null references public.permissions (key) on delete cascade,
+
+  -- 'none' is how a REVOKE is spelled: an explicit denial that outranks every
+  -- role the person holds. Absence of a row means "inherit", which is why
+  -- clearing an override is a DELETE and not a write of 'none'.
+  scope          public.access_scope not null,
+
+  updated_at     timestamptz not null default now(),
+  primary key (staff_id, permission_key)
+);
+
+create index staff_permissions_permission_key_idx
+  on public.staff_permissions (permission_key);
+
+create trigger staff_permissions_set_updated_at
+  before update on public.staff_permissions
+  for each row execute function private.set_updated_at();
+
+comment on table public.staff_permissions is
+  'Layer 3 of the permission cascade: an override on the PERSON. Keyed on the staff record rather than the membership so it survives a hire with no account yet, and an access revoke/re-grant.';
+
+alter table public.staff_permissions enable row level security;
+
+-- Visible to anyone who can already see the staff row. Knowing that a groomer
+-- has an extra permission is not the sensitive part; changing it is.
+create policy staff_permissions_read on public.staff_permissions
+  for select to authenticated
+  using (
+    private.is_platform_admin()
+    or exists (
+      select 1 from public.staff s
+       where s.id = staff_permissions.staff_id
+         and (s.id in (select private.own_staff_ids())
+              or s.facility_id in (select private.member_facility_ids()))
+    )
+  );
+
+create policy staff_permissions_insert on public.staff_permissions
+  for insert to authenticated
+  with check (exists (
+    select 1 from public.staff s
+     where s.id = staff_permissions.staff_id
+       and private.has_permission(s.facility_id, 'manage_roles')));
+create policy staff_permissions_update on public.staff_permissions
+  for update to authenticated
+  using (exists (
+    select 1 from public.staff s
+     where s.id = staff_permissions.staff_id
+       and private.has_permission(s.facility_id, 'manage_roles')))
+  with check (exists (
+    select 1 from public.staff s
+     where s.id = staff_permissions.staff_id
+       and private.has_permission(s.facility_id, 'manage_roles')));
+create policy staff_permissions_delete on public.staff_permissions
+  for delete to authenticated
+  using (exists (
+    select 1 from public.staff s
+     where s.id = staff_permissions.staff_id
+       and private.has_permission(s.facility_id, 'manage_roles')));
+
+-- ── 3. Resolution, matching the TypeScript ──────────────────────────────────
+-- Precedence, most specific first:
+--   account override  (membership_permissions)   — wins outright, incl. 'none'
+--   person override   (staff_permissions)        — wins outright, incl. 'none'
+--   roles             — union of every role held, widest scope wins
+--
+-- The first two use coalesce, so a stored 'none' short-circuits and denies.
+-- The role layer filters 'none' out instead, because there a 'none' means
+-- "this role does not grant it" and another role still might.
+
+create or replace function private.resolve_permission(
+  p_membership_id uuid,
+  p_permission    text
+)
+returns public.access_scope
+language sql
+stable
+security definer
+set search_path = ''
+as $$
+  with m as (
+    select fm.id, fm.facility_id, fm.role
+      from public.facility_memberships fm
+     where fm.id = p_membership_id
+  ),
+  -- The person behind the account, if the staff record has been linked.
+  s as (
+    select st.id, st.primary_role, st.additional_roles
+      from public.staff st
+      join m on m.id = st.membership_id
+  ),
+  -- Every role this person carries. `m.role` is always present; the staff
+  -- record adds its own primary and any additional roles. UNION dedupes.
+  held_roles as (
+    select m.role as role from m
+     union
+    select s.primary_role from s
+     union
+    select unnest(s.additional_roles) from s
+  ),
+  -- Each role resolved through the facility's override, else the global preset.
+  role_scopes as (
+    select coalesce(
+             (select frp.scope
+                from public.facility_role_permissions frp
+               where frp.facility_id    = (select facility_id from m)
+                 and frp.role           = hr.role
+                 and frp.permission_key = p_permission),
+             (select rpp.scope
+                from public.role_preset_permissions rpp
+               where rpp.role           = hr.role
+                 and rpp.permission_key = p_permission)
+           ) as scope
+      from held_roles hr
+  )
+  select coalesce(
+    (select mp.scope
+       from public.membership_permissions mp
+      where mp.membership_id  = p_membership_id
+        and mp.permission_key = p_permission),
+    (select sp.scope
+       from public.staff_permissions sp
+       join s on s.id = sp.staff_id
+      where sp.permission_key = p_permission),
+    (select rs.scope
+       from role_scopes rs
+      where rs.scope is not null
+        and rs.scope <> 'none'::public.access_scope
+      order by case rs.scope
+                 when 'anytime'         then 3
+                 when 'operating_hours' then 2
+                 when 'assigned_shifts' then 1
+                 else 0
+               end desc
+      limit 1)
+  );
+$$;
+
+comment on function private.resolve_permission is
+  'Effective scope for one membership and one permission. Account override, then person override (both absolute, including a stored ''none''), then the widest scope across every role held. NULL means not granted. The SQL twin of resolvePermission() in src/types/facility-staff.ts.';
+
+grant execute on function private.resolve_permission(uuid, text) to authenticated;

--- a/tests/e2e/role-editor-writes.spec.ts
+++ b/tests/e2e/role-editor-writes.spec.ts
@@ -1,0 +1,246 @@
+import { test, expect, type Page } from "@playwright/test";
+
+// ============================================================================
+// The role editor edits what Postgres enforces.
+//
+// The regression this guards against is specific and was live until now: the
+// editor wrote to localStorage, so an owner could revoke a permission, see the
+// checkbox clear, and change nothing about what anyone was actually allowed to
+// do. A test that only asserted "the save succeeded" would have passed the
+// whole time.
+//
+// So each check below reads the OTHER person's resolved permission map after
+// the edit — the thing that has to move — rather than the editor's own state.
+//
+// Runs against the live Supabase project using the dev accounts. It writes
+// real override rows and removes them again; a failure mid-run can leave one
+// behind, which the first step clears.
+// ============================================================================
+
+const PASSWORD = "YipyyDev!2026";
+
+type PermissionMap = Record<string, string>;
+
+async function signIn(page: Page, email: string) {
+  await page.goto("/login");
+  await page.fill("#email", email);
+  await page.fill("#password", PASSWORD);
+  await page.getByRole("button", { name: /sign in/i }).click();
+  // The landing path differs per role and some portals redirect again; wait for
+  // the session cookie to be usable rather than for any particular URL.
+  await expect
+    .poll(async () => (await page.request.get("/api/permissions")).status(), {
+      timeout: 30_000,
+    })
+    .toBe(200);
+}
+
+async function signOut(page: Page) {
+  await page.context().clearCookies();
+}
+
+const permissions = async (page: Page): Promise<PermissionMap> => {
+  const response = await page.request.get("/api/permissions");
+  expect(response.status()).toBe(200);
+  return (await response.json()) as PermissionMap;
+};
+
+const setOverride = (page: Page, body: unknown) =>
+  page.request.put("/api/roles/overrides", { data: body });
+
+test.describe.configure({ mode: "serial" });
+
+test.describe("role editor writes", () => {
+  test("owner's edit to a role changes what a groomer may do", async ({
+    page,
+  }) => {
+    await signIn(page, "owner@yipyy.dev");
+
+    // Clear anything a previous failed run left behind.
+    await setOverride(page, {
+      kind: "facility-role",
+      role: "groomer",
+      key: "manage_staff",
+      scope: null,
+    });
+
+    await signOut(page);
+    await signIn(page, "groomer@yipyy.dev");
+    const before = await permissions(page);
+    expect(before.manage_staff).toBe("none");
+    // Baseline worth pinning: a groomer's booking access is SCOPED, not a
+    // boolean. If this ever reads "anytime" the cascade has been flattened.
+    expect(before.view_bookings).toBe("assigned_shifts");
+
+    await signOut(page);
+    await signIn(page, "owner@yipyy.dev");
+    const granted = await setOverride(page, {
+      kind: "facility-role",
+      role: "groomer",
+      key: "manage_staff",
+      scope: "anytime",
+    });
+    expect(granted.status()).toBe(200);
+
+    // The assertion that matters: a DIFFERENT account's resolved map moved.
+    await signOut(page);
+    await signIn(page, "groomer@yipyy.dev");
+    expect((await permissions(page)).manage_staff).toBe("anytime");
+
+    // And a revoke removes something the preset grants.
+    await signOut(page);
+    await signIn(page, "owner@yipyy.dev");
+    await setOverride(page, {
+      kind: "facility-role",
+      role: "groomer",
+      key: "view_bookings",
+      scope: "revoked",
+    });
+
+    await signOut(page);
+    await signIn(page, "groomer@yipyy.dev");
+    const after = await permissions(page);
+    expect(after.view_bookings).toBe("none");
+    // The reception preset is untouched — an override is per role, not global.
+    await signOut(page);
+    await signIn(page, "reception@yipyy.dev");
+    expect((await permissions(page)).view_bookings).not.toBe("none");
+  });
+
+  test("clearing an override restores the preset", async ({ page }) => {
+    await signIn(page, "owner@yipyy.dev");
+    for (const key of ["manage_staff", "view_bookings"]) {
+      const cleared = await setOverride(page, {
+        kind: "facility-role",
+        role: "groomer",
+        key,
+        scope: null,
+      });
+      expect(cleared.status()).toBe(200);
+    }
+
+    await signOut(page);
+    await signIn(page, "groomer@yipyy.dev");
+    const restored = await permissions(page);
+    // Back to the global preset, not to "denied" — clearing must inherit, and
+    // writing 'none' where the UI meant "reset" is the easy way to get this
+    // wrong.
+    expect(restored.view_bookings).toBe("assigned_shifts");
+    expect(restored.manage_staff).toBe("none");
+  });
+
+  test("a manager cannot edit roles", async ({ page }) => {
+    // manager holds manage_staff but NOT manage_roles. Before this change the
+    // policy gated on scheduling_view_all, which a manager (and a supervisor)
+    // does hold — so this request would have succeeded.
+    await signIn(page, "manager@yipyy.dev");
+    const refused = await setOverride(page, {
+      kind: "facility-role",
+      role: "groomer",
+      key: "manage_staff",
+      scope: "anytime",
+    });
+    expect(refused.status()).toBe(403);
+
+    // And the refusal is real, not just a status: the groomer is unchanged.
+    await signOut(page);
+    await signIn(page, "groomer@yipyy.dev");
+    expect((await permissions(page)).manage_staff).toBe("none");
+  });
+
+  test("the editor UI itself reaches Postgres", async ({ page }) => {
+    // The three checks above prove the route. This one proves the control is
+    // wired to it — which is the actual bug: every one of these dropdowns has
+    // been changing a localStorage blob and nothing else.
+    await signIn(page, "owner@yipyy.dev");
+    await page.goto("/facility/dashboard/settings?section=roles-permissions");
+
+    // Role cards read "Trainer / 2 staff / Preset".
+    await page
+      .getByRole("button", { name: /^Trainer\b/ })
+      .first()
+      .click();
+
+    const label = page.getByText("Manage staff", { exact: true }).first();
+    await label.scrollIntoViewIfNeeded();
+    const control = label
+      .locator(
+        "xpath=ancestor::div[button[@role='combobox']][1]//button[@role='combobox']",
+      )
+      .first();
+    await expect(control).toContainText("Not granted");
+
+    await control.click();
+    await page
+      .getByRole("option", { name: /^Anytime/ })
+      .first()
+      .click();
+
+    // Editing a preset role asks once before applying.
+    await page.getByRole("button", { name: /change defaults/i }).click();
+
+    // The assertion: a row now exists in facility_role_permissions. Read it
+    // back through the API rather than trusting the control's own appearance —
+    // looking right is exactly what it did before.
+    await expect
+      .poll(
+        async () => {
+          const body = (await (
+            await page.request.get("/api/roles/overrides")
+          ).json()) as {
+            facilityRoles: Record<string, Record<string, string>>;
+          };
+          return body.facilityRoles.trainer?.manage_staff;
+        },
+        { timeout: 15_000 },
+      )
+      .toBe("anytime");
+
+    // Clean up so the suite is re-runnable.
+    await setOverride(page, {
+      kind: "facility-role",
+      role: "trainer",
+      key: "manage_staff",
+      scope: null,
+    });
+  });
+
+  test("a per-staff override is stored against the person", async ({
+    page,
+  }) => {
+    await signIn(page, "owner@yipyy.dev");
+
+    const set = await setOverride(page, {
+      kind: "staff",
+      staffId: "fs-groom-01",
+      key: "manage_roles",
+      setting: { granted: true, scope: "anytime" },
+    });
+    // fs-groom-01 has no account yet — the point of keying layer 3 on the
+    // staff record is that the override can still be written and stored now.
+    expect(set.status()).toBe(200);
+
+    const read = await page.request.get("/api/roles/overrides");
+    const body = (await read.json()) as {
+      staff: Record<string, Record<string, unknown>>;
+    };
+    expect(body.staff["fs-groom-01"]?.manage_roles).toEqual({
+      granted: true,
+      scope: "anytime",
+    });
+
+    const cleared = await setOverride(page, {
+      kind: "staff",
+      staffId: "fs-groom-01",
+      key: "manage_roles",
+      setting: null,
+    });
+    expect(cleared.status()).toBe(200);
+
+    const readAgain = await page.request.get("/api/roles/overrides");
+    const bodyAgain = (await readAgain.json()) as {
+      staff: Record<string, unknown>;
+    };
+    expect(bodyAgain.staff["fs-groom-01"]).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## The bug

The three-layer permission cascade has existed since the tenancy migration, but only layer 1 — the global role presets — ever had rows. `facility_role_permissions` and `membership_permissions` were created, indexed and RLS'd, then left empty, because nothing could write to them.

Meanwhile the roles studio let a facility owner change what a role may do and told them it had saved. It had: to `localStorage`. Since #99 made the database answer `my_permissions()`, that edit was not merely private to one browser — it was **discarded on the next load**. Every dropdown in the editor was a control that did nothing, and looked exactly like one that did.

## What changed

Two layers are now writable through `PUT /api/roles/overrides`, authorised by RLS rather than by the route:

| kind | table | means |
| --- | --- | --- |
| `facility-role` | `facility_role_permissions` | "what Groomer means **here**" |
| `staff` | `staff_permissions` | "except for **this person**" |

The reset paths write through too. Clearing an override only in local state would leave the row in Postgres still in force — the same lie behind a different button.

## Three things surfaced on the way

**A live privilege escalation.** Every write policy on the permission tables gated on `scheduling_view_all` — *"View all staff schedules"* — while the comment directly above them said *"written only by someone holding the staff-management permission"*. A placeholder nobody replaced. `supervisor` holds `scheduling_view_all`, so **any supervisor could rewrite their facility's permission table and grant themselves anything**, `manage_roles` included. These now gate on `manage_roles` (owner and admin only); membership writes gate on `manage_staff`.

**Layer 3 had nowhere to live.** `membership_permissions` keys on a membership — an *account* — and 0 of the 18 staff records have one, because a staff record is created at hire and a membership only when the invite is accepted. The override could not be written until the person signed in, and would be destroyed if their access were revoked and re-granted. `staff_permissions` keys on the durable HR record instead, which is what `StaffProfile.permissionOverrides` has always meant. `membership_permissions` is kept above it for overrides belonging to the login rather than the person.

**The cascade only ever read one role.** `resolvePermission()` in TypeScript unions across `primaryRole` and `additionalRoles`, widest scope winning; the SQL read `facility_memberships.role`, singular — so a groomer who is also a supervisor resolved as a groomer alone. `private.resolve_permission` now unions the same way. That makes a facility-layer revoke non-absolute, exactly as the TypeScript has it: revoking for Groomer removes the groomer's claim, but Supervisor may still grant it. A revoke that must bind regardless is a per-staff override, the layer above.

## Verification

Against the live project. Each check reads **the other account's** resolved map after the edit, not the editor's own state — asserting "the save succeeded" would have passed for as long as this bug existed.

```
owner grants manage_staff to Groomer  ->  groomer resolves anytime
owner revokes view_bookings           ->  groomer none, reception untouched
owner clears both                     ->  back to assigned_shifts, not denied
manager attempts the same write       ->  403, and the groomer is unchanged
the studio's own dropdown             ->  row lands in facility_role_permissions
per-staff override for fs-groom-01    ->  stored, though they have no account
```

All six are committed as `tests/e2e/role-editor-writes.spec.ts` (5 tests, all passing). SQL-level checks confirmed the union and precedence separately, and the probe rows were removed.

Two tests in `staff-portal-nav.spec.ts` fail — **confirmed pre-existing**, reproduced on a stashed tree without these changes.

## Not in scope

Custom roles remain browser-local. They have no home in the schema: `facility_role_permissions.role` is the `facility_staff_role` enum and memberships carry one enum value. Giving them a real one means a table, a join table and a fourth branch in the union — and it needs a product answer first: are they roles, or saved bundles of per-staff overrides?
