### PR TITLE
feat(auth): the facility portal knows who you are

### DIFF
--- a/src/app/facility/dashboard/staff/[id]/staff-profile-view.tsx
+++ b/src/app/facility/dashboard/staff/[id]/staff-profile-view.tsx
@@ -17,7 +17,7 @@ import {
   ShieldAlert,
   Save,
 } from "lucide-react";
-import { FacilityRbacProvider, usePermission } from "@/hooks/use-facility-rbac";
+import { usePermission } from "@/hooks/use-facility-rbac";
 import { useSetStaffCustomRoles } from "@/lib/api/roles";
 import {
   ROLE_PRESETS,
@@ -106,11 +106,10 @@ const STATUS_META: Record<
 };
 
 export function StaffProfileView({ staffId }: { staffId: string }) {
-  return (
-    <FacilityRbacProvider>
-      <StaffProfileInner staffId={staffId} />
-    </FacilityRbacProvider>
-  );
+  // The provider now lives at the facility layout, holding the identity
+  // resolved from the session. Mounting a second one here would shadow it with
+  // a fresh default — which is to say, with the owner.
+  return <StaffProfileInner staffId={staffId} />;
 }
 
 function StaffProfileInner({ staffId }: { staffId: string }) {

--- a/src/app/facility/dashboard/staff/layout.tsx
+++ b/src/app/facility/dashboard/staff/layout.tsx
@@ -11,11 +11,7 @@ import {
   Eye,
   ShieldAlert,
 } from "lucide-react";
-import {
-  FacilityRbacProvider,
-  useFacilityViewer,
-} from "@/hooks/use-facility-rbac";
-import { facilityStaff } from "@/data/facility-staff";
+import { useFacilityViewer } from "@/hooks/use-facility-rbac";
 import {
   Select,
   SelectContent,
@@ -54,7 +50,45 @@ const staffTabs = [
 ];
 
 function ViewingAsSwitcher() {
-  const { viewerId, setViewerId, viewer } = useFacilityViewer();
+  const {
+    viewerId,
+    setViewerId,
+    viewer,
+    canSwitchViewer,
+    viewerResolved,
+    staff,
+  } = useFacilityViewer();
+
+  // Until the roster arrives, `viewer` is a fallback — showing its name would
+  // briefly name a COLLEAGUE. Say nothing rather than something wrong.
+  if (!canSwitchViewer && !viewerResolved) {
+    return (
+      <div className="text-muted-foreground flex items-center gap-1.5 text-xs">
+        <Eye className="size-3" /> Signed in…
+      </div>
+    );
+  }
+
+  // Signed in as a real staff member, this control does nothing — the identity
+  // came from the session. Showing a dropdown that silently ignores clicks is
+  // worse than showing none, so it renders who you are instead.
+  if (!canSwitchViewer) {
+    return (
+      <div className="text-muted-foreground flex items-center gap-1.5 text-xs">
+        <Eye className="size-3" />
+        <span className="truncate">
+          Signed in as{" "}
+          <span className="text-foreground font-medium">
+            {viewer.firstName} {viewer.lastName}
+          </span>
+          <span className="ml-1.5">
+            · {ROLE_META[viewer.primaryRole].label}
+          </span>
+        </span>
+      </div>
+    );
+  }
+
   return (
     <div className="flex items-center gap-2">
       <div className="text-muted-foreground flex items-center gap-1.5 text-xs">
@@ -72,7 +106,7 @@ function ViewingAsSwitcher() {
           </SelectValue>
         </SelectTrigger>
         <SelectContent>
-          {facilityStaff.map((s) => (
+          {staff.map((s) => (
             <SelectItem key={s.id} value={s.id} className="text-xs">
               <span className="font-medium">
                 {s.firstName} {s.lastName}
@@ -151,9 +185,7 @@ export default function StaffLayout({
 }: {
   children: React.ReactNode;
 }) {
-  return (
-    <FacilityRbacProvider>
-      <StaffLayoutShell>{children}</StaffLayoutShell>
-    </FacilityRbacProvider>
-  );
+  // No provider here any more — the facility layout mounts it with the
+  // session-resolved identity. A nested one would shadow that with a default.
+  return <StaffLayoutShell>{children}</StaffLayoutShell>;
 }

--- a/src/app/facility/layout.tsx
+++ b/src/app/facility/layout.tsx
@@ -1,5 +1,7 @@
 import { canAccessFacilityPortal, canManageCustomers } from "@/lib/auth/viewer";
 import { guardPortal } from "@/lib/auth/portal-gate";
+import { legacyStaffIdForEmail } from "@/lib/auth/legacy-identity";
+import { FacilityRbacProvider } from "@/hooks/use-facility-rbac";
 import { FacilitySidebar } from "@/components/layout/facility-admin-sidebar";
 import {
   SidebarInset,
@@ -39,48 +41,70 @@ export default async function FacilityLayout({
 
   const canCreateCustomer = canManageCustomers(viewer);
 
+  // Who the portal thinks you are, resolved from your VERIFIED session email
+  // against the staff table — the same bridge the groomer and staff portals
+  // already use, which this portal never had.
+  //
+  // Without it the RBAC provider defaulted to the hardcoded "fs-owner-01" and
+  // let anyone change it from localStorage. Permissions stopped following that
+  // when they moved into Postgres, so the effect was subtler than a privilege
+  // hole and arguably worse: a signed-in groomer saw the OWNER's name, avatar
+  // and profile while holding a groomer's permissions.
+  //
+  // `null` when signed out or when the session has no staff record. That is the
+  // whole app today, and it keeps today's behaviour — a switchable viewer
+  // defaulting to the owner — rather than blanking the portal.
+  const staffId = await legacyStaffIdForEmail(viewer.email);
+
   return (
-    <LocationContextProviderWrapper>
-      <SettingsProviderWrapper>
-        <LoyaltyProgramProvider>
-          <BookingModalProviderWrapper>
-            <CallAvailabilityProvider>
-              <CallTagsProvider>
-                <ReputationProvider>
-                  <SidebarProvider className="min-h-[calc(100vh-64px)]">
-                    <FacilitySidebar />
-                    <SidebarInset className="flex min-h-[calc(100vh-64px)] min-w-0 flex-col overflow-x-clip">
-                      <header className="from-background to-muted/20 sticky top-0 z-40 flex h-16 shrink-0 items-center justify-between gap-4 border-b bg-linear-to-r px-4 backdrop-blur-sm sm:px-6">
-                        <div className="flex min-w-0 items-center gap-3">
-                          <SidebarTrigger className="hover:bg-muted size-9 rounded-xl transition-colors md:hidden" />
-                          <GlobalSearchNext
-                            className="hidden w-[460px] max-w-[480px] min-w-0 sm:flex"
-                            canCreateCustomer={canCreateCustomer}
-                          />
-                          <MobileSearch
-                            className="sm:hidden"
-                            canCreateCustomer={canCreateCustomer}
-                          />
-                        </div>
-                        <FacilityHeaderActions facilityId={11} />
-                      </header>
-                      <main className="min-w-0 flex-1 overflow-x-clip">
-                        <ImpersonationBanner />
-                        <AnnouncementBanner facilityId={11} />
-                        <FacilityOnboardingBanner />
-                        {children}
-                      </main>
-                      <FacilityMobileBottomNav />
-                    </SidebarInset>
-                    <SupportFab />
-                    <SupportCenter />
-                  </SidebarProvider>
-                </ReputationProvider>
-              </CallTagsProvider>
-            </CallAvailabilityProvider>
-          </BookingModalProviderWrapper>
-        </LoyaltyProgramProvider>
-      </SettingsProviderWrapper>
-    </LocationContextProviderWrapper>
+    <FacilityRbacProvider
+      initialViewerId={staffId ?? undefined}
+      // Platform admins keep the switcher: reviewing a facility as one of its
+      // staff is what the tool is for. Anyone else is themselves.
+      allowViewerSwitch={staffId === null || viewer.isPlatformAdmin}
+    >
+      <LocationContextProviderWrapper>
+        <SettingsProviderWrapper>
+          <LoyaltyProgramProvider>
+            <BookingModalProviderWrapper>
+              <CallAvailabilityProvider>
+                <CallTagsProvider>
+                  <ReputationProvider>
+                    <SidebarProvider className="min-h-[calc(100vh-64px)]">
+                      <FacilitySidebar />
+                      <SidebarInset className="flex min-h-[calc(100vh-64px)] min-w-0 flex-col overflow-x-clip">
+                        <header className="from-background to-muted/20 sticky top-0 z-40 flex h-16 shrink-0 items-center justify-between gap-4 border-b bg-linear-to-r px-4 backdrop-blur-sm sm:px-6">
+                          <div className="flex min-w-0 items-center gap-3">
+                            <SidebarTrigger className="hover:bg-muted size-9 rounded-xl transition-colors md:hidden" />
+                            <GlobalSearchNext
+                              className="hidden w-[460px] max-w-[480px] min-w-0 sm:flex"
+                              canCreateCustomer={canCreateCustomer}
+                            />
+                            <MobileSearch
+                              className="sm:hidden"
+                              canCreateCustomer={canCreateCustomer}
+                            />
+                          </div>
+                          <FacilityHeaderActions facilityId={11} />
+                        </header>
+                        <main className="min-w-0 flex-1 overflow-x-clip">
+                          <ImpersonationBanner />
+                          <AnnouncementBanner facilityId={11} />
+                          <FacilityOnboardingBanner />
+                          {children}
+                        </main>
+                        <FacilityMobileBottomNav />
+                      </SidebarInset>
+                      <SupportFab />
+                      <SupportCenter />
+                    </SidebarProvider>
+                  </ReputationProvider>
+                </CallTagsProvider>
+              </CallAvailabilityProvider>
+            </BookingModalProviderWrapper>
+          </LoyaltyProgramProvider>
+        </SettingsProviderWrapper>
+      </LocationContextProviderWrapper>
+    </FacilityRbacProvider>
   );
 }

--- a/src/hooks/use-facility-rbac.tsx
+++ b/src/hooks/use-facility-rbac.tsx
@@ -25,6 +25,7 @@ import {
   type StaffProfile,
 } from "@/types/facility-staff";
 import { facilityStaff } from "@/data/facility-staff";
+import { staffQueries } from "@/lib/api/staff";
 import { setFacilityRoleCookie } from "@/lib/facility-role";
 import { useDbPermissions } from "@/hooks/use-db-permissions";
 import {
@@ -57,6 +58,24 @@ interface RbacContextValue {
   viewer: StaffProfile;
   viewerId: string;
   setViewerId: (id: string) => void;
+  /**
+   * Whether `setViewerId` does anything. A switcher UI should hide itself when
+   * this is false rather than render a control that silently ignores clicks.
+   */
+  canSwitchViewer: boolean;
+  /**
+   * False for the moment between mount and the staff roster arriving, when
+   * `viewer` is a fallback rather than the person the session names. UI that
+   * shows WHO you are should draw a placeholder until this is true.
+   */
+  viewerResolved: boolean;
+  /**
+   * The roster identities resolve against: Postgres rows when there is a
+   * session, the mock array when there is not. Anything offering a choice of
+   * staff must read THIS, not the mock array — offering an id the provider
+   * cannot resolve silently selects somebody else.
+   */
+  staff: StaffProfile[];
   /** All custom roles, keyed by id. */
   customRoles: CustomRolesById;
   /** Preset permission overrides, keyed by role then permission. */
@@ -142,10 +161,25 @@ export function FacilityRbacProvider({
    * (the facility staff layout does) to keep the switchable, persisted viewer.
    */
   initialViewerId,
+  allowViewerSwitch,
   previewPermissions,
 }: {
   children: ReactNode;
   initialViewerId?: string;
+  /**
+   * Whether the "viewing as" switcher may change who the tree thinks you are.
+   *
+   * Defaults to `initialViewerId == null`, which reproduces the old behaviour
+   * exactly: the employee portal passed an id and got a fixed viewer, the
+   * facility staff section passed none and got a switchable one.
+   *
+   * The facility portal now passes it explicitly, because "switchable" there
+   * meant ANY visitor could type an id into localStorage and have the UI redraw
+   * as the owner. Permissions stopped following that in PR #99 — they come from
+   * the database now — but the identity did, and a groomer looking at the
+   * owner's name and profile is its own problem.
+   */
+  allowViewerSwitch?: boolean;
   /**
    * Section 7 — "Preview as employee". When set, EVERY permission decision in
    * the tree resolves from this map instead of a real staff profile, so the
@@ -154,6 +188,7 @@ export function FacilityRbacProvider({
    */
   previewPermissions?: EffectivePermissions | null;
 }) {
+  const canSwitch = allowViewerSwitch ?? initialViewerId == null;
   const [state, setState] = useState<RbacState>(
     initialViewerId
       ? { ...DEFAULT_STATE, viewerId: initialViewerId }
@@ -166,6 +201,20 @@ export function FacilityRbacProvider({
   const { data: customRolesData } = useQuery(roleQueries.customRoles());
   const customRoles = customRolesData?.roles ?? EMPTY_CUSTOM_ROLES;
   const customAssignments = customRolesData?.assignments;
+
+  // The roster this provider resolves identities against.
+  //
+  // It used to be the mock array, full stop, which quietly broke the moment an
+  // id came from anywhere real: `initialViewerId` resolved from a session finds
+  // no match in the mock array, and `.find() ?? facilityStaff[0]` then hands
+  // back SOMEBODY ELSE rather than failing. A staff member appearing as a
+  // colleague is worse than an error, because nothing looks wrong.
+  //
+  // staffQueries.profiles() serves Postgres rows when there is a session and
+  // the same mock array when there is not, so both ids resolve in their own
+  // world.
+  const { data: dbStaff } = useQuery(staffQueries.profiles());
+  const staffList = dbStaff ?? facilityStaff;
 
   // The two DB-backed layers of the cascade. `undefined` while loading and
   // `null` when signed out; in both cases the local state below is what the UI
@@ -191,9 +240,12 @@ export function FacilityRbacProvider({
         // the query store, so only pull the fields this provider still owns.
         const parsed = JSON.parse(raw) as Partial<RbacState>;
         setState((prev) => ({
-          // In fixed-viewer (employee) mode the identity comes from the session
-          // cookie — never let a stored "viewing as" id override it.
-          viewerId: initialViewerId ?? parsed.viewerId ?? prev.viewerId,
+          // A stored "viewing as" id is only allowed to win where switching is
+          // allowed. Everywhere else the identity came from a verified session
+          // and localStorage does not get a vote.
+          viewerId: canSwitch
+            ? (parsed.viewerId ?? initialViewerId ?? prev.viewerId)
+            : (initialViewerId ?? prev.viewerId),
           presetOverrides: parsed.presetOverrides ?? prev.presetOverrides,
           staffOverrides: parsed.staffOverrides ?? prev.staffOverrides,
         }));
@@ -202,25 +254,36 @@ export function FacilityRbacProvider({
       /* ignore */
     }
     setHydrated(true);
-  }, [initialViewerId]);
+  }, [initialViewerId, canSwitch]);
 
   useEffect(() => {
     if (!hydrated || typeof window === "undefined") return;
-    // Don't write the employee portal's cookie-driven viewer back into the
-    // shared key (it would bleed into the facility "viewing as" switcher).
-    if (initialViewerId) return;
+    // Don't write a session-derived viewer back into the shared key — it would
+    // bleed into the switcher and outlive the session that produced it.
+    if (!canSwitch) return;
     try {
       localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
     } catch {
       /* ignore */
     }
-  }, [state, hydrated, initialViewerId]);
+  }, [state, hydrated, canSwitch]);
 
-  const viewer = useMemo<StaffProfile>(() => {
-    return (
-      facilityStaff.find((s) => s.id === state.viewerId) ?? facilityStaff[0]
-    );
-  }, [state.viewerId]);
+  // `staffList[0]` is a reasonable default for the SWITCHABLE case, where the
+  // viewer is a choice rather than a fact. It is a bad one for a
+  // session-derived identity that has not arrived yet: the roster loads
+  // asynchronously, so for the first paint "fs-dev-groomer" is absent and the
+  // fallback renders a COLLEAGUE'S name and role. Correct a moment later, wrong
+  // in the meantime, and wrong in the way nobody notices.
+  //
+  // `viewerResolved` is what lets a caller draw a placeholder instead. It does
+  // not change `viewer` itself, because every consumer needs a profile to read;
+  // it marks the one moment when that profile is not yet the right person.
+  const resolvedViewer = useMemo(
+    () => staffList.find((s) => s.id === state.viewerId),
+    [staffList, state.viewerId],
+  );
+  const viewer = resolvedViewer ?? staffList[0];
+  const viewerResolved = resolvedViewer != null;
 
   // Mirror the active viewer's role into a server-readable cookie so server-side
   // route guards (e.g. the owner-only Documents / Yipyy Agreements area) can
@@ -246,11 +309,9 @@ export function FacilityRbacProvider({
       // though it were in force.
       const edited = dbOverrides ? undefined : state.staffOverrides[staffId];
       if (edited) return edited;
-      return (
-        facilityStaff.find((s) => s.id === staffId)?.permissionOverrides ?? {}
-      );
+      return staffList.find((s) => s.id === staffId)?.permissionOverrides ?? {};
     },
-    [dbOverrides, state.staffOverrides],
+    [dbOverrides, staffList, state.staffOverrides],
   );
 
   // Overlay the provider's per-staff overrides onto the profile before resolving
@@ -299,7 +360,7 @@ export function FacilityRbacProvider({
     (staffId: string): EffectivePermissions => {
       // Section 7: preview short-circuits — the whole tree sees the role's map.
       if (previewPermissions) return previewPermissions;
-      const staff = facilityStaff.find((s) => s.id === staffId);
+      const staff = staffList.find((s) => s.id === staffId);
       if (!staff) {
         return Object.fromEntries(
           ALL_PERMISSION_KEYS.map((k) => [k, false]),
@@ -310,7 +371,13 @@ export function FacilityRbacProvider({
         presetOverrides,
       });
     },
-    [customRoles, presetOverrides, withOverrides, previewPermissions],
+    [
+      customRoles,
+      presetOverrides,
+      withOverrides,
+      previewPermissions,
+      staffList,
+    ],
   );
 
   const setStaffPermission = useCallback(
@@ -329,7 +396,7 @@ export function FacilityRbacProvider({
         // on top of any pre-existing seed rather than wiping it.
         const base =
           prev.staffOverrides[staffId] ??
-          facilityStaff.find((s) => s.id === staffId)?.permissionOverrides ??
+          staffList.find((s) => s.id === staffId)?.permissionOverrides ??
           {};
         const current = { ...base };
         if (setting === null) {
@@ -343,7 +410,7 @@ export function FacilityRbacProvider({
         };
       });
     },
-    [setStaffPermissionMutate],
+    [setStaffPermissionMutate, staffList],
   );
 
   const resetStaffOverrides = useCallback(
@@ -466,15 +533,25 @@ export function FacilityRbacProvider({
     setState((prev) => ({ ...prev, presetOverrides: {} }));
   }, [presetOverrides, setFacilityRolePermissionMutate]);
 
-  const setViewerId = useCallback((id: string) => {
-    setState((prev) => ({ ...prev, viewerId: id }));
-  }, []);
+  const setViewerId = useCallback(
+    (id: string) => {
+      // A no-op rather than a throw: callers render a switcher that is simply
+      // absent where switching is not allowed, and a stray call from a stale
+      // component must not break the page.
+      if (!canSwitch) return;
+      setState((prev) => ({ ...prev, viewerId: id }));
+    },
+    [canSwitch],
+  );
 
   const value = useMemo<RbacContextValue>(
     () => ({
       viewer,
       viewerId: state.viewerId,
       setViewerId,
+      canSwitchViewer: canSwitch,
+      viewerResolved,
+      staff: staffList,
       customRoles,
       presetOverrides,
       can,
@@ -494,6 +571,9 @@ export function FacilityRbacProvider({
     [
       viewer,
       state.viewerId,
+      canSwitch,
+      viewerResolved,
+      staffList,
       customRoles,
       presetOverrides,
       setViewerId,
@@ -531,6 +611,9 @@ export function useFacilityRbac(): RbacContextValue {
       viewer: owner,
       viewerId: owner.id,
       setViewerId: () => {},
+      canSwitchViewer: false,
+      viewerResolved: true,
+      staff: facilityStaff,
       customRoles: {},
       presetOverrides: {},
       can: () => true,
@@ -559,8 +642,24 @@ export function useFacilityRbac(): RbacContextValue {
 }
 
 export function useFacilityViewer() {
-  const { viewer, viewerId, setViewerId, can } = useFacilityRbac();
-  return { viewer, viewerId, setViewerId, can };
+  const {
+    viewer,
+    viewerId,
+    setViewerId,
+    canSwitchViewer,
+    viewerResolved,
+    staff,
+    can,
+  } = useFacilityRbac();
+  return {
+    viewer,
+    viewerId,
+    setViewerId,
+    canSwitchViewer,
+    viewerResolved,
+    staff,
+    can,
+  };
 }
 
 /**

--- a/tests/e2e/facility-identity.spec.ts
+++ b/tests/e2e/facility-identity.spec.ts
@@ -1,0 +1,105 @@
+import { test, expect, type Page } from "@playwright/test";
+
+// ============================================================================
+// The facility portal knows who you are.
+//
+// It did not. The groomer and staff portals resolve identity from the session;
+// this one mounted the RBAC provider with a hardcoded "fs-owner-01" and let
+// anyone change it from localStorage.
+//
+// Permissions stopped following that when they moved into Postgres, which made
+// the remaining bug quieter and arguably worse: a signed-in groomer saw the
+// OWNER's name, avatar and profile while holding a groomer's permissions.
+// Nothing looked broken.
+//
+// The last check is the one that matters — writing an id into localStorage and
+// confirming the portal ignores it.
+// ============================================================================
+
+const PASSWORD = "YipyyDev!2026";
+const STORAGE_KEY = "facility-rbac-state-v1";
+
+async function signIn(page: Page, email: string) {
+  await page.goto("/login");
+  await page.fill("#email", email);
+  await page.fill("#password", PASSWORD);
+  await page.getByRole("button", { name: /sign in/i }).click();
+  await expect
+    .poll(async () => (await page.request.get("/api/permissions")).status(), {
+      timeout: 30_000,
+    })
+    .toBe(200);
+}
+
+/**
+ * The "Signed in as … · Role" line the staff section renders, once the roster
+ * has arrived. The placeholder ("Signed in…") is deliberately excluded: reading
+ * it too early is how the first version of this test caught a real bug, and
+ * settling for it would hide the same bug next time.
+ */
+async function identityLine(page: Page): Promise<string> {
+  await page.goto("/facility/dashboard/staff");
+  const line = page.locator("text=/Signed in as|Viewing as/").first();
+  await expect(line).toBeVisible({ timeout: 30_000 });
+  await expect(line).not.toHaveText(/Signed in…/, { timeout: 30_000 });
+  return (await line.innerText()).replace(/\s+/g, " ").trim();
+}
+
+test.describe.configure({ mode: "serial" });
+
+test.describe("facility portal identity", () => {
+  test("each account is itself, not the owner", async ({ page }) => {
+    // Every one of these read "Émilie Laurent · Owner" before the bridge.
+    await signIn(page, "owner@yipyy.dev");
+    expect(await identityLine(page)).toContain("Dana Okafor");
+
+    await page.context().clearCookies();
+    await signIn(page, "groomer@yipyy.dev");
+    const groomer = await identityLine(page);
+    expect(groomer).toContain("Jessica Alvarez");
+    expect(groomer).toContain("Groomer");
+
+    await page.context().clearCookies();
+    await signIn(page, "manager@yipyy.dev");
+    expect(await identityLine(page)).toContain("Priya Raman");
+  });
+
+  test("the switcher is gone for a real staff member", async ({ page }) => {
+    await signIn(page, "groomer@yipyy.dev");
+    expect(await identityLine(page)).toContain("Signed in as");
+
+    // Not merely hidden — there is no combobox to click.
+    await expect(
+      page.locator("button[role='combobox']").filter({ hasText: /Alvarez/ }),
+    ).toHaveCount(0);
+  });
+
+  test("localStorage cannot change who you are", async ({ page }) => {
+    await signIn(page, "groomer@yipyy.dev");
+
+    // The exact attack the old provider allowed: name yourself the owner.
+    await page.evaluate(
+      ({ key, id }) => {
+        window.localStorage.setItem(
+          key,
+          JSON.stringify({
+            viewerId: id,
+            presetOverrides: {},
+            staffOverrides: {},
+          }),
+        );
+      },
+      { key: STORAGE_KEY, id: "fs-dev-owner" },
+    );
+
+    const after = await identityLine(page);
+    expect(after).toContain("Jessica Alvarez");
+    expect(after).not.toContain("Dana Okafor");
+
+    // And the permissions agree — manage_roles is owner/admin only.
+    const map = (await (
+      await page.request.get("/api/permissions")
+    ).json()) as Record<string, string>;
+    expect(map.manage_roles).toBe("none");
+  });
+});


### PR DESCRIPTION
## The facility portal never knew who you were

The groomer and staff portals resolve identity from the session. This one mounted the RBAC provider with a hardcoded `"fs-owner-01"` and let anyone change it from `localStorage`.

Permissions stopped following that when they moved into Postgres (#99), which made the remaining bug quieter and arguably worse than a privilege hole: a signed-in groomer saw **the owner's name, avatar and profile** while holding a groomer's permissions. Nothing looked broken.

```
owner@yipyy.dev    ->  Dana Okafor · Owner
groomer@yipyy.dev  ->  Jessica Alvarez · Groomer
manager@yipyy.dev  ->  Priya Raman · Manager
```

All three read *Émilie Laurent · Owner* before this.

## The blocker underneath

The provider resolved `viewer` from the **mock array**. So an id from a session — `fs-dev-groomer` — matched nothing, and `.find() ?? facilityStaff[0]` handed back a *colleague* rather than failing. Identity silently landing on the wrong person is worse than an error, because there is nothing to notice.

It now resolves against `staffQueries.profiles()`: Postgres rows when there is a session, the same mock array when there is not, so both kinds of id resolve in their own world. The "viewing as" dropdown lists that roster too — offering an id the provider cannot resolve is the same bug wearing a different hat.

## The switcher

`allowViewerSwitch` separates *who am I* from *may I pretend to be someone else*. Platform admins keep it, because reviewing a facility as one of its staff is what the tool is for. Everyone else is themselves, and the control renders who they are rather than a dropdown that ignores clicks.

Two nested `FacilityRbacProvider` mounts are gone — the staff layout and the staff profile view — because a nested provider shadows the real identity with a fresh default.

## A bug the first version of the test caught

The roster loads asynchronously, so on **first paint** the session id is absent and the fallback named a colleague. Correct a moment later, wrong in the meantime.

An earlier probe that waited 6 seconds missed this entirely. The test that asserted immediately did not. `viewerResolved` marks that window so UI draws a placeholder instead of a wrong name.

That fixes the visible symptom. **The complete fix is prefetching the roster on the server** so the first paint already has it — a follow-up, stated here rather than left implied.

## Verification

```
three accounts, three identities, correct roles
the switcher is absent for a real staff member (no combobox, not merely hidden)
writing "fs-dev-owner" into localStorage changes NOTHING, and manage_roles
  still resolves to "none"
```

That last one is the attack the old provider allowed, and it's the check that makes this real rather than cosmetic.

Swept 12 facility routes under `AUTH_ENFORCED=admin,facility` as owner, manager and groomer. Nothing broke that this change caused. Two things found, and **checked rather than assumed**:

- **A hydration mismatch** on `/facility/dashboard` (`SmartInsightsWidget`'s high-priority `Badge`). **Reproduced on `develop` when signed in** — so it predates this and is triggered by having a session, which is about to become mandatory. Worth its own fix.
- `/facility/dashboard/staff/tasks` redirects to `/tasks?tab=staff` for everyone. An intentional route move; my sweep raced it.

Full suite: **22 passed**. The two `staff-portal-nav` failures are the same ones reproduced at `de9b6099`, before any of this session's work.

## Enabling nothing

`.env.local` is gitignored. Setting `AUTH_ENFORCED=admin,facility` in the deployment environment remains a separate, deliberate act.
