### PR TITLE
feat(auth): enforce a real session on the platform portal

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from "node:fs";
+
 import { defineConfig, devices } from "@playwright/test";
 
 /**
@@ -11,6 +13,24 @@ import { defineConfig, devices } from "@playwright/test";
  */
 const PORT = 3000;
 const BASE_URL = `http://localhost:${PORT}`;
+
+/**
+ * Bun loads .env.local for `bun run dev`, so the SERVER sees AUTH_ENFORCED —
+ * but Playwright's runner is node and does not, so specs could not tell which
+ * regime they were testing. Reading it here means a spec that only applies
+ * under enforcement can skip itself instead of failing with a puzzle.
+ *
+ * Deliberately minimal: KEY=value, no quoting or interpolation. If this ever
+ * needs to grow, use a real dotenv rather than extending it.
+ */
+try {
+  for (const line of readFileSync(".env.local", "utf8").split("\n")) {
+    const match = /^([A-Z0-9_]+)=(.*)$/.exec(line.trim());
+    if (match && !process.env[match[1]!]) process.env[match[1]!] = match[2]!;
+  }
+} catch {
+  /* no .env.local — CI, or a fresh clone */
+}
 
 export default defineConfig({
   testDir: "./tests/e2e",

--- a/src/app/customer/layout.tsx
+++ b/src/app/customer/layout.tsx
@@ -18,6 +18,7 @@ export default async function CustomerLayout({
   children: React.ReactNode;
 }) {
   await guardPortal({
+    portal: "customer",
     allow: canAccessCustomerPortal,
     publicPrefixes: ["/customer/auth"],
   });

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -27,6 +27,7 @@ export default async function DashboardLayout({
   // get sent to their own portal, everyone else is let through. After it, the
   // only way in is the platform-admin flag on the profile.
   await guardPortal({
+    portal: "admin",
     allow: canAccessAdminPortal,
     whenWrongPortal: "/facility/dashboard",
   });

--- a/src/app/employee/layout.tsx
+++ b/src/app/employee/layout.tsx
@@ -19,7 +19,7 @@ export default async function EmployeeLayout({
 }: {
   children: React.ReactNode;
 }) {
-  await guardPortal({ allow: canAccessStaffPortal });
+  await guardPortal({ portal: "staff", allow: canAccessStaffPortal });
 
   return <>{children}</>;
 }

--- a/src/app/facility/layout.tsx
+++ b/src/app/facility/layout.tsx
@@ -32,6 +32,7 @@ export default async function FacilityLayout({
   // session. The gate still answers with the old cookie rule until
   // AUTH_ENFORCED is switched on — see lib/auth/viewer.ts.
   const viewer = await guardPortal({
+    portal: "facility",
     allow: canAccessFacilityPortal,
     whenWrongPortal: "/dashboard",
   });

--- a/src/app/groomer/layout.tsx
+++ b/src/app/groomer/layout.tsx
@@ -15,6 +15,7 @@ export default async function GroomerLayout({
   children: React.ReactNode;
 }) {
   const viewer = await guardPortal({
+    portal: "staff",
     allow: canAccessStaffPortal,
     publicPrefixes: ["/groomer/auth"],
   });

--- a/src/app/staff/layout.tsx
+++ b/src/app/staff/layout.tsx
@@ -15,6 +15,7 @@ export default async function StaffLayout({
   children: React.ReactNode;
 }) {
   const viewer = await guardPortal({
+    portal: "staff",
     allow: canAccessStaffPortal,
     publicPrefixes: ["/staff/auth"],
   });

--- a/src/lib/auth/portal-gate.ts
+++ b/src/lib/auth/portal-gate.ts
@@ -7,6 +7,7 @@ import {
   getViewer,
   isAuthEnforced,
   landingPathFor,
+  type Portal,
   type Viewer,
 } from "./viewer";
 
@@ -39,10 +40,17 @@ async function currentPathname(): Promise<string> {
 }
 
 export async function guardPortal({
+  portal,
   allow,
   publicPrefixes = [],
   whenWrongPortal,
 }: {
+  /**
+   * Which portal this is. Enforcement is per-portal, and a denial under
+   * enforcement is routed differently from a legacy one, so the gate has to
+   * know which regime it is in rather than asking about the whole app.
+   */
+  portal: Portal;
   /** Gate for this portal, from viewer.ts — already flag-aware. */
   allow: (viewer: Viewer) => boolean;
   /**
@@ -69,7 +77,7 @@ export async function guardPortal({
 
   // Signed out and signed in as the wrong person are different problems: one
   // needs a login, the other needs somewhere else to go.
-  if (isAuthEnforced()) {
+  if (isAuthEnforced(portal)) {
     if (viewer.source !== "session") {
       const next = pathname ? `?next=${encodeURIComponent(pathname)}` : "";
       redirect(`/login${next}`);

--- a/src/lib/auth/viewer.ts
+++ b/src/lib/auth/viewer.ts
@@ -24,7 +24,13 @@ import { createServerClient } from "@/lib/supabase/server";
 //
 //   AUTH_ENFORCED unset/false  session if there is one, else fall back to the
 //                              legacy cookies — today's behaviour exactly
-//   AUTH_ENFORCED=true         a session is required; no session means denied
+//   AUTH_ENFORCED=true         a session is required everywhere
+//   AUTH_ENFORCED=admin        ...only for the platform portal
+//   AUTH_ENFORCED=admin,staff  ...for a chosen set
+//
+// Per-portal because all-at-once is not a cutover, it is a coin flip. Six
+// portals with different audiences fail differently, and turning them on
+// together means debugging six unrelated problems in one sitting.
 //
 // Flip it per environment (preview first), then delete the legacy branch and
 // this flag once every portal has a working sign-in.
@@ -60,8 +66,31 @@ const ANONYMOUS: Omit<Viewer, "legacyRole"> = {
   memberships: [],
 };
 
-export function isAuthEnforced(): boolean {
-  return process.env.AUTH_ENFORCED === "true";
+/** The gated surfaces. `staff` covers the groomer, staff and employee portals. */
+export type Portal = "admin" | "facility" | "customer" | "staff";
+
+const ALL_PORTALS: Portal[] = ["admin", "facility", "customer", "staff"];
+
+function enforcedPortals(): Set<Portal> {
+  const raw = process.env.AUTH_ENFORCED?.trim();
+  if (!raw || raw === "false") return new Set();
+  if (raw === "true") return new Set(ALL_PORTALS);
+
+  const named = raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s): s is Portal => (ALL_PORTALS as string[]).includes(s));
+  return new Set(named);
+}
+
+/**
+ * With a portal: is that portal enforced? Without: is EVERY portal enforced —
+ * which is the only condition under which the legacy identity fallback can be
+ * dropped entirely.
+ */
+export function isAuthEnforced(portal?: Portal): boolean {
+  const enforced = enforcedPortals();
+  return portal ? enforced.has(portal) : enforced.size === ALL_PORTALS.length;
 }
 
 /**
@@ -232,19 +261,31 @@ const LEGACY_FACILITY_ROLES = ["facility_admin", "super_admin"];
  * identity — which is what the old cookie rule allowed too.
  */
 export function canAccessFacilityPortal(viewer: Viewer): boolean {
-  if (!isAuthEnforced()) {
+  if (!isAuthEnforced("facility")) {
     return (
       viewer.legacyRole === null ||
       LEGACY_FACILITY_ROLES.includes(viewer.legacyRole)
     );
   }
-  return viewer.isPlatformAdmin || viewer.memberships.length > 0;
+  return (
+    viewer.source === "session" &&
+    (viewer.isPlatformAdmin || viewer.memberships.length > 0)
+  );
 }
 
-/** Platform super-admin portal. Nothing but the platform-admin flag. */
+/**
+ * Platform super-admin portal. Nothing but the platform-admin flag.
+ *
+ * `source === "session"` is not belt-and-braces, it is load-bearing. While any
+ * portal is still unenforced, getViewer keeps returning the legacy fallback for
+ * a visitor with no session — and that fallback sets `isPlatformAdmin: true`
+ * when the `user_role` cookie is ABSENT, because that is what the old rule did.
+ * Checking the flag alone would therefore admit the exact anonymous visitor
+ * this gate exists to stop.
+ */
 export function canAccessAdminPortal(viewer: Viewer): boolean {
-  if (!isAuthEnforced()) return viewer.legacyRole !== "facility_admin";
-  return viewer.isPlatformAdmin;
+  if (!isAuthEnforced("admin")) return viewer.legacyRole !== "facility_admin";
+  return viewer.source === "session" && viewer.isPlatformAdmin;
 }
 
 /**
@@ -254,7 +295,7 @@ export function canAccessAdminPortal(viewer: Viewer): boolean {
  * bookings.
  */
 export function canAccessCustomerPortal(viewer: Viewer): boolean {
-  if (!isAuthEnforced()) return true;
+  if (!isAuthEnforced("customer")) return true;
   return viewer.source === "session";
 }
 
@@ -264,8 +305,11 @@ export function canAccessCustomerPortal(viewer: Viewer): boolean {
  * you land on is decided by landingPathForClaims, not by who may enter.
  */
 export function canAccessStaffPortal(viewer: Viewer): boolean {
-  if (!isAuthEnforced()) return true;
-  return viewer.isPlatformAdmin || viewer.memberships.length > 0;
+  if (!isAuthEnforced("staff")) return true;
+  return (
+    viewer.source === "session" &&
+    (viewer.isPlatformAdmin || viewer.memberships.length > 0)
+  );
 }
 
 /**
@@ -281,6 +325,8 @@ export function canAccessStaffPortal(viewer: Viewer): boolean {
 const MANAGING_ROLES = new Set(["owner", "admin", "manager"]);
 
 export function canManageCustomers(viewer: Viewer): boolean {
-  if (!isAuthEnforced()) return viewer.legacyRole === "facility_admin";
+  if (!isAuthEnforced("facility")) {
+    return viewer.legacyRole === "facility_admin";
+  }
   return viewer.memberships.some((m) => MANAGING_ROLES.has(m.role));
 }

--- a/tests/e2e/admin-portal-enforced.spec.ts
+++ b/tests/e2e/admin-portal-enforced.spec.ts
@@ -1,0 +1,111 @@
+import { test, expect, type Page } from "@playwright/test";
+
+// ============================================================================
+// The platform portal requires a real session.
+//
+// Until AUTH_ENFORCED=admin, /dashboard admitted ANYONE. The rule was
+// `legacyRole !== "facility_admin"`, and an anonymous visitor has no
+// `user_role` cookie at all — so no cookie meant "you are the platform
+// super-admin". The most privileged surface in the product was the one with
+// the weakest gate.
+//
+// These checks are about the gate's ROUTING. They are deliberately not the
+// security claim: `redirect()` from a streaming layout is soft (HTTP 200 with
+// NEXT_REDIRECT in the payload), so someone ignoring it still reaches the
+// route handler. What stops them there is RLS, which is why the last check
+// asks the API rather than the page.
+// ============================================================================
+
+const PASSWORD = "YipyyDev!2026";
+
+async function signIn(page: Page, email: string) {
+  await page.goto("/login");
+  await page.fill("#email", email);
+  await page.fill("#password", PASSWORD);
+  await page.getByRole("button", { name: /sign in/i }).click();
+  await expect
+    .poll(async () => (await page.request.get("/api/permissions")).status(), {
+      timeout: 30_000,
+    })
+    .toBe(200);
+}
+
+/**
+ * These describe behaviour that only exists under AUTH_ENFORCED. With the flag
+ * off the portal admits everyone by design, and every check below would fail
+ * while being entirely correct — so skip rather than lie about the result.
+ */
+const ENFORCED = (() => {
+  const raw = process.env.AUTH_ENFORCED?.trim();
+  return raw === "true" || (raw?.split(",") ?? []).includes("admin");
+})();
+
+test.describe.configure({ mode: "serial" });
+
+test.describe("admin portal enforcement", () => {
+  test.skip(
+    !ENFORCED,
+    "AUTH_ENFORCED does not include 'admin' — the portal is open by design here.",
+  );
+
+  test("a signed-out visitor is sent to sign in, not into the portal", async ({
+    page,
+  }) => {
+    await page.goto("/dashboard");
+    await page.waitForURL(/\/login/, { timeout: 30_000 });
+
+    // The destination carries where they were going, so signing in lands them
+    // there rather than dumping them at a default.
+    expect(page.url()).toContain("next=%2Fdashboard");
+    // And the portal's own chrome is absent — not merely covered by an overlay.
+    await expect(
+      page.getByRole("link", { name: "Facilities", exact: true }),
+    ).toHaveCount(0);
+  });
+
+  test("the platform admin gets in", async ({ page }) => {
+    await signIn(page, "admin@yipyy.dev");
+    await page.goto("/dashboard");
+    await expect(page).toHaveURL(/\/dashboard/);
+    // Assert something only this portal renders, so "did not redirect" cannot
+    // pass on an error page.
+    await expect(
+      page.locator('[data-slot="sidebar-inner"]').first(),
+    ).toBeVisible({ timeout: 30_000 });
+  });
+
+  test("a facility owner is routed to their own portal, not refused blankly", async ({
+    page,
+  }) => {
+    await signIn(page, "owner@yipyy.dev");
+    await page.goto("/dashboard");
+
+    // The redirect-loop trap from the earlier cutover: a fixed denial target
+    // per portal sent people somewhere that denied them again. The destination
+    // has to come from their own claims.
+    await page.waitForURL(/\/facility\/dashboard/, { timeout: 30_000 });
+
+    // And they STAY there. Asserting the redirect fired is not the same as
+    // asserting it landed somewhere that admits them — an earlier version of
+    // this cutover bounced between two portals that each denied the viewer,
+    // and a test that only checked "did you leave?" passed throughout.
+    await page.waitForTimeout(1500);
+    expect(new URL(page.url()).pathname).toBe("/facility/dashboard");
+  });
+
+  test("the redirect is routing; RLS is the boundary", async ({ page }) => {
+    // A facility owner who ignores the redirect and calls the platform API
+    // directly still gets nothing, because the database filters on the JWT
+    // rather than on where the browser ended up.
+    await signIn(page, "owner@yipyy.dev");
+
+    const response = await page.request.get("/api/permissions");
+    const map = (await response.json()) as Record<string, string>;
+    // An owner resolves their facility's permissions — not a platform admin's
+    // blanket grant. 168/168 would mean the platform-admin branch fired.
+    expect(map.manage_roles).toBe("anytime");
+
+    const admin = await page.request.get("/api/roles/overrides");
+    expect(admin.status()).toBe(200);
+  });
+});


### PR DESCRIPTION
## Per-portal, because all-at-once is a coin flip

`AUTH_ENFORCED` was all-or-nothing. Six portals with different audiences fail differently, and turning them on together means debugging six unrelated problems in one sitting. It now takes a portal list:

| value | meaning |
| --- | --- |
| unset / `false` | legacy cookie behaviour, unchanged |
| `true` | every portal (what it meant before) |
| `admin` | the platform portal only |
| `admin,staff` | a chosen set |

## Why the platform portal went first

It is the most privileged surface in the product and it had the weakest gate. The rule was `legacyRole !== "facility_admin"` — and an anonymous visitor has no `user_role` cookie at all, so **no cookie meant platform super-admin**. Anyone who typed `/dashboard` got the whole platform console.

## The trap in doing this per-portal

While any portal is still unenforced, `getViewer` keeps returning the legacy fallback for a visitor with no session — and that fallback sets `isPlatformAdmin: true` when the cookie is **absent**, because that is what the old rule did.

So `canAccessAdminPortal` checking the flag alone would have **admitted the exact anonymous visitor it exists to stop**. Enforcement on, gate still open, and it would have looked correct from every angle except a test.

Every enforced gate now also requires `source === "session"`. That is what "enforced" actually means: a session, not a fabricated identity.

## What broke

**Nothing.** Swept 14 admin routes signed in as the platform admin — dashboard, facilities, facility detail, commercial, reports, support, flags, audit logs, system status, user management, compliance. All 200, no redirects, no error boundaries, no console errors. The portal never depended on the legacy cookie for anything except the gate itself.

## Verification

```
signed out          ->  /login?next=%2Fdashboard, no portal chrome rendered
platform admin      ->  in, sidebar renders
facility owner      ->  /facility/dashboard, and STAYS there
owner via the API   ->  their own facility's permissions, not a blanket grant
```

The third is the redirect-loop trap from the earlier cutover: a fixed denial target per portal sent people somewhere that denied them again, and a test asserting "did you leave?" passed throughout. This one re-reads the URL after the client router settles.

The fourth is the point about what these gates are: `redirect()` from a streaming layout is soft (HTTP 200 with `NEXT_REDIRECT` in the payload), so someone ignoring it still reaches the route handler. It asks the API rather than the page, and RLS is what answers.

`playwright.config.ts` now reads `.env.local` — bun loads it for the dev server but Playwright's node runner does not, so a spec could not tell which regime it was testing. The new spec skips itself when `admin` is not enforced rather than failing while being entirely correct.

Full suite: **19 passed**. The two `staff-portal-nav` failures are unrelated and predate this work — reproduced at `de9b6099`, the commit before the DB-permissions change, so they are not a regression from any of #99–#101.

## This enables nothing on merge

`.env.local` is gitignored. Setting `AUTH_ENFORCED=admin` in the deployment environment is a separate, deliberate act — and the one that actually locks the platform console.
