### PR TITLE
feat(rbac): custom roles become real

### DIFF
--- a/src/app/api/roles/custom/route.ts
+++ b/src/app/api/roles/custom/route.ts
@@ -1,0 +1,332 @@
+import { NextResponse, type NextRequest } from "next/server";
+import type { PostgrestError } from "@supabase/supabase-js";
+
+import { createServerClient, getCurrentUser } from "@/lib/supabase/server";
+import type {
+  AccessScope,
+  CustomFacilityRole,
+  CustomRolesById,
+  PermissionKey,
+} from "@/types/facility-staff";
+
+// ============================================================================
+// Custom roles — the facility's own roles, and who holds them.
+//
+// The last part of the role editor that was browser-local. A facility could
+// invent "Senior Groomer", give it permissions and assign it to three people,
+// and none of it left localStorage.
+//
+// The shape here follows what the client already believes: a role is
+// identified by its client-minted id ("custom-mabc123-xy9z"), carried as
+// `legacy_id`, and carries a flat permission map. Assignment is a separate
+// verb because it is a different question — "what does this role mean" versus
+// "who is in it" — and the two are edited on different screens.
+//
+// Authorisation is `manage_roles`, enforced by RLS on all three tables.
+// ============================================================================
+
+export const dynamic = "force-dynamic";
+
+export type CustomRoleWrite =
+  | { kind: "upsert"; role: CustomFacilityRole }
+  | { kind: "delete"; id: string }
+  | {
+      kind: "permission";
+      id: string;
+      key: PermissionKey;
+      /** `null` removes the grant — a custom role's map holds only grants. */
+      scope: AccessScope | null;
+    }
+  | {
+      kind: "assignments";
+      /** Staff legacy id, e.g. "fs-groom-01". */
+      staffId: string;
+      /** The complete set the person should hold; replaces what is stored. */
+      roleIds: string[];
+    };
+
+const unauthorised = () =>
+  NextResponse.json({ error: "Not signed in." }, { status: 401 });
+
+const denied = () =>
+  NextResponse.json(
+    { error: "You do not have permission to edit roles here." },
+    { status: 403 },
+  );
+
+const ok = () => NextResponse.json({ ok: true });
+
+function failure(error: PostgrestError): NextResponse {
+  if (error.code === "42501") return denied();
+  return NextResponse.json(
+    { error: error.message },
+    { status: error.code === "23503" ? 400 : 500 },
+  );
+}
+
+// ── Read ────────────────────────────────────────────────────────────────────
+
+export type CustomRolesResponse = {
+  roles: CustomRolesById;
+  /**
+   * Staff legacy id -> the custom role ids they hold.
+   *
+   * `null` means "not known" — the signed-out fallback, where staff rows are
+   * unreadable. That is NOT the same as an empty map, which means "known, and
+   * nobody holds one"; conflating them would blank every assignment the mock
+   * profiles carry the moment a browser had no session.
+   */
+  assignments: Record<string, string[]> | null;
+};
+
+export async function GET() {
+  const user = await getCurrentUser().catch(() => null);
+  if (!user) return unauthorised();
+
+  const supabase = await createServerClient();
+
+  const [roleRows, permRows, assignRows] = await Promise.all([
+    supabase
+      .from("facility_custom_roles")
+      .select(
+        "id, legacy_id, label, description, accent, ring, icon, created_at",
+      )
+      .order("created_at"),
+    supabase
+      .from("facility_custom_role_permissions")
+      .select("custom_role_id, permission_key, scope"),
+    supabase
+      .from("staff_custom_roles")
+      .select("staff:staff_id (legacy_id), role:custom_role_id (legacy_id)"),
+  ]);
+
+  const error = roleRows.error ?? permRows.error ?? assignRows.error;
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  // uuid -> legacy id, so permissions can be hung off the id the client uses.
+  const legacyById = new Map<string, string>();
+  const roles: CustomRolesById = {};
+  for (const row of roleRows.data ?? []) {
+    if (!row.legacy_id) continue;
+    legacyById.set(row.id, row.legacy_id);
+    roles[row.legacy_id] = {
+      id: row.legacy_id,
+      label: row.label,
+      description: row.description,
+      accent: row.accent,
+      ring: row.ring,
+      icon: row.icon,
+      permissions: {},
+      createdAt: row.created_at,
+    };
+  }
+
+  for (const row of permRows.data ?? []) {
+    const legacyId = legacyById.get(row.custom_role_id);
+    if (!legacyId) continue;
+    roles[legacyId]!.permissions[row.permission_key as PermissionKey] =
+      row.scope;
+  }
+
+  const assignments: Record<string, string[]> = {};
+  for (const row of assignRows.data ?? []) {
+    const staffId = row.staff?.legacy_id;
+    const roleId = row.role?.legacy_id;
+    if (!staffId || !roleId) continue;
+    (assignments[staffId] ??= []).push(roleId);
+  }
+
+  return NextResponse.json({
+    roles,
+    assignments,
+  } satisfies CustomRolesResponse);
+}
+
+// ── Write ───────────────────────────────────────────────────────────────────
+
+export async function PUT(request: NextRequest) {
+  const user = await getCurrentUser().catch(() => null);
+  if (!user) return unauthorised();
+
+  const body = (await request.json()) as CustomRoleWrite;
+  const supabase = await createServerClient();
+
+  /** The uuid behind a client-minted role id. */
+  async function roleUuid(legacyId: string): Promise<string | null> {
+    const { data } = await supabase
+      .from("facility_custom_roles")
+      .select("id")
+      .eq("legacy_id", legacyId)
+      .maybeSingle();
+    return data?.id ?? null;
+  }
+
+  if (body.kind === "upsert") {
+    const { data: membership } = await supabase
+      .from("facility_memberships")
+      .select("facility_id")
+      .eq("is_active", true)
+      .order("created_at")
+      .limit(1)
+      .maybeSingle();
+
+    if (!membership) {
+      return NextResponse.json(
+        { error: "You do not belong to a facility." },
+        { status: 403 },
+      );
+    }
+
+    const { role } = body;
+    const { error } = await supabase.from("facility_custom_roles").upsert(
+      {
+        facility_id: membership.facility_id,
+        legacy_id: role.id,
+        label: role.label,
+        description: role.description,
+        accent: role.accent,
+        ring: role.ring,
+        icon: role.icon,
+      },
+      { onConflict: "legacy_id" },
+    );
+    if (error) return failure(error);
+
+    // A newly created role usually arrives with its permission map already
+    // populated (the studio's Duplicate button copies a preset wholesale), so
+    // write those too rather than making the client replay them one by one.
+    const entries = Object.entries(role.permissions);
+    if (entries.length > 0) {
+      const id = await roleUuid(role.id);
+      if (id) {
+        const { error: permError } = await supabase
+          .from("facility_custom_role_permissions")
+          .upsert(
+            entries.map(([key, scope]) => ({
+              custom_role_id: id,
+              permission_key: key,
+              scope: scope as AccessScope,
+            })),
+          );
+        if (permError) return failure(permError);
+      }
+    }
+    return ok();
+  }
+
+  if (body.kind === "delete") {
+    const { error } = await supabase
+      .from("facility_custom_roles")
+      .delete()
+      .eq("legacy_id", body.id);
+    if (error) return failure(error);
+
+    // A refused DELETE matches zero rows rather than failing, so the only way
+    // to tell "denied" from "already gone" is to look for the row again.
+    const { data: survivor } = await supabase
+      .from("facility_custom_roles")
+      .select("id")
+      .eq("legacy_id", body.id)
+      .maybeSingle();
+    return survivor ? denied() : ok();
+  }
+
+  if (body.kind === "permission") {
+    const id = await roleUuid(body.id);
+    if (!id) {
+      return NextResponse.json({ error: "No such role." }, { status: 404 });
+    }
+
+    if (body.scope === null) {
+      const match = { custom_role_id: id, permission_key: body.key };
+      const { error } = await supabase
+        .from("facility_custom_role_permissions")
+        .delete()
+        .match(match);
+      if (error) return failure(error);
+
+      const { data: survivor } = await supabase
+        .from("facility_custom_role_permissions")
+        .select("permission_key")
+        .match(match)
+        .maybeSingle();
+      return survivor ? denied() : ok();
+    }
+
+    const { error } = await supabase
+      .from("facility_custom_role_permissions")
+      .upsert({
+        custom_role_id: id,
+        permission_key: body.key,
+        scope: body.scope,
+      });
+    return error ? failure(error) : ok();
+  }
+
+  if (body.kind === "assignments") {
+    const { data: staffRow } = await supabase
+      .from("staff")
+      .select("id")
+      .eq("legacy_id", body.staffId)
+      .maybeSingle();
+
+    if (!staffRow) {
+      return NextResponse.json(
+        { error: `No staff record for "${body.staffId}".` },
+        { status: 404 },
+      );
+    }
+
+    const { data: roleRows } = await supabase
+      .from("facility_custom_roles")
+      .select("id, legacy_id")
+      .in("legacy_id", body.roleIds.length > 0 ? body.roleIds : ["__none__"]);
+
+    const wanted = new Set((roleRows ?? []).map((r) => r.id));
+
+    // Replace the set: remove what is no longer held, add what is new. Doing
+    // it as a diff rather than delete-all-then-insert keeps the table stable
+    // when nothing changed, and means a refused write cannot leave the person
+    // holding nothing.
+    const { data: current } = await supabase
+      .from("staff_custom_roles")
+      .select("custom_role_id")
+      .eq("staff_id", staffRow.id);
+
+    const held = new Set((current ?? []).map((r) => r.custom_role_id));
+    const toAdd = [...wanted].filter((id) => !held.has(id));
+    const toRemove = [...held].filter((id) => !wanted.has(id));
+
+    if (toAdd.length > 0) {
+      const { error } = await supabase.from("staff_custom_roles").insert(
+        toAdd.map((custom_role_id) => ({
+          staff_id: staffRow.id,
+          custom_role_id,
+        })),
+      );
+      if (error) return failure(error);
+    }
+
+    if (toRemove.length > 0) {
+      const { error } = await supabase
+        .from("staff_custom_roles")
+        .delete()
+        .eq("staff_id", staffRow.id)
+        .in("custom_role_id", toRemove);
+      if (error) return failure(error);
+
+      const { data: survivors } = await supabase
+        .from("staff_custom_roles")
+        .select("custom_role_id")
+        .eq("staff_id", staffRow.id)
+        .in("custom_role_id", toRemove);
+      if (survivors && survivors.length > 0) return denied();
+    }
+
+    return ok();
+  }
+
+  return NextResponse.json({ error: "Unknown write kind." }, { status: 400 });
+}

--- a/src/app/facility/dashboard/staff/[id]/staff-profile-view.tsx
+++ b/src/app/facility/dashboard/staff/[id]/staff-profile-view.tsx
@@ -18,6 +18,7 @@ import {
   Save,
 } from "lucide-react";
 import { FacilityRbacProvider, usePermission } from "@/hooks/use-facility-rbac";
+import { useSetStaffCustomRoles } from "@/lib/api/roles";
 import {
   ROLE_PRESETS,
   buildDefaultNotifications,
@@ -151,6 +152,8 @@ function StaffProfileInner({ staffId }: { staffId: string }) {
     staff ? { ...staff } : null,
   );
 
+  const { mutate: setStaffCustomRoles } = useSetStaffCustomRoles();
+
   // Onboarding review/activation (derived pending-review state).
   const onboardingInstance = useOnboardingInstance(staffId);
   const pendingReview =
@@ -231,6 +234,14 @@ function StaffProfileInner({ staffId }: { staffId: string }) {
   const saveProfile = () => {
     if (!draft) return;
     upsertFacilityStaff(draft);
+    // Custom-role assignments are the one part of this profile that the
+    // database already owns — they feed private.resolve_permission. Saving
+    // them only into the mock array would mean the roles shown here and the
+    // permissions actually enforced disagree.
+    setStaffCustomRoles({
+      staffId: draft.id,
+      roleIds: draft.customRoleIds ?? [],
+    });
     bumpProfile();
     toast.success(`${fullNameOf(draft)}'s profile updated`);
   };

--- a/src/hooks/use-facility-rbac.tsx
+++ b/src/hooks/use-facility-rbac.tsx
@@ -164,7 +164,8 @@ export function FacilityRbacProvider({
   // Custom roles are read through the roles query layer; their writes go through
   // the mutations below. viewerId stays local to this provider.
   const { data: customRolesData } = useQuery(roleQueries.customRoles());
-  const customRoles = customRolesData ?? EMPTY_CUSTOM_ROLES;
+  const customRoles = customRolesData?.roles ?? EMPTY_CUSTOM_ROLES;
+  const customAssignments = customRolesData?.assignments;
 
   // The two DB-backed layers of the cascade. `undefined` while loading and
   // `null` when signed out; in both cases the local state below is what the UI
@@ -254,12 +255,20 @@ export function FacilityRbacProvider({
 
   // Overlay the provider's per-staff overrides onto the profile before resolving
   // so guards/sidebar/masks reflect per-staff edits, not just the baked seed.
+  //
+  // Custom-role assignments are overlaid the same way and for the same reason:
+  // once the database has answered, staff_custom_roles is who actually holds a
+  // role. The mock profile's own customRoleIds is a seed, and showing it while
+  // Postgres says otherwise is the bug this whole change is about.
   const withOverrides = useCallback(
     (staff: StaffProfile): StaffProfile => ({
       ...staff,
       permissionOverrides: staffOverridesFor(staff.id),
+      customRoleIds: customAssignments
+        ? (customAssignments[staff.id] ?? [])
+        : staff.customRoleIds,
     }),
-    [staffOverridesFor],
+    [staffOverridesFor, customAssignments],
   );
 
   const resolveFor = useCallback(

--- a/src/lib/api/live-fetch.ts
+++ b/src/lib/api/live-fetch.ts
@@ -40,6 +40,37 @@ export async function liveFetch<T>(
   return (await response.json()) as T;
 }
 
+/**
+ * A write that is genuinely optional because there is nowhere to send it:
+ * signed out, there is no session and no rows to own. Returns `null` on 401
+ * and behaves exactly like `liveWrite` otherwise — a real failure still
+ * throws.
+ *
+ * Only for state that also has a local home (the role editor's localStorage
+ * fallback). Never for a write whose whole purpose is to persist.
+ */
+export async function liveWriteOptional<T>(
+  path: string,
+  method: "POST" | "PATCH" | "PUT",
+  body: unknown,
+): Promise<T | null> {
+  const response = await fetch(path, {
+    method,
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+
+  if (response.status === 401) return null;
+  if (!response.ok) {
+    const detail = await response
+      .json()
+      .then((b: { error?: string }) => b.error)
+      .catch(() => null);
+    throw new Error(detail ?? `Request failed (${response.status})`);
+  }
+  return (await response.json()) as T;
+}
+
 /** Write helper — no fallback, because a write must never silently no-op. */
 export async function liveWrite<T>(
   path: string,

--- a/src/lib/api/roles.ts
+++ b/src/lib/api/roles.ts
@@ -6,12 +6,16 @@ import {
   type QueryClient,
 } from "@tanstack/react-query";
 import { facilityRolesStore } from "@/lib/facility-roles-store";
-import { liveWrite } from "@/lib/api/live-fetch";
+import { liveWriteOptional } from "@/lib/api/live-fetch";
 import { permissionQueries } from "@/hooks/use-db-permissions";
 import type {
   RoleOverrides,
   RoleOverrideWrite,
 } from "@/app/api/roles/overrides/route";
+import type {
+  CustomRolesResponse,
+  CustomRoleWrite,
+} from "@/app/api/roles/custom/route";
 import type {
   AccessScope,
   CustomFacilityRole,
@@ -21,15 +25,18 @@ import type {
   PermissionSetting,
 } from "@/types/facility-staff";
 
-// Roles domain query layer. Facility custom roles are read through
-// `roleQueries.customRoles()` and written through the mutation hooks below, so
-// the TanStack Query cache is the single source of truth. The underlying
-// persistence lives in @/lib/facility-roles-store (the mock "backend").
+// Roles domain query layer. Every layer of the cascade is read and written
+// through here, so the TanStack Query cache is the single source of truth for
+// the UI and Postgres is the single source of truth for enforcement.
 //
-// The two DB-backed layers are separate: `roleQueries.overrides()` reads what
-// Postgres will actually enforce, and the override mutations write it. Custom
-// roles are still browser-local — they have no home in the schema yet, because
-// facility_role_permissions.role is an enum. See the migration for why.
+//   roleQueries.overrides()    facility_role_permissions + staff_permissions
+//   roleQueries.customRoles()  facility_custom_roles + their permissions and
+//                              assignments
+//
+// @/lib/facility-roles-store (localStorage) survives as the SIGNED-OUT
+// fallback only. Most of the app is still browsed without a session until
+// AUTH_ENFORCED flips, and an editor that blanked itself would read as a bug
+// rather than a sign-in prompt.
 
 export const roleKeys = {
   all: ["facility-roles"] as const,
@@ -47,10 +54,25 @@ async function fetchOverrides(): Promise<RoleOverrides | null> {
   return (await response.json()) as RoleOverrides;
 }
 
+async function fetchCustomRoles(): Promise<CustomRolesResponse> {
+  const response = await fetch("/api/roles/custom");
+  // Signed out: the browser's own roles, and assignments UNKNOWN — they live
+  // on staff rows, which need a session to read. `null` rather than `{}` so
+  // the caller keeps each profile's seeded assignments instead of concluding
+  // that nobody holds anything.
+  if (response.status === 401) {
+    return { roles: facilityRolesStore.getAll(), assignments: null };
+  }
+  if (!response.ok) {
+    throw new Error(`Failed to load custom roles (${response.status})`);
+  }
+  return (await response.json()) as CustomRolesResponse;
+}
+
 export const roleQueries = {
   customRoles: () => ({
     queryKey: roleKeys.custom(),
-    queryFn: async (): Promise<CustomRolesById> => facilityRolesStore.getAll(),
+    queryFn: fetchCustomRoles,
   }),
   /** What the database will enforce, as opposed to what this browser remembers. */
   overrides: () => ({
@@ -60,18 +82,40 @@ export const roleQueries = {
   }),
 };
 
+// Only used as the seed for an optimistic patch that lands before the first
+// fetch. `assignments: null` keeps the "not known" meaning intact.
+const EMPTY_CUSTOM: CustomRolesResponse = { roles: {}, assignments: null };
+
 /** Optimistically patch the cached custom-role map so the UI stays instant. */
 function patchCache(
   queryClient: QueryClient,
   updater: (prev: CustomRolesById) => CustomRolesById,
 ): void {
-  queryClient.setQueryData<CustomRolesById>(roleKeys.custom(), (prev) =>
-    updater(prev ?? {}),
+  queryClient.setQueryData<CustomRolesResponse>(
+    roleKeys.custom(),
+    (prev = EMPTY_CUSTOM) => ({ ...prev, roles: updater(prev.roles) }),
   );
 }
 
+/**
+ * Custom-role edits go to Postgres AND to the localStorage store. The store is
+ * what a signed-out browser reads back; the database is what RLS enforces and
+ * what every other browser will see. `liveWriteOptional` is what makes the
+ * signed-out case a no-op rather than a thrown error.
+ */
+function write(body: CustomRoleWrite) {
+  return liveWriteOptional<{ ok: true }>("/api/roles/custom", "PUT", body);
+}
+
 function invalidate(queryClient: QueryClient) {
-  return queryClient.invalidateQueries({ queryKey: roleKeys.custom() });
+  // A custom role's permissions feed the cascade, so the viewer's own resolved
+  // map can move when one changes.
+  return Promise.all([
+    queryClient.invalidateQueries({ queryKey: roleKeys.custom() }),
+    queryClient.invalidateQueries({
+      queryKey: permissionQueries.mine().queryKey,
+    }),
+  ]);
 }
 
 export type UpdateCustomRoleVars = {
@@ -90,8 +134,10 @@ export type SetCustomRolePermissionVars = {
 export function useCreateCustomRole() {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: async (role: CustomFacilityRole) =>
-      facilityRolesStore.put(role),
+    mutationFn: async (role: CustomFacilityRole) => {
+      await write({ kind: "upsert", role });
+      return facilityRolesStore.put(role);
+    },
     onMutate: (role) => {
       patchCache(queryClient, (prev) => ({ ...prev, [role.id]: role }));
     },
@@ -102,8 +148,14 @@ export function useCreateCustomRole() {
 export function useUpdateCustomRole() {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: async ({ id, patch }: UpdateCustomRoleVars) =>
-      facilityRolesStore.update(id, patch),
+    mutationFn: async ({ id, patch }: UpdateCustomRoleVars) => {
+      const next = facilityRolesStore.update(id, patch);
+      // The route upserts a whole role, so send the merged result rather than
+      // the patch — a partial upsert would blank the fields left out.
+      const merged = next[id];
+      if (merged) await write({ kind: "upsert", role: merged });
+      return next;
+    },
     onMutate: ({ id, patch }) => {
       patchCache(queryClient, (prev) => {
         const existing = prev[id];
@@ -121,7 +173,10 @@ export function useUpdateCustomRole() {
 export function useDeleteCustomRole() {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: async (id: string) => facilityRolesStore.remove(id),
+    mutationFn: async (id: string) => {
+      await write({ kind: "delete", id });
+      return facilityRolesStore.remove(id);
+    },
     onMutate: (id) => {
       patchCache(queryClient, (prev) => {
         if (!(id in prev)) return prev;
@@ -129,6 +184,28 @@ export function useDeleteCustomRole() {
         return rest;
       });
     },
+    onSettled: () => invalidate(queryClient),
+  });
+}
+
+export type SetStaffCustomRolesVars = {
+  /** Staff legacy id, e.g. "fs-groom-01". */
+  staffId: string;
+  /** The complete set the person should hold. */
+  roleIds: string[];
+};
+
+/**
+ * Who holds a custom role. Separate from the role's definition because it is a
+ * different question edited on a different screen — the staff profile, not the
+ * roles studio — and because the assignment is what actually moves someone's
+ * permissions.
+ */
+export function useSetStaffCustomRoles() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ staffId, roleIds }: SetStaffCustomRolesVars) =>
+      write({ kind: "assignments", staffId, roleIds }),
     onSettled: () => invalidate(queryClient),
   });
 }
@@ -171,7 +248,7 @@ export function useSetFacilityRolePermission() {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: async (vars: SetFacilityRolePermissionVars) =>
-      liveWrite<{ ok: true }>("/api/roles/overrides", "PUT", {
+      liveWriteOptional<{ ok: true }>("/api/roles/overrides", "PUT", {
         kind: "facility-role",
         ...vars,
       } satisfies RoleOverrideWrite),
@@ -206,7 +283,7 @@ export function useSetStaffPermission() {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: async (vars: SetStaffPermissionVars) =>
-      liveWrite<{ ok: true }>("/api/roles/overrides", "PUT", {
+      liveWriteOptional<{ ok: true }>("/api/roles/overrides", "PUT", {
         kind: "staff",
         ...vars,
       } satisfies RoleOverrideWrite),
@@ -228,8 +305,10 @@ export function useSetStaffPermission() {
 export function useSetCustomRolePermission() {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: async ({ id, key, scope }: SetCustomRolePermissionVars) =>
-      facilityRolesStore.setPermission(id, key, scope),
+    mutationFn: async ({ id, key, scope }: SetCustomRolePermissionVars) => {
+      await write({ kind: "permission", id, key, scope });
+      return facilityRolesStore.setPermission(id, key, scope);
+    },
     onMutate: ({ id, key, scope }) => {
       patchCache(queryClient, (prev) => {
         const role = prev[id];

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -471,6 +471,116 @@ export type Database = {
           },
         ];
       };
+      facility_custom_roles: {
+        Row: {
+          accent: string;
+          created_at: string;
+          description: string;
+          facility_id: string;
+          icon: string;
+          id: string;
+          label: string;
+          legacy_id: string | null;
+          ring: string;
+          updated_at: string;
+        };
+        Insert: {
+          accent?: string;
+          created_at?: string;
+          description?: string;
+          facility_id: string;
+          icon?: string;
+          id?: string;
+          label: string;
+          legacy_id?: string | null;
+          ring?: string;
+          updated_at?: string;
+        };
+        Update: {
+          accent?: string;
+          created_at?: string;
+          description?: string;
+          facility_id?: string;
+          icon?: string;
+          id?: string;
+          label?: string;
+          legacy_id?: string | null;
+          ring?: string;
+          updated_at?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "facility_custom_roles_facility_id_fkey";
+            columns: ["facility_id"];
+            isOneToOne: false;
+            referencedRelation: "facilities";
+            referencedColumns: ["id"];
+          },
+        ];
+      };
+      facility_custom_role_permissions: {
+        Row: {
+          custom_role_id: string;
+          permission_key: string;
+          scope: Database["public"]["Enums"]["access_scope"];
+        };
+        Insert: {
+          custom_role_id: string;
+          permission_key: string;
+          scope: Database["public"]["Enums"]["access_scope"];
+        };
+        Update: {
+          custom_role_id?: string;
+          permission_key?: string;
+          scope?: Database["public"]["Enums"]["access_scope"];
+        };
+        Relationships: [
+          {
+            foreignKeyName: "facility_custom_role_permissions_custom_role_id_fkey";
+            columns: ["custom_role_id"];
+            isOneToOne: false;
+            referencedRelation: "facility_custom_roles";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "facility_custom_role_permissions_permission_key_fkey";
+            columns: ["permission_key"];
+            isOneToOne: false;
+            referencedRelation: "permissions";
+            referencedColumns: ["key"];
+          },
+        ];
+      };
+      staff_custom_roles: {
+        Row: {
+          custom_role_id: string;
+          staff_id: string;
+        };
+        Insert: {
+          custom_role_id: string;
+          staff_id: string;
+        };
+        Update: {
+          custom_role_id?: string;
+          staff_id?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "staff_custom_roles_custom_role_id_fkey";
+            columns: ["custom_role_id"];
+            isOneToOne: false;
+            referencedRelation: "facility_custom_roles";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "staff_custom_roles_staff_id_fkey";
+            columns: ["staff_id"];
+            isOneToOne: false;
+            referencedRelation: "staff";
+            referencedColumns: ["id"];
+          },
+        ];
+      };
       locations: {
         Row: {
           created_at: string;

--- a/supabase/migrations/20260801180000_custom_roles.sql
+++ b/supabase/migrations/20260801180000_custom_roles.sql
@@ -1,0 +1,250 @@
+-- ============================================================================
+-- Custom roles.
+--
+-- The last part of the role editor that was still lying. A facility could
+-- invent "Senior Groomer", give it permissions, assign it to people — and all
+-- of it lived in one browser's localStorage.
+--
+-- ── Why this is cheaper than it looked ─────────────────────────────────────
+-- The open question was whether a custom role is a ROLE (and therefore needs
+-- to be something `facility_memberships.role` can point at, which is an enum
+-- and so would need widening or replacing) or a saved BUNDLE of per-staff
+-- overrides.
+--
+-- The code already answers it. `StaffProfile.customRoleIds` is an ARRAY,
+-- resolved by resolvePermission() in exactly the same union as
+-- `additionalRoles`: every role a person holds contributes, widest scope wins.
+-- No code path ever puts a custom role in `primaryRole`. So a custom role is
+-- additive — a named, reusable permission bundle attached to N staff — and it
+-- never needs to be an enum value. The enum problem was imaginary.
+--
+-- That makes it a real role in the only sense that matters (named, reusable,
+-- owns a permission set) at the cost of three ordinary tables.
+--
+-- ── Assignment hangs off staff, not membership ─────────────────────────────
+-- Same reasoning as staff_permissions in the previous migration: 0 of 18 staff
+-- have an account, and a custom role assigned at hire has to survive until
+-- they do.
+--
+-- ── legacy_id ──────────────────────────────────────────────────────────────
+-- Custom role ids are minted client-side as "custom-<base36>-<rand>" and are
+-- referenced across the staff editor, the role studio and the admin roles
+-- page. Keeping them means those files keep working unchanged.
+-- ============================================================================
+
+create table public.facility_custom_roles (
+  id          uuid primary key default gen_random_uuid(),
+  facility_id uuid not null references public.facilities (id) on delete cascade,
+
+  /** The client-minted id, e.g. "custom-mabc123-xy9z". */
+  legacy_id   text unique,
+
+  label       text not null,
+  description text not null default '',
+
+  -- Presentation, carried so a role looks the same in every browser rather
+  -- than only the one that created it.
+  accent      text not null default '',
+  ring        text not null default '',
+  icon        text not null default '',
+
+  created_at  timestamptz not null default now(),
+  updated_at  timestamptz not null default now()
+);
+
+-- Deliberately no unique constraint on (facility_id, label): the studio's
+-- Duplicate button mints "Groomer (Copy)", and duplicating twice would then
+-- fail on a name collision rather than doing the obvious thing.
+create index facility_custom_roles_facility_idx
+  on public.facility_custom_roles (facility_id);
+
+create trigger facility_custom_roles_set_updated_at
+  before update on public.facility_custom_roles
+  for each row execute function private.set_updated_at();
+
+create table public.facility_custom_role_permissions (
+  custom_role_id uuid not null references public.facility_custom_roles (id) on delete cascade,
+  permission_key text not null references public.permissions (key) on delete cascade,
+  scope          public.access_scope not null,
+  primary key (custom_role_id, permission_key)
+);
+
+create index facility_custom_role_permissions_key_idx
+  on public.facility_custom_role_permissions (permission_key);
+
+-- Who holds the role. A plain join table: a person may hold several, and a
+-- role may be held by several people.
+create table public.staff_custom_roles (
+  staff_id       uuid not null references public.staff (id) on delete cascade,
+  custom_role_id uuid not null references public.facility_custom_roles (id) on delete cascade,
+  primary key (staff_id, custom_role_id)
+);
+
+create index staff_custom_roles_role_idx
+  on public.staff_custom_roles (custom_role_id);
+
+-- ── RLS ─────────────────────────────────────────────────────────────────────
+-- Reading is facility-wide: the staff editor has to list the roles on offer,
+-- and knowing "Senior Groomer exists" is not the sensitive part. Writing is
+-- manage_roles, the same gate as every other layer of the cascade.
+
+alter table public.facility_custom_roles            enable row level security;
+alter table public.facility_custom_role_permissions enable row level security;
+alter table public.staff_custom_roles               enable row level security;
+
+create policy facility_custom_roles_read on public.facility_custom_roles
+  for select to authenticated
+  using (
+    private.is_platform_admin()
+    or facility_id in (select private.member_facility_ids())
+  );
+create policy facility_custom_roles_insert on public.facility_custom_roles
+  for insert to authenticated
+  with check (private.has_permission(facility_id, 'manage_roles'));
+create policy facility_custom_roles_update on public.facility_custom_roles
+  for update to authenticated
+  using (private.has_permission(facility_id, 'manage_roles'))
+  with check (private.has_permission(facility_id, 'manage_roles'));
+create policy facility_custom_roles_delete on public.facility_custom_roles
+  for delete to authenticated
+  using (private.has_permission(facility_id, 'manage_roles'));
+
+create policy facility_custom_role_permissions_read on public.facility_custom_role_permissions
+  for select to authenticated
+  using (exists (
+    select 1 from public.facility_custom_roles r
+     where r.id = facility_custom_role_permissions.custom_role_id
+       and (private.is_platform_admin()
+            or r.facility_id in (select private.member_facility_ids()))));
+create policy facility_custom_role_permissions_insert on public.facility_custom_role_permissions
+  for insert to authenticated
+  with check (exists (
+    select 1 from public.facility_custom_roles r
+     where r.id = facility_custom_role_permissions.custom_role_id
+       and private.has_permission(r.facility_id, 'manage_roles')));
+create policy facility_custom_role_permissions_update on public.facility_custom_role_permissions
+  for update to authenticated
+  using (exists (
+    select 1 from public.facility_custom_roles r
+     where r.id = facility_custom_role_permissions.custom_role_id
+       and private.has_permission(r.facility_id, 'manage_roles')))
+  with check (exists (
+    select 1 from public.facility_custom_roles r
+     where r.id = facility_custom_role_permissions.custom_role_id
+       and private.has_permission(r.facility_id, 'manage_roles')));
+create policy facility_custom_role_permissions_delete on public.facility_custom_role_permissions
+  for delete to authenticated
+  using (exists (
+    select 1 from public.facility_custom_roles r
+     where r.id = facility_custom_role_permissions.custom_role_id
+       and private.has_permission(r.facility_id, 'manage_roles')));
+
+create policy staff_custom_roles_read on public.staff_custom_roles
+  for select to authenticated
+  using (exists (
+    select 1 from public.staff s
+     where s.id = staff_custom_roles.staff_id
+       and (private.is_platform_admin()
+            or s.facility_id in (select private.member_facility_ids()))));
+create policy staff_custom_roles_insert on public.staff_custom_roles
+  for insert to authenticated
+  with check (exists (
+    select 1 from public.staff s
+     where s.id = staff_custom_roles.staff_id
+       and private.has_permission(s.facility_id, 'manage_roles')));
+create policy staff_custom_roles_delete on public.staff_custom_roles
+  for delete to authenticated
+  using (exists (
+    select 1 from public.staff s
+     where s.id = staff_custom_roles.staff_id
+       and private.has_permission(s.facility_id, 'manage_roles')));
+-- No update policy: an assignment is a (staff, role) pair with nothing else to
+-- change. Reassigning is a delete and an insert.
+
+-- ── Resolution ──────────────────────────────────────────────────────────────
+-- Unchanged except for one addition: the roles layer now unions the scopes
+-- granted by every custom role the person holds, alongside their preset roles.
+-- Precedence above it is untouched — an account override, then a person
+-- override, either of which is absolute.
+
+create or replace function private.resolve_permission(
+  p_membership_id uuid,
+  p_permission    text
+)
+returns public.access_scope
+language sql
+stable
+security definer
+set search_path = ''
+as $fn$
+  with m as (
+    select fm.id, fm.facility_id, fm.role
+      from public.facility_memberships fm
+     where fm.id = p_membership_id
+  ),
+  s as (
+    select st.id, st.primary_role, st.additional_roles
+      from public.staff st
+      join m on m.id = st.membership_id
+  ),
+  held_roles as (
+    select m.role as role from m
+     union
+    select s.primary_role from s
+     union
+    select unnest(s.additional_roles) from s
+  ),
+  preset_scopes as (
+    select coalesce(
+             (select frp.scope
+                from public.facility_role_permissions frp
+               where frp.facility_id    = (select facility_id from m)
+                 and frp.role           = hr.role
+                 and frp.permission_key = p_permission),
+             (select rpp.scope
+                from public.role_preset_permissions rpp
+               where rpp.role           = hr.role
+                 and rpp.permission_key = p_permission)
+           ) as scope
+      from held_roles hr
+  ),
+  custom_scopes as (
+    select cp.scope
+      from public.staff_custom_roles scr
+      join s on s.id = scr.staff_id
+      join public.facility_custom_role_permissions cp
+        on cp.custom_role_id = scr.custom_role_id
+     where cp.permission_key = p_permission
+  ),
+  role_scopes as (
+    select scope from preset_scopes
+     union all
+    select scope from custom_scopes
+  )
+  select coalesce(
+    (select mp.scope
+       from public.membership_permissions mp
+      where mp.membership_id  = p_membership_id
+        and mp.permission_key = p_permission),
+    (select sp.scope
+       from public.staff_permissions sp
+       join s on s.id = sp.staff_id
+      where sp.permission_key = p_permission),
+    (select rs.scope
+       from role_scopes rs
+      where rs.scope is not null
+        and rs.scope <> 'none'::public.access_scope
+      order by case rs.scope
+                 when 'anytime'         then 3
+                 when 'operating_hours' then 2
+                 when 'assigned_shifts' then 1
+                 else 0
+               end desc
+      limit 1)
+  );
+$fn$;
+
+comment on function private.resolve_permission is
+  'Effective scope for one membership and one permission. Account override, then person override (both absolute, including a stored ''none''), then the widest scope across every role held — preset roles and custom roles alike. NULL means not granted. The SQL twin of resolvePermission() in src/types/facility-staff.ts.';
+
+grant execute on function private.resolve_permission(uuid, text) to authenticated;

--- a/supabase/seed/dev-accounts.sql
+++ b/supabase/seed/dev-accounts.sql
@@ -121,3 +121,62 @@ select p.email,
   left join public.facility_memberships m on m.profile_id = p.id
  where p.email like '%@yipyy.dev'
  order by p.is_platform_admin desc, m.role nulls last, p.email;
+
+-- ============================================================================
+-- Staff records for the dev accounts.
+--
+-- Added because the permission cascade had become unobservable. Layer 3
+-- (staff_permissions) and custom-role assignments both hang off a STAFF row,
+-- and private.resolve_permission reaches them through staff.membership_id.
+-- Every one of the 18 seeded staff records has membership_id NULL — they are
+-- mock people with no account — so those layers could be written and would
+-- never resolve for anybody.
+--
+-- These five are staff of the demo facility who genuinely do have accounts, so
+-- linking them is not a fiction. The existing 18 are left exactly as they are:
+-- attaching Émilie's staff record to owner@yipyy.dev would be inventing an
+-- identity to make a test pass.
+-- ============================================================================
+
+do $$
+declare
+  v_fac_id uuid;
+  r        record;
+begin
+  select id into v_fac_id from public.facilities where legacy_id = '11';
+  if v_fac_id is null then
+    raise notice 'Facility 11 missing — run facility-11-data.sql first.';
+    return;
+  end if;
+
+  for r in
+    select m.id as membership_id, m.role, p.email, p.full_name
+      from public.facility_memberships m
+      join public.profiles p on p.id = m.profile_id
+     where p.email like '%@yipyy.dev'
+       and m.facility_id = v_fac_id
+  loop
+    insert into public.staff (
+      facility_id, membership_id, legacy_id,
+      first_name, last_name, email, primary_role, status
+    )
+    values (
+      v_fac_id,
+      r.membership_id,
+      'fs-dev-' || r.role::text,
+      split_part(coalesce(r.full_name, r.email), ' ', 1),
+      coalesce(nullif(split_part(coalesce(r.full_name, ''), ' ', 2), ''), 'Dev'),
+      r.email,
+      r.role,
+      'active'
+    )
+    on conflict (legacy_id) do update
+      set membership_id = excluded.membership_id,
+          primary_role  = excluded.primary_role;
+  end loop;
+end $$;
+
+select s.legacy_id, s.email, s.primary_role, s.membership_id is not null as linked
+  from public.staff s
+ where s.legacy_id like 'fs-dev-%'
+ order by s.legacy_id;

--- a/tests/e2e/role-editor-writes.spec.ts
+++ b/tests/e2e/role-editor-writes.spec.ts
@@ -243,4 +243,134 @@ test.describe("role editor writes", () => {
     };
     expect(bodyAgain.staff["fs-groom-01"]).toBeUndefined();
   });
+
+  test("a per-staff override moves the person it names", async ({ page }) => {
+    // The check above proves storage. This one proves effect — the dev
+    // accounts have staff records linked to their memberships, so layer 3 can
+    // finally resolve for somebody. Without that link the override is written
+    // and inert, which is indistinguishable from broken.
+    await signIn(page, "owner@yipyy.dev");
+    await setOverride(page, {
+      kind: "staff",
+      staffId: "fs-dev-groomer",
+      key: "manage_roles",
+      setting: { granted: true, scope: "anytime" },
+    });
+
+    await signOut(page);
+    await signIn(page, "groomer@yipyy.dev");
+    // No role a groomer holds grants manage_roles; only the person override does.
+    expect((await permissions(page)).manage_roles).toBe("anytime");
+
+    await signOut(page);
+    await signIn(page, "owner@yipyy.dev");
+    await setOverride(page, {
+      kind: "staff",
+      staffId: "fs-dev-groomer",
+      key: "manage_roles",
+      setting: null,
+    });
+
+    await signOut(page);
+    await signIn(page, "groomer@yipyy.dev");
+    expect((await permissions(page)).manage_roles).toBe("none");
+  });
+
+  test("a custom role grants through the cascade", async ({ page }) => {
+    const roleId = "custom-e2e-senior-groomer";
+    const custom = (body: unknown) =>
+      page.request.put("/api/roles/custom", { data: body });
+
+    await signIn(page, "owner@yipyy.dev");
+    await custom({ kind: "delete", id: roleId }); // clear a failed prior run
+
+    const created = await custom({
+      kind: "upsert",
+      role: {
+        id: roleId,
+        label: "Senior Groomer (e2e)",
+        description: "",
+        accent: "",
+        ring: "",
+        icon: "Sparkles",
+        permissions: {},
+        createdAt: new Date().toISOString(),
+      },
+    });
+    expect(created.status()).toBe(200);
+
+    await custom({
+      kind: "permission",
+      id: roleId,
+      key: "manage_staff",
+      scope: "operating_hours",
+    });
+
+    // Defining the role changes nothing until somebody holds it.
+    await signOut(page);
+    await signIn(page, "groomer@yipyy.dev");
+    expect((await permissions(page)).manage_staff).toBe("none");
+
+    await signOut(page);
+    await signIn(page, "owner@yipyy.dev");
+    const assigned = await custom({
+      kind: "assignments",
+      staffId: "fs-dev-groomer",
+      roleIds: [roleId],
+    });
+    expect(assigned.status()).toBe(200);
+
+    // Now it does — via the fourth branch of the union, not a preset.
+    await signOut(page);
+    await signIn(page, "groomer@yipyy.dev");
+    expect((await permissions(page)).manage_staff).toBe("operating_hours");
+
+    // Unassigning is what takes it away again, and the role itself survives.
+    await signOut(page);
+    await signIn(page, "owner@yipyy.dev");
+    await custom({
+      kind: "assignments",
+      staffId: "fs-dev-groomer",
+      roleIds: [],
+    });
+
+    await signOut(page);
+    await signIn(page, "groomer@yipyy.dev");
+    expect((await permissions(page)).manage_staff).toBe("none");
+
+    await signOut(page);
+    await signIn(page, "owner@yipyy.dev");
+    const listed = (await (
+      await page.request.get("/api/roles/custom")
+    ).json()) as { roles: Record<string, { label: string }> };
+    expect(listed.roles[roleId]?.label).toBe("Senior Groomer (e2e)");
+
+    expect((await custom({ kind: "delete", id: roleId })).status()).toBe(200);
+  });
+
+  test("a manager cannot create or assign custom roles", async ({ page }) => {
+    await signIn(page, "manager@yipyy.dev");
+    const refused = await page.request.put("/api/roles/custom", {
+      data: {
+        kind: "upsert",
+        role: {
+          id: "custom-e2e-forbidden",
+          label: "Should not exist",
+          description: "",
+          accent: "",
+          ring: "",
+          icon: "Sparkles",
+          permissions: {},
+          createdAt: new Date().toISOString(),
+        },
+      },
+    });
+    expect(refused.status()).toBe(403);
+
+    // And nothing was created — a 403 that still wrote would be worse than a 200.
+    const listed = (await (
+      await page.request.get("/api/roles/custom")
+    ).json()) as { roles: Record<string, unknown> };
+    expect(listed.roles["custom-e2e-forbidden"]).toBeUndefined();
+  });
 });


### PR DESCRIPTION
## The question, and why it dissolved

Custom roles were the last part of the role editor still lying: a facility could invent "Senior Groomer", give it permissions, assign it to three people, and none of it left one browser's `localStorage`.

I'd flagged this as needing a product answer — is a custom role a **role** (needing something `facility_memberships.role` can point at, which is an enum, so widening or replacing it) or a saved **bundle** of per-staff overrides?

The code already answered it. `StaffProfile.customRoleIds` is an **array**, resolved by `resolvePermission()` in the same union as `additionalRoles`, and no code path ever puts a custom role in `primaryRole`. A custom role is additive, so it never needs to be an enum value. **The enum problem was imaginary**, and this costs three ordinary tables:

| table | holds |
| --- | --- |
| `facility_custom_roles` | the role |
| `facility_custom_role_permissions` | what it grants |
| `staff_custom_roles` | who holds it |

`private.resolve_permission` gains a fourth source in the same union — a custom role contributes exactly like a preset role, widest scope winning. Precedence above it is untouched: account override, then person override, either absolute.

Assignment hangs off the staff record rather than the membership, for the same reason `staff_permissions` does: a role given at hire has to survive until the person has an account.

## The cascade was unobservable

Both layer 3 and custom-role assignment reach the resolver through `staff.membership_id`, and **all 18 seeded staff had it NULL** — mock people with no accounts. So both could be written and would never resolve for anyone, which is indistinguishable from broken.

`supabase/seed/dev-accounts.sql` now also creates a staff record for each of the five dev accounts, linked to its membership. They are genuinely staff of the demo facility. The 18 mock records are left alone — attaching Émilie's record to `owner@yipyy.dev` would be inventing an identity to make a test pass.

## Two things fixed on the way

**Signed-out edits threw silently.** Role-editor writes used `liveWrite`, which throws on 401. Signed out — most of the app until `AUTH_ENFORCED` flips — every edit rejected into the mutation's error state where nothing displayed it. Added `liveWriteOptional`: `null` on 401, throws on everything else, for state that also has a local home. Never for a write whose whole purpose is to persist.

**"Not known" vs "nobody holds one."** The signed-out custom-roles fallback returns `assignments: null`, not `{}`. The empty map would have blanked every assignment the mock profiles carry the moment a browser had no session.

## Verification

Eight e2e checks against the live project, each reading the affected account's resolved map rather than the editor's own state:

```
define a custom role, grant manage_staff  ->  groomer unchanged (nobody holds it)
assign it to the groomer                  ->  resolves operating_hours
unassign                                  ->  back to none, role survives
manager attempts to create one            ->  403, and nothing was created
per-staff override on a linked record     ->  moves that person, then clears
```

Plus the five from #100, still passing — 8/8. SQL-level checks confirmed the fourth branch and that a person override still beats a custom role. Probe rows removed. typecheck, lint, format and build green.

Two `staff-portal-nav.spec.ts` tests remain red; reproduced on a clean tree in #100, so still pre-existing and worth a separate look.
