### PR TITLE
release: stop /api/staff handing out payroll and clock-in codes

### DIFF
--- a/docs/quality/debt-map.md
+++ b/docs/quality/debt-map.md
@@ -69,6 +69,18 @@ The document builders (`src/lib/quickbooks/documents/`) and their enqueue points
 
 ---
 
+## Snapshot (2026-08-02, staff field exposure)
+
+### 🟡 The staff screens still read the mock array, so the redaction is API-only
+
+`/api/staff` now trims payroll, HR notes, the clock-in access code, `statusNote` and `permissionOverrides` for callers without `view_payroll` / `manage_staff` / `view_staff_permissions` (`redactStaffProfile`, proven by `tests/e2e/staff-field-exposure.spec.ts`). But `src/app/facility/dashboard/staff/page.tsx` still does `useState(facilityStaff)` — the mock array, imported directly — so **no staff screen consumes the redacted response today.** The one real consumer is `use-facility-rbac.tsx`.
+
+**Why it matters:** the leak that mattered is closed (anyone signed in could `curl /api/staff` and read a colleague's salary), but the "Hidden — requires …" notices in `staff-form-sections.tsx`, `access-tab.tsx` and `staff-profile-sheet.tsx` are **unreachable in the running app** — verified by driving the editor as a manager with `view_payroll` revoked: the API withheld the figures, the screen rendered mock ones. Treat those notices as staged for the migration, not as something currently observed working.
+
+**Do instead:** when moving the staff page onto `staffQueries.profiles()`, do **not** paper over the now-optional fields with `?? 0` / `?? {}` / `?? ""`. Absent means withheld. A zeroed default renders "$0/hr" as a fact, and — because the editor's draft is what Save writes back — an editable blank silently overwrites the real value with nothing. The guards that refuse to render in that state are the point of them.
+
+---
+
 ## How to add to this map
 
 Append under a new dated heading. For each item: a one-line description, a severity, **why it's risky**, and **what to do instead** of casually touching it. Don't delete items — strike them through with the date and PR when genuinely resolved.

--- a/src/app/api/staff/route.ts
+++ b/src/app/api/staff/route.ts
@@ -1,20 +1,29 @@
 import { NextResponse } from "next/server";
 
 import { createServerClient, getCurrentUser } from "@/lib/supabase/server";
-import { STAFF_SELECT, rowToStaffProfile } from "@/lib/api/mappers/staff";
+import { holds, myPermissions } from "@/lib/auth/permissions";
+import {
+  STAFF_SELECT,
+  redactStaffProfile,
+  rowToStaffProfile,
+} from "@/lib/api/mappers/staff";
 
 // ============================================================================
 // Staff at the caller's facility.
 //
-// RLS decides what comes back: anyone with a membership can see their
+// RLS decides WHICH ROWS come back: anyone with a membership can see their
 // colleagues, because rotas, calendars and handovers are unusable otherwise.
-// Being able to see that a groomer exists is not the sensitive part — payroll
-// and permission overrides are, and those ride along in `details`.
+// Being able to see that a groomer exists is not the sensitive part — payroll,
+// HR notes, the clock-in code and the permission overrides are, and those ride
+// along in `details`.
 //
-// That is a gap worth naming rather than leaving implied: this route returns
-// the whole row to anyone who can read it. Splitting the sensitive tail behind
-// `view_staff_performance` / `view_staff_permissions` is the follow-up, and it
-// belongs here in the route, since RLS gates rows and not columns.
+// RLS cannot help with that. It gates rows, not columns, so a policy that lets
+// you see a colleague lets you see every column of them. Column-level access
+// has to be decided above the database, which is here.
+//
+// The permissions used are the DATABASE's answer (`my_permissions()`), not the
+// client's opinion of itself — the same map /api/permissions returns, resolved
+// server-side where it can decide what leaves rather than what gets drawn.
 // ============================================================================
 
 export const dynamic = "force-dynamic";
@@ -27,14 +36,34 @@ export async function GET() {
 
   const supabase = await createServerClient();
 
-  const { data, error } = await supabase
-    .from("staff")
-    .select(STAFF_SELECT)
-    .order("legacy_id");
+  const [{ data, error }, permissions] = await Promise.all([
+    supabase.from("staff").select(STAFF_SELECT).order("legacy_id"),
+    myPermissions(),
+  ]);
 
   if (error) {
     return NextResponse.json({ error: error.message }, { status: 500 });
   }
 
-  return NextResponse.json(data.map(rowToStaffProfile));
+  const grants = {
+    payroll: holds(permissions, "view_payroll"),
+    permissions: holds(permissions, "view_staff_permissions"),
+    hr: holds(permissions, "manage_staff"),
+  };
+
+  // Which row is the caller's own. Matched on the VERIFIED session email, the
+  // same bridge lib/auth/legacy-identity.ts uses. Lowercased both sides
+  // because the staff table does not constrain case and a mismatch here fails
+  // in the safe direction — you would be redacted from your own record, which
+  // is confusing but not a leak.
+  const email = user.email?.trim().toLowerCase();
+
+  const profiles = data.map((row) => {
+    const profile = rowToStaffProfile(row);
+    const isSelf =
+      email != null && profile.email?.trim().toLowerCase() === email;
+    return redactStaffProfile(profile, grants, isSelf);
+  });
+
+  return NextResponse.json(profiles);
 }

--- a/src/app/facility/dashboard/staff/_components/access-tab.tsx
+++ b/src/app/facility/dashboard/staff/_components/access-tab.tsx
@@ -324,26 +324,45 @@ function PermissionsSection({
   resolveFor: (p: StaffProfile, k: PermissionKey) => PermissionSetting;
   customRoleLabels: Record<string, string>;
 }) {
+  // The per-person overrides are withheld without `view_staff_permissions`.
+  // Nothing below can be shown honestly without them — the resolved column
+  // would silently omit whatever an override changes — and editing would be
+  // destructive, since a save writes back only the overrides in hand and drops
+  // the rest.
+  const overrides = profile.permissionOverrides;
+
   const rows = useMemo(() => {
     return PERMISSION_GROUPS.map((g) => ({
       ...g,
       permissions: g.permissions.map((p) => {
         const resolved = resolveFor(profile, p.key);
-        const override = profile.permissionOverrides[p.key];
+        const override = overrides?.[p.key];
         return { ...p, resolved, override };
       }),
     }));
-  }, [profile, resolveFor]);
+  }, [profile, overrides, resolveFor]);
 
   const totalGranted = rows.reduce(
     (n, g) => n + g.permissions.filter((p) => p.resolved.granted).length,
     0,
   );
-  const overrideCount = Object.keys(profile.permissionOverrides).length;
+
+  if (!overrides) {
+    return (
+      <div className="text-muted-foreground rounded-md border border-dashed p-6 text-center text-sm">
+        Permissions are hidden.
+        <div className="mt-1 text-xs">
+          Requires the “View staff permissions” permission.
+        </div>
+      </div>
+    );
+  }
+
+  const overrideCount = Object.keys(overrides).length;
 
   function applyScope(key: PermissionKey, next: AccessScope | "reset") {
     if (!onUpdate) return;
-    const nextOverrides = { ...profile.permissionOverrides };
+    const nextOverrides = { ...overrides };
     if (next === "reset") {
       delete nextOverrides[key];
     } else if (next === "none") {

--- a/src/app/facility/dashboard/staff/_components/staff-form-sections.tsx
+++ b/src/app/facility/dashboard/staff/_components/staff-form-sections.tsx
@@ -248,17 +248,21 @@ export function ProfileSection({
         label="Internal notes"
         hint="Visible to managers and owners only."
       >
-        <Textarea
-          rows={3}
-          value={draft.employment.notes}
-          onChange={(e) =>
-            update("employment", {
-              ...draft.employment,
-              notes: e.target.value,
-            })
-          }
-          placeholder="e.g. Overnight shifts only, handles hand stripping."
-        />
+        {draft.employment.notes === undefined ? (
+          <WithheldNotice permission="Manage staff" />
+        ) : (
+          <Textarea
+            rows={3}
+            value={draft.employment.notes}
+            onChange={(e) =>
+              update("employment", {
+                ...draft.employment,
+                notes: e.target.value,
+              })
+            }
+            placeholder="e.g. Overnight shifts only, handles hand stripping."
+          />
+        )}
       </FieldRow>
     </div>
   );
@@ -581,6 +585,10 @@ export function AccessSection({
     key: PermissionKey,
     next: { granted: boolean; scope: AccessScope },
   ) {
+    // Withheld — the controls are hidden, but refuse here too. Writing back a
+    // map built from nothing would delete every override this caller was not
+    // allowed to see.
+    if (!draft.permissionOverrides) return;
     const overrides = { ...draft.permissionOverrides };
     const resolved = resolvePermission(
       { ...draft, permissionOverrides: {} },
@@ -668,19 +676,26 @@ export function AccessSection({
           {draft.clockIn.requireAccessCode && (
             <div className="mt-2">
               <FieldRow label="4-digit code">
-                <Input
-                  inputMode="numeric"
-                  maxLength={6}
-                  value={draft.clockIn.accessCode ?? ""}
-                  onChange={(e) =>
-                    update("clockIn", {
-                      requireAccessCode: true,
-                      accessCode: e.target.value,
-                    })
-                  }
-                  placeholder="4421"
-                  className="max-w-[120px] font-mono"
-                />
+                {draft.clockIn.accessCode === undefined ? (
+                  // A code is required but was not sent — withheld, not blank.
+                  // An empty box would look like "no code set" and saving it
+                  // would replace this person's real code with nothing.
+                  <WithheldNotice permission="Manage staff" />
+                ) : (
+                  <Input
+                    inputMode="numeric"
+                    maxLength={6}
+                    value={draft.clockIn.accessCode}
+                    onChange={(e) =>
+                      update("clockIn", {
+                        requireAccessCode: true,
+                        accessCode: e.target.value,
+                      })
+                    }
+                    placeholder="4421"
+                    className="max-w-[120px] font-mono"
+                  />
+                )}
               </FieldRow>
             </div>
           )}
@@ -694,7 +709,12 @@ export function AccessSection({
           title="Permission overrides"
           hint="Fine-grained per-permission. Scope controls when access is active."
         />
-        <div className="mt-2 space-y-4">
+        {!draft.permissionOverrides && (
+          <div className="mt-2">
+            <WithheldNotice permission="View staff permissions" />
+          </div>
+        )}
+        <div className="mt-2 space-y-4" hidden={!draft.permissionOverrides}>
           {groupedPerms.map((g) => (
             <div
               key={g.id}
@@ -745,7 +765,7 @@ export function AccessSection({
                             <SelectItem value="none">No access</SelectItem>
                           </SelectContent>
                         </Select>
-                        {draft.permissionOverrides[p.key] && (
+                        {draft.permissionOverrides?.[p.key] && (
                           <span className="inline-flex items-center gap-1 text-[10px] font-medium text-amber-600 dark:text-amber-400">
                             <Sparkles className="size-3" />
                             override
@@ -859,6 +879,25 @@ export function PayrollSection({
   draft: StaffProfile;
   update: SectionUpdate;
 }) {
+  // No inputs at all when the figures were withheld.
+  //
+  // Rendering them with zeroes would be worse than useless: the draft is what
+  // Save writes back, so an editor without `view_payroll` would silently reset
+  // this person's real hourly rate and commission to nothing. Absent has to
+  // stay absent all the way through the form.
+  const payroll = draft.payroll;
+  if (!payroll) {
+    return (
+      <div className="space-y-5">
+        <SectionHeader
+          title="Compensation"
+          hint="Drives payroll reports and commission tracking."
+        />
+        <WithheldNotice permission="View payroll" />
+      </div>
+    );
+  }
+
   return (
     <div className="space-y-5">
       <SectionHeader
@@ -871,10 +910,10 @@ export function PayrollSection({
             type="number"
             min={0}
             max={100}
-            value={draft.payroll.generalServiceCommission}
+            value={payroll.generalServiceCommission}
             onChange={(e) =>
               update("payroll", {
-                ...draft.payroll,
+                ...payroll,
                 generalServiceCommission: Number(e.target.value),
               })
             }
@@ -884,10 +923,10 @@ export function PayrollSection({
           <Input
             type="number"
             min={0}
-            value={draft.payroll.hourlyRate}
+            value={payroll.hourlyRate}
             onChange={(e) =>
               update("payroll", {
-                ...draft.payroll,
+                ...payroll,
                 hourlyRate: Number(e.target.value),
               })
             }
@@ -898,10 +937,10 @@ export function PayrollSection({
             type="number"
             min={0}
             max={100}
-            value={draft.payroll.tipsRate}
+            value={payroll.tipsRate}
             onChange={(e) =>
               update("payroll", {
-                ...draft.payroll,
+                ...payroll,
                 tipsRate: Number(e.target.value),
               })
             }
@@ -923,6 +962,22 @@ export function PayrollSection({
 // ============================================================================
 // Shared field helpers
 // ============================================================================
+
+/**
+ * Stands in for a field the server did not send.
+ *
+ * Says WITHHELD rather than showing an empty control, because an empty control
+ * is both a lie ("there is nothing here") and a hazard — the draft is what
+ * Save writes back, so an editable blank would overwrite the real value with
+ * nothing.
+ */
+export function WithheldNotice({ permission }: { permission: string }) {
+  return (
+    <div className="text-muted-foreground border-border/60 rounded-lg border border-dashed px-3 py-2.5 text-xs">
+      Hidden — requires the “{permission}” permission.
+    </div>
+  );
+}
 
 export function SectionHeader({
   title,

--- a/src/app/facility/dashboard/staff/_components/staff-profile-sheet.tsx
+++ b/src/app/facility/dashboard/staff/_components/staff-profile-sheet.tsx
@@ -528,6 +528,21 @@ function NotificationsTab({ profile }: { profile: StaffProfile }) {
 }
 
 function PayrollTab({ profile }: { profile: StaffProfile }) {
+  // Withheld, not empty. The server drops `payroll` for anyone without
+  // `view_payroll` on someone else's record, and "—" in the cards below would
+  // read as "unpaid" rather than "not yours to see".
+  const payroll = profile.payroll;
+  if (!payroll) {
+    return (
+      <div className="text-muted-foreground rounded-md border border-dashed p-6 text-center text-sm">
+        Pay details are hidden.
+        <div className="mt-1 text-xs">
+          Requires the “View payroll” permission.
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className="space-y-4">
       <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
@@ -535,8 +550,8 @@ function PayrollTab({ profile }: { profile: StaffProfile }) {
           icon={Wallet}
           label="Service commission"
           value={
-            profile.payroll.generalServiceCommission > 0
-              ? `${profile.payroll.generalServiceCommission}%`
+            payroll.generalServiceCommission > 0
+              ? `${payroll.generalServiceCommission}%`
               : "—"
           }
           sub="On collected service + add-on revenue"
@@ -544,30 +559,26 @@ function PayrollTab({ profile }: { profile: StaffProfile }) {
         <PayCard
           icon={Clock}
           label="Hourly rate"
-          value={
-            profile.payroll.hourlyRate > 0
-              ? `$${profile.payroll.hourlyRate}/hr`
-              : "—"
-          }
+          value={payroll.hourlyRate > 0 ? `$${payroll.hourlyRate}/hr` : "—"}
           sub="Calculated from clock in/out"
         />
         <PayCard
           icon={BadgeCheck}
           label="Tips"
           value={
-            profile.payroll.tipsRate > 0
-              ? `${profile.payroll.tipsRate}% retained`
+            payroll.tipsRate > 0
+              ? `${payroll.tipsRate}% retained`
               : "No tips collected"
           }
           sub="From assigned appointments"
         />
       </div>
 
-      {profile.payroll.overrides.length > 0 && (
+      {payroll.overrides.length > 0 && (
         <div>
           <div className="mb-2 text-sm font-semibold">Service overrides</div>
           <div className="space-y-1.5">
-            {profile.payroll.overrides.map((o) => (
+            {payroll.overrides.map((o) => (
               <div
                 key={o.serviceModule}
                 className="border-border/60 flex items-center justify-between rounded-md border px-3 py-2 text-sm"

--- a/src/app/facility/dashboard/staff/_components/staff-roles-tab.tsx
+++ b/src/app/facility/dashboard/staff/_components/staff-roles-tab.tsx
@@ -36,7 +36,10 @@ export function StaffRolesTab({
   const grantedCount = Object.values(effective).filter(
     (v) => v !== false,
   ).length;
-  const overrideCount = Object.keys(draft.permissionOverrides).length;
+  // 0 when withheld, which reads as "no overrides mentioned" rather than a
+  // wrong count — the badge is hidden at 0. The Access tab is where the real
+  // "hidden" message lives.
+  const overrideCount = Object.keys(draft.permissionOverrides ?? {}).length;
 
   return (
     <div className="space-y-6">

--- a/src/lib/api/mappers/staff.ts
+++ b/src/lib/api/mappers/staff.ts
@@ -46,3 +46,69 @@ export function rowToStaffProfile(row: StaffRow): StaffProfileWithRowId {
 }
 
 export const STAFF_SELECT = `*` as const;
+
+// ============================================================================
+// Redaction — because RLS gates rows, not columns.
+//
+// Every staff member can read their colleagues' rows, and that is deliberate:
+// rotas, calendars and handovers are unusable otherwise. Being able to see
+// that a groomer exists is not the sensitive part. What rides along in
+// `details` is: what they are paid, the free-text HR notes about them, the
+// code they clock in with, and the individual permission grants that describe
+// how the facility's access control is put together.
+//
+// So the row is the right unit for the database and the wrong unit for the
+// response. This trims the response to what the caller may see.
+//
+// TWO RULES SHAPE ALL OF IT:
+//
+//   • You always see your OWN record in full. Your pay is yours; your clock-in
+//     code is one you type in yourself. Withholding it would be theatre.
+//
+//   • Withheld means ABSENT, never zeroed. A `hourlyRate: 0` in the response
+//     is indistinguishable from an unpaid volunteer, and the UI would render
+//     "$0/hr" as fact. `undefined` is the only value that cannot be mistaken
+//     for an answer, which is why the fields below are optional in the type.
+// ============================================================================
+
+export interface StaffFieldGrants {
+  /** `view_payroll` — commission, hourly rate, tips. */
+  payroll: boolean;
+  /** `view_staff_permissions` — the per-person permission overrides. */
+  permissions: boolean;
+  /** `manage_staff` — HR notes, status notes, and the clock-in access code. */
+  hr: boolean;
+}
+
+/**
+ * A colleague's profile, trimmed to what `grants` allows.
+ *
+ * `isSelf` short-circuits everything: it is your own record.
+ */
+export function redactStaffProfile<T extends StaffProfile>(
+  profile: T,
+  grants: StaffFieldGrants,
+  isSelf: boolean,
+): T {
+  if (isSelf) return profile;
+
+  const out = { ...profile };
+
+  if (!grants.payroll) delete out.payroll;
+  if (!grants.permissions) delete out.permissionOverrides;
+
+  if (!grants.hr) {
+    // Free text written ABOUT this person by a manager — the termination note
+    // especially. Never a directory field.
+    delete out.statusNote;
+    if (out.employment)
+      out.employment = { ...out.employment, notes: undefined };
+    // Whether a code is required is roster information and stays. The code
+    // itself is a shared secret that clocks this person in.
+    if (out.clockIn?.accessCode) {
+      out.clockIn = { ...out.clockIn, accessCode: undefined };
+    }
+  }
+
+  return out;
+}

--- a/src/lib/auth/permissions.ts
+++ b/src/lib/auth/permissions.ts
@@ -1,0 +1,53 @@
+import "server-only";
+
+import { createServerClient } from "@/lib/supabase/server";
+import type { AccessScope, PermissionKey } from "@/types/facility-staff";
+
+// ============================================================================
+// The caller's permissions, on the SERVER, from the database.
+//
+// /api/permissions already hands this map to the browser so it can draw the
+// right controls. This is the same map resolved server-side, where it can
+// decide what leaves the building rather than what gets rendered.
+//
+// The distinction matters for route handlers: RLS gates ROWS, not COLUMNS. It
+// can say "you may read your colleague" — which is correct, rotas need it —
+// but it cannot say "and not the salary column". Anything column-level has to
+// be enforced above it, which means here.
+// ============================================================================
+
+export type PermissionMap = Partial<Record<PermissionKey, AccessScope>>;
+
+/**
+ * Every permission the database grants the caller, keyed by permission.
+ *
+ * `my_permissions()` returns a row for EVERY key, using the scope `'none'` to
+ * mean "not granted" — so a missing key means the RPC failed or there is no
+ * session, and an explicit `'none'` means denied. Both read as "no" through
+ * `holds`, which is what callers want; the difference only matters if you are
+ * debugging why a map is empty.
+ */
+export async function myPermissions(): Promise<PermissionMap> {
+  const supabase = await createServerClient();
+  const { data, error } = await supabase.rpc("my_permissions");
+  if (error || !data) return {};
+
+  const map: PermissionMap = {};
+  for (const row of data) {
+    map[row.permission_key as PermissionKey] = row.scope;
+  }
+  return map;
+}
+
+/**
+ * Whether the caller holds `key` at all.
+ *
+ * Deliberately ignores WHICH scope. Scope answers "over whose records" —
+ * assigned shifts, operating hours, anytime — and the row-level part of that
+ * is RLS's job. Here the question is only whether a column may be seen, so any
+ * scope other than 'none' is a yes.
+ */
+export function holds(map: PermissionMap, key: PermissionKey): boolean {
+  const scope = map[key];
+  return scope != null && scope !== "none";
+}

--- a/src/lib/staff-audit.ts
+++ b/src/lib/staff-audit.ts
@@ -354,34 +354,40 @@ export function diffProfile(
   );
   push("Hire date", prev.employment.hireDate, next.employment.hireDate);
 
-  // Payroll
-  if (prev.payroll.hourlyRate !== next.payroll.hourlyRate) {
-    push(
-      "Hourly rate",
-      prev.payroll.hourlyRate > 0 ? `$${prev.payroll.hourlyRate}/hr` : "—",
-      next.payroll.hourlyRate > 0 ? `$${next.payroll.hourlyRate}/hr` : "—",
-    );
-  }
-  if (
-    prev.payroll.generalServiceCommission !==
-    next.payroll.generalServiceCommission
-  ) {
-    push(
-      "Service commission",
-      prev.payroll.generalServiceCommission > 0
-        ? `${prev.payroll.generalServiceCommission}%`
-        : "—",
-      next.payroll.generalServiceCommission > 0
-        ? `${next.payroll.generalServiceCommission}%`
-        : "—",
-    );
-  }
-  if (prev.payroll.tipsRate !== next.payroll.tipsRate) {
-    push(
-      "Tips rate",
-      prev.payroll.tipsRate > 0 ? `${prev.payroll.tipsRate}% retained` : "None",
-      next.payroll.tipsRate > 0 ? `${next.payroll.tipsRate}% retained` : "None",
-    );
+  // Payroll — only when BOTH sides carry it.
+  //
+  // `payroll` is absent when the caller lacks `view_payroll`, so a one-sided
+  // comparison would read as a change from nothing to something and write an
+  // audit entry disclosing the very figure that was withheld. Someone without
+  // the permission cannot edit these fields either, so skipping loses nothing.
+  const prevPay = prev.payroll;
+  const nextPay = next.payroll;
+  if (prevPay && nextPay) {
+    if (prevPay.hourlyRate !== nextPay.hourlyRate) {
+      push(
+        "Hourly rate",
+        prevPay.hourlyRate > 0 ? `$${prevPay.hourlyRate}/hr` : "—",
+        nextPay.hourlyRate > 0 ? `$${nextPay.hourlyRate}/hr` : "—",
+      );
+    }
+    if (prevPay.generalServiceCommission !== nextPay.generalServiceCommission) {
+      push(
+        "Service commission",
+        prevPay.generalServiceCommission > 0
+          ? `${prevPay.generalServiceCommission}%`
+          : "—",
+        nextPay.generalServiceCommission > 0
+          ? `${nextPay.generalServiceCommission}%`
+          : "—",
+      );
+    }
+    if (prevPay.tipsRate !== nextPay.tipsRate) {
+      push(
+        "Tips rate",
+        prevPay.tipsRate > 0 ? `${prevPay.tipsRate}% retained` : "None",
+        nextPay.tipsRate > 0 ? `${nextPay.tipsRate}% retained` : "None",
+      );
+    }
   }
 
   return changes;

--- a/src/types/facility-staff.ts
+++ b/src/types/facility-staff.ts
@@ -262,7 +262,11 @@ export interface EmploymentDetails {
   /** A configured employment-type value (StaffHrConfig.employmentTypes). Left as
    *  a string so the facility can add custom types (e.g. volunteer, intern). */
   employmentType: string;
-  notes: string;
+  /** Free-text HR notes. `undefined` means WITHHELD — the caller lacks
+   *  `manage_staff` on someone else's record. `""` means there are none.
+   *  Do not collapse the two: "no notes" and "notes you may not read" look the
+   *  same on screen and are not the same thing. */
+  notes?: string;
 }
 
 export interface ClockInSettings {
@@ -289,9 +293,13 @@ export interface StaffProfile {
   showOnCalendar: boolean;
   calendarAccess: CalendarAccess;
   clockIn: ClockInSettings;
-  permissionOverrides: Partial<Record<PermissionKey, PermissionSetting>>;
+  /** `undefined` means WITHHELD (no `view_staff_permissions` on someone
+   *  else's record) — distinct from `{}`, which means "no overrides set". */
+  permissionOverrides?: Partial<Record<PermissionKey, PermissionSetting>>;
   notifications: Record<NotificationEvent, NotificationScope>;
-  payroll: PayrollConfig;
+  /** `undefined` means WITHHELD (no `view_payroll` on someone else's record).
+   *  Never fall back to zeroes: `$0/hr` renders as a fact about their pay. */
+  payroll?: PayrollConfig;
   employment: EmploymentDetails;
   status: "active" | "invited" | "inactive" | "terminated";
   /** ISO timestamp of the last status change */
@@ -1649,9 +1657,14 @@ export function resolvePermission(
   key: PermissionKey,
   ctx: ResolvePermissionContext = {},
 ): PermissionSetting {
-  if (staff.permissionOverrides[key]) {
-    return staff.permissionOverrides[key]!;
-  }
+  // Absent overrides mean WITHHELD, not "none set" — the caller lacks
+  // `view_staff_permissions` on this person. The cascade then resolves from
+  // roles alone, which under-reports: it can say "denied" where an override
+  // grants. That is the safe direction for drawing UI, and it is never the
+  // enforcement — RLS and my_permissions() answer for the person themselves,
+  // with the overrides they cannot see.
+  const override = staff.permissionOverrides?.[key];
+  if (override) return override;
 
   const scopes: AccessScope[] = [];
   const primary = scopeForRole(staff.primaryRole, key, ctx.presetOverrides);

--- a/supabase/seed/dev-accounts.sql
+++ b/supabase/seed/dev-accounts.sql
@@ -174,6 +174,34 @@ begin
       set membership_id = excluded.membership_id,
           primary_role  = excluded.primary_role;
   end loop;
+
+  -- Sensitive fields, so that "you always see your OWN record in full" is
+  -- something a test can actually observe.
+  --
+  -- These five rows were created bare, which made the self-exemption in
+  -- /api/staff untestable: a groomer reading back no payroll proves nothing
+  -- when there was no payroll to read. The figures are invented and belong to
+  -- invented people; the point is only that the fields are non-empty.
+  update public.staff
+     set details = coalesce(details, '{}'::jsonb) || jsonb_build_object(
+           'payroll', jsonb_build_object(
+             'generalServiceCommission', 10,
+             'hourlyRate', 21,
+             'tipsRate', 100,
+             'overrides', '[]'::jsonb
+           ),
+           'clockIn', jsonb_build_object(
+             'requireAccessCode', true,
+             'accessCode', '9001'
+           ),
+           'employment', jsonb_build_object(
+             'hireDate', '2025-03-01',
+             'employmentType', 'full_time',
+             'notes', 'Dev account. Seeded HR note — manage_staff only.'
+           )
+         )
+   where legacy_id like 'fs-dev-%'
+     and facility_id = v_fac_id;
 end $$;
 
 select s.legacy_id, s.email, s.primary_role, s.membership_id is not null as linked

--- a/tests/e2e/staff-field-exposure.spec.ts
+++ b/tests/e2e/staff-field-exposure.spec.ts
@@ -1,0 +1,138 @@
+import { test, expect, type Page } from "@playwright/test";
+
+// ============================================================================
+// /api/staff does not hand out what the caller may not see.
+//
+// RLS lets every staff member read their colleagues' rows, deliberately —
+// rotas and handovers need it. But it gates ROWS, not COLUMNS, so the same
+// policy handed over everything in `details`: hourly rates, clock-in codes,
+// HR notes, and each person's individual permission grants. Any signed-in
+// groomer could curl the endpoint and read the owner's salary.
+//
+// These checks read the API directly rather than the screen. The profile sheet
+// already hid the Payroll tab without `view_payroll` — that was never the
+// problem. The data was in the response either way, and a hidden tab is not a
+// control.
+//
+// TO CONFIRM THESE FAIL WITHOUT THE FIX: drop the `redactStaffProfile` call in
+// src/app/api/staff/route.ts and re-run. Every "cannot see" expectation below
+// should go red.
+// ============================================================================
+
+const PASSWORD = "YipyyDev!2026";
+
+/** A seeded colleague with a full sensitive tail — pay, code, notes, overrides. */
+const COLLEAGUE = "fs-board-01";
+
+interface StaffRow {
+  id: string;
+  email: string;
+  payroll?: { hourlyRate: number };
+  permissionOverrides?: Record<string, unknown>;
+  employment: { notes?: string };
+  clockIn?: { requireAccessCode: boolean; accessCode?: string };
+  statusNote?: string;
+}
+
+async function signIn(page: Page, email: string) {
+  await page.goto("/login");
+  await page.fill("#email", email);
+  await page.fill("#password", PASSWORD);
+  await page.getByRole("button", { name: /sign in/i }).click();
+  await expect
+    .poll(async () => (await page.request.get("/api/permissions")).status(), {
+      timeout: 30_000,
+    })
+    .toBe(200);
+}
+
+async function staffAs(page: Page, email: string): Promise<StaffRow[]> {
+  await signIn(page, email);
+  const res = await page.request.get("/api/staff");
+  expect(res.status()).toBe(200);
+  return (await res.json()) as StaffRow[];
+}
+
+function byId(rows: StaffRow[], id: string): StaffRow {
+  const row = rows.find((r) => r.id === id);
+  expect(
+    row,
+    `${id} should be readable — RLS lets colleagues see each other`,
+  ).toBeDefined();
+  return row!;
+}
+
+test.describe.configure({ mode: "serial" });
+
+test.describe("staff field exposure", () => {
+  test("a groomer cannot read a colleague's pay, code, notes or grants", async ({
+    page,
+  }) => {
+    const rows = await staffAs(page, "groomer@yipyy.dev");
+    const colleague = byId(rows, COLLEAGUE);
+
+    // The row itself is visible. That is correct and must stay true.
+    expect(colleague.email).toBeTruthy();
+
+    // Absent, not zeroed. `hourlyRate: 0` would render as "$0/hr" — a claim
+    // about their pay rather than a refusal to answer.
+    expect(colleague.payroll, "payroll must be absent").toBeUndefined();
+    expect(colleague.permissionOverrides).toBeUndefined();
+    expect(colleague.employment.notes).toBeUndefined();
+    expect(colleague.statusNote).toBeUndefined();
+
+    // Whether a code is required is roster information; the code is a secret.
+    expect(colleague.clockIn?.accessCode).toBeUndefined();
+
+    // Not one row anywhere in the response carries a rate or a code.
+    expect(rows.filter((r) => r.id !== "fs-dev-groomer" && r.payroll)).toEqual(
+      [],
+    );
+    expect(
+      rows.filter((r) => r.id !== "fs-dev-groomer" && r.clockIn?.accessCode),
+    ).toEqual([]);
+  });
+
+  test("a groomer still sees their own record in full", async ({ page }) => {
+    const rows = await staffAs(page, "groomer@yipyy.dev");
+    const self = byId(rows, "fs-dev-groomer");
+
+    // Your pay is yours, and the clock-in code is one you type in yourself.
+    // Seeded in supabase/seed/dev-accounts.sql precisely so this is checkable —
+    // reading back nothing from an empty record would prove nothing.
+    expect(self.payroll?.hourlyRate).toBe(21);
+    expect(self.clockIn?.accessCode).toBe("9001");
+    expect(self.employment.notes).toContain("Seeded HR note");
+  });
+
+  test("an owner sees everything", async ({ page }) => {
+    const rows = await staffAs(page, "owner@yipyy.dev");
+    const colleague = byId(rows, COLLEAGUE);
+
+    // Owner holds view_payroll, view_staff_permissions and manage_staff, so
+    // nothing is trimmed. This is the half that proves the redaction is keyed
+    // on permissions rather than just deleting fields for everyone.
+    expect(colleague.payroll?.hourlyRate).toBeGreaterThan(0);
+    expect(colleague.permissionOverrides).toBeDefined();
+    expect(colleague.employment.notes).toBeTruthy();
+    expect(colleague.clockIn?.accessCode).toBe("7702");
+  });
+
+  test("a receptionist is trimmed the same way as the groomer", async ({
+    page,
+  }) => {
+    // A second non-privileged role, because a single one leaves open the
+    // possibility that the groomer is special rather than the permission is.
+    const rows = await staffAs(page, "reception@yipyy.dev");
+    const colleague = byId(rows, COLLEAGUE);
+
+    expect(colleague.payroll).toBeUndefined();
+    expect(colleague.clockIn?.accessCode).toBeUndefined();
+    expect(colleague.employment.notes).toBeUndefined();
+  });
+
+  test("signed out gets nothing at all", async ({ page }) => {
+    const res = await page.request.get("/api/staff");
+    expect(res.status()).toBe(401);
+  });
+});


### PR DESCRIPTION
Ships #106 to production. One change, one fix.

## What goes live

`/api/staff` currently returns the whole staff row to anyone who can read it. RLS lets every staff member see their colleagues — deliberately, rotas need it — but **it gates rows, not columns**, so the same policy hands over everything in `details`: hourly rates and commission, the free-text HR notes written about someone, the code they clock in with, termination notes, and each person's individual permission grants.

Any signed-in account can `curl https://www.yipyy.com/api/staff` today and read the owner's salary. That is what this closes.

After this, the response is trimmed against the permissions the **database** resolves (`my_permissions()`), never the client's opinion of itself:

| Withheld | Requires |
| --- | --- |
| `payroll` | `view_payroll` |
| `permissionOverrides` | `view_staff_permissions` |
| `employment.notes`, `statusNote`, `clockIn.accessCode` | `manage_staff` |

You always see your own record in full. Withheld means **absent**, never zeroed — `hourlyRate: 0` would render as "\$0/hr", a claim about someone's pay rather than a refusal to answer.

## Risk

Low, and it tightens rather than loosens.

- **No behaviour change for owners or managers** — they hold all three permissions, so nothing is trimmed for them.
- **No screen changes today.** The staff page still reads the mock array (`useState(facilityStaff)`), so no UI consumes the redacted response. The only real consumer is the RBAC provider, which uses identity and roles, not the sensitive tail.
- **Nothing here depends on `AUTH_ENFORCED`**, which stays unset. Signed-out callers already get 401 from this route.
- The DB seed change (payroll/code/notes on the five dev staff rows) has **already been applied** to the live project; the file is committed so a fresh seed reproduces it.

## Verified

Five e2e checks against live Supabase — a groomer and a receptionist read a colleague with payroll, code, notes, `statusNote` and overrides all absent, each still gets their own record whole, an owner sees everything, signed out is 401. Confirmed load-bearing by removing the redaction and watching the receptionist check go red on a real figure (`"hourlyRate": 23`). Re-ran `facility-identity` and `role-editor-writes` alongside: 16/16.

`typecheck`, `lint` (0 errors), `format:check` and `build` all green on #106.

## Known gap

The "Hidden — requires …" notices added to the staff editor and profile sheet are **staged for the mock-array migration, not observed working** — checked by driving the editor as a manager with `view_payroll` revoked, where the API withheld the figures and the screen rendered mock ones. Recorded in [docs/quality/debt-map.md](docs/quality/debt-map.md) with the instruction that matters when the page moves onto `staffQueries.profiles()`: absent means withheld, do not default it to `?? 0`.