### PR TITLE
fix(dashboard): stop the facility dashboard mismatching on hydration

### DIFF
--- a/src/components/facility/dashboard/SmartInsightsWidget.tsx
+++ b/src/components/facility/dashboard/SmartInsightsWidget.tsx
@@ -8,6 +8,7 @@ import { Sparkles, ArrowRight } from "lucide-react";
 import { Card } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { insightMutations, insightQueries } from "@/lib/api/smart-insights";
+import { useHydrated } from "@/hooks/use-hydrated";
 import type { Insight } from "@/types/smart-insights";
 import { InsightCardCompact } from "@/components/smart-insights/InsightCardCompact";
 import { InsightActionDrawer } from "@/components/smart-insights/drawer/InsightActionDrawer";
@@ -23,6 +24,24 @@ const UNDO_WINDOW_MS = 10_000;
  */
 export function SmartInsightsWidget() {
   const [drawerInsight, setDrawerInsight] = useState<Insight | null>(null);
+
+  // Insight state is CLIENT-ONLY by construction: resolveAll() folds in
+  // dismissals, snoozes and settings from localStorage (lib/smart-insights/
+  // storage.ts), which the server cannot see and never will while that is
+  // where the state lives.
+  //
+  // So the server always renders "no insights, no badge" and the client
+  // renders whatever this browser knows — a hydration mismatch on every load
+  // of the facility dashboard by anyone whose browser has insight state.
+  // React then throws away and re-renders the whole subtree.
+  //
+  // It was invisible because it needs a session to reach this dashboard, and
+  // almost nobody signed in. Enforcement changes that.
+  //
+  // `useHydrated` is false during SSR *and* during the hydration render, and
+  // true only afterwards, so the two passes agree by construction. Prefetching
+  // on the server is not an alternative here — the data does not exist there.
+  const hydrated = useHydrated();
 
   const queryClient = useQueryClient();
   const top3Query = useQuery(insightQueries.dashboardTop3(FACILITY_ID));
@@ -68,8 +87,12 @@ export function SmartInsightsWidget() {
     );
   };
 
-  const insights = top3Query.data ?? [];
-  const highPriorityCount = highPriorityQuery.data ?? 0;
+  // Both derive from the same client-only source, so both wait for hydration.
+  // Gating only the badge would move the mismatch into the list below rather
+  // than remove it — React reports the first difference it finds, not all of
+  // them.
+  const insights = hydrated ? (top3Query.data ?? []) : [];
+  const highPriorityCount = hydrated ? (highPriorityQuery.data ?? 0) : 0;
 
   return (
     <Card className="space-y-4 p-5">
@@ -92,7 +115,7 @@ export function SmartInsightsWidget() {
         </Link>
       </div>
 
-      {top3Query.isLoading ? (
+      {!hydrated || top3Query.isLoading ? (
         <p className="text-muted-foreground py-4 text-center text-xs">
           Loading…
         </p>

--- a/src/hooks/use-db-permissions.ts
+++ b/src/hooks/use-db-permissions.ts
@@ -2,6 +2,8 @@
 
 import { useQuery } from "@tanstack/react-query";
 
+import { useHydrated } from "@/hooks/use-hydrated";
+
 import type {
   AccessScope,
   EffectivePermissions,
@@ -51,10 +53,34 @@ export const permissionQueries = {
 /**
  * The database's answer, or `null` when there is no session / it has not
  * arrived yet. Callers treat `null` as "use the legacy path".
+ *
+ * WHY THE HYDRATION GATE — and what it is and is not evidence of.
+ *
+ * The server has no answer here: this reads a browser fetch. So SSR always
+ * renders the legacy fallback, which resolves against the mock roster and is
+ * effectively OWNER defaults. If the client used the real map during the
+ * HYDRATION render, the two passes would disagree for everyone who is not that
+ * mock owner — a latent mismatch behind every permission-gated control.
+ *
+ * `useHydrated` is false during SSR and during hydration, true after, so both
+ * passes take the legacy path and the database's answer applies from the first
+ * render that cannot contradict server HTML.
+ *
+ * HONESTLY: this closes the possibility structurally. It is NOT a fix for a
+ * reproduction. A mismatch was observed once on the staff page under a loaded
+ * test run, and could not be reproduced afterwards with or without this gate —
+ * so whatever triggered that specific one is not established. Do not read this
+ * comment as "the staff-page bug is fixed".
+ *
+ * The real fix is resolving permissions on the SERVER, which it is perfectly
+ * able to do — it holds the session — and passing them into the tree. That
+ * removes the fallback, the legacy cascade beneath it, and the flash of
+ * owner-shaped UI that this gate preserves.
  */
 export function useDbPermissions(): EffectivePermissions | null {
+  const hydrated = useHydrated();
   const { data } = useQuery(permissionQueries.mine());
-  if (!data) return null;
+  if (!hydrated || !data) return null;
 
   // 'none' is how the database says "not granted"; the client type says
   // `false`. Translated here so no consumer has to know both spellings.

--- a/tests/e2e/hydration.spec.ts
+++ b/tests/e2e/hydration.spec.ts
@@ -1,0 +1,101 @@
+import {
+  test,
+  expect,
+  type Browser,
+  type BrowserContext,
+  type Page,
+} from "@playwright/test";
+
+// ============================================================================
+// No hydration mismatches on the surfaces a signed-in person lands on.
+//
+// The bug that prompted this: the smart-insights widget. Its state
+// (dismissals, snoozes, settings) lives in localStorage, so the server rendered
+// "no insights, no badge" and the client rendered whatever this browser knew.
+// Reproducible on every load, and this test fails without the fix — checked by
+// reverting it.
+//
+// A SECOND mismatch was seen once, on the staff page, under a loaded suite run.
+// It has not been reproduced since. This test does NOT currently catch it, and
+// saying otherwise would be worse than not having the test: if it reappears,
+// this file is where the reproduction belongs.
+//
+// TWO THINGS THIS TEST DOES DELIBERATELY, both learned from nearly missing the
+// first bug:
+//
+//   • A FRESH TAB per route. A mismatch only happens during hydration, so a
+//     client-side navigation from another page never exercises it — the test
+//     would pass while the bug shipped.
+//
+//   • It signs in as a GROOMER, not an admin. A platform admin holds every
+//     permission, which is what the server's SSR fallback already assumes, so
+//     permission-shaped mismatches would agree by accident and stay hidden.
+// ============================================================================
+
+const PASSWORD = "YipyyDev!2026";
+
+const FACILITY_ROUTES = [
+  "/facility/dashboard",
+  "/facility/dashboard/insights",
+  "/facility/dashboard/staff",
+  "/facility/dashboard/settings",
+];
+
+async function signIn(page: Page, email: string) {
+  await page.goto("/login");
+  await page.fill("#email", email);
+  await page.fill("#password", PASSWORD);
+  await page.getByRole("button", { name: /sign in/i }).click();
+  await expect
+    .poll(async () => (await page.request.get("/api/permissions")).status(), {
+      timeout: 30_000,
+    })
+    .toBe(200);
+}
+
+/** Sign in, then drop the warm JS context so each route is a first arrival. */
+async function sessionFor(
+  browser: Browser,
+  email: string,
+): Promise<BrowserContext> {
+  const ctx = await browser.newContext();
+  const page = await ctx.newPage();
+  await signIn(page, email);
+  await page.close();
+  return ctx;
+}
+
+async function hydrationErrors(ctx: BrowserContext, route: string) {
+  const page = await ctx.newPage();
+  const errors: string[] = [];
+  page.on("pageerror", (e) => {
+    if (e.message.includes("Hydration")) errors.push(e.message.slice(0, 100));
+  });
+  await page.goto(route, { waitUntil: "domcontentloaded" });
+  await page.waitForTimeout(4500);
+  await page.close();
+  return errors;
+}
+
+test("the facility portal hydrates cleanly for a non-owner", async ({
+  browser,
+}) => {
+  test.setTimeout(600_000);
+  const ctx = await sessionFor(browser, "groomer@yipyy.dev");
+  for (const route of FACILITY_ROUTES) {
+    expect(await hydrationErrors(ctx, route), `hydration on ${route}`).toEqual(
+      [],
+    );
+  }
+  await ctx.close();
+});
+
+test("the platform portal hydrates cleanly", async ({ browser }) => {
+  test.setTimeout(600_000);
+  const ctx = await sessionFor(browser, "admin@yipyy.dev");
+  expect(
+    await hydrationErrors(ctx, "/dashboard"),
+    "hydration on /dashboard",
+  ).toEqual([]);
+  await ctx.close();
+});


### PR DESCRIPTION
## The bug

The facility dashboard threw a hydration error on **every signed-in load**, and React responded by discarding and re-rendering the whole widget subtree.

Smart-insight state — dismissals, snoozes, settings — lives in `localStorage` ([storage.ts](src/lib/smart-insights/storage.ts)), so `resolveAll()` is **client-only by construction**. The server always computed "no insights, no badge"; the client computed whatever that browser knew.

Confirmed by stamping the server's own value into the HTML rather than inferring it:

```
SERVER stamp:  server|pending|undefined
SERVER has-High-badge:  false
CLIENT first render:  status=success data=14
```

Prefetching on the server isn't the alternative — **the data does not exist there**. `useHydrated` (already in the repo) is false during SSR *and* during the hydration render, true afterwards, so both passes agree by construction.

The insights list is gated as well as the badge. Gating only the badge would have moved the mismatch into the list rather than removed it: React reports the first difference it finds, not all of them.

## Why nobody had seen it

Reaching this dashboard needs a session, and almost nobody signs in. It surfaced only because the enforcement sweep started signing in — and it would have become universal the moment `AUTH_ENFORCED` goes on.

## A second mismatch — found, and NOT fixed

A different one appeared once on `/facility/dashboard/staff` (a "Manage departments" button the server rendered and the client did not) during a loaded 10-minute suite run. **It has not reproduced since** — not on the fresh-tab path, and not on the warm-navigation path that originally showed it.

`useDbPermissions` now takes the same hydration gate, because the mismatch it allows is *structural*: the server cannot know session permissions, so it renders owner-shaped defaults, and any client holding the real map mid-hydration would disagree. That closes the possibility.

It is **not** evidence that the observed staff-page mismatch is fixed. I reverted the gate and re-ran both paths — no change either way. The comment in that file says so, rather than implying a fix I can't demonstrate.

## The guard

`tests/e2e/hydration.spec.ts`, **verified by reverting the widget fix and watching it fail**. Two deliberate choices, both from nearly missing the bug myself:

- **A fresh tab per route.** A mismatch only happens during hydration, so a client-side navigation never exercises it — the test would pass while the bug shipped.
- **Signed in as a groomer, not an admin.** An admin holds every permission, which is what the server's fallback already assumes, so permission-shaped mismatches would agree by accident and stay hidden.

The spec states plainly that it does not currently catch the staff-page one. If that reappears, the file is where the reproduction belongs.

## Suite

**20 passed.** Four failures, all investigated rather than waved off:

- 2 × `staff-portal-nav` — predate this session, reproduced at `de9b6099`
- 2 × flakes under the loaded run (a sign-in returning 401 for 30s; a 120s click timeout) — both pass in isolation

## Follow-up worth naming

The real fix for permission-shaped mismatches is **resolving permissions on the server**, which it is perfectly able to do — it holds the session. That removes the fallback, the legacy cascade beneath it, and the flash of owner-shaped UI this gate preserves.
