### PR TITLE
perf(rbac): resolve permissions on the server, not after hydration

### DIFF
--- a/src/app/employee/(shell)/layout.tsx
+++ b/src/app/employee/(shell)/layout.tsx
@@ -2,6 +2,7 @@ import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 import { SidebarProvider, SidebarInset } from "@/components/ui/sidebar";
 import { EmployeeRbacBoundary } from "@/components/employee/EmployeeRbacBoundary";
+import { PermissionsHydration } from "@/components/providers/PermissionsHydration";
 import { SettingsProviderWrapper } from "@/components/providers/ModulesConfigProviderWrapper";
 import { LocationContextProviderWrapper } from "@/components/providers/LocationContextProviderWrapper";
 import { BookingModalProviderWrapper } from "@/components/providers/BookingModalProviderWrapper";
@@ -30,58 +31,64 @@ export default async function EmployeeShellLayout({
   }
 
   return (
-    // The signed-in employee is the acting RBAC viewer — every /employee screen
-    // resolves permissions for THIS staff member (F0.2 / spec 8C), not the owner
-    // default. Downstream screens read it via usePermission / useCan /
-    // useEffectivePermissions / useFacilityViewer.
-    <EmployeeRbacBoundary staffId={staffId}>
-      {/* Mandatory cash-count gate: for staff with register access, blocks the
+    // Wherever FacilityRbacProvider is mounted, the server's permission map has
+    // to be seeded alongside it. Mount one without the other and SSR resolves
+    // from the legacy cascade while the client resolves from the database — a
+    // hydration mismatch on every permission-gated control in this shell.
+    <PermissionsHydration>
+      {/* The signed-in employee is the acting RBAC viewer — every /employee
+        screen resolves permissions for THIS staff member (F0.2 / spec 8C), not
+        the owner default. Downstream screens read it via usePermission /
+        useCan / useEffectivePermissions / useFacilityViewer. */}
+      <EmployeeRbacBoundary staffId={staffId}>
+        {/* Mandatory cash-count gate: for staff with register access, blocks the
           whole portal with the opening-count flow until today's drawer is open
           (facility-toggleable). Sits outside the heavy provider stack so it
           renders instantly and nothing else mounts while gated. */}
-      <RegisterOpenGate staffId={staffId}>
-        {/* Section 5A: the employee portal renders the SAME admin module
+        <RegisterOpenGate staffId={staffId}>
+          {/* Section 5A: the employee portal renders the SAME admin module
           components (grooming, bookings, clients), so it must supply the same
           provider stack the facility layout does — otherwise those shared
           components throw (e.g. useLoyaltyEngine needs LoyaltyProgramProvider). */}
-        <LocationContextProviderWrapper>
-          <SettingsProviderWrapper>
-            <LoyaltyProgramProvider>
-              <BookingModalProviderWrapper>
-                <CallAvailabilityProvider>
-                  <CallTagsProvider>
-                    <ReputationProvider>
-                      <SidebarProvider>
-                        <EmployeeSidebar staffId={staffId} />
-                        <SidebarInset className="flex min-h-screen flex-col">
-                          <WriteUpAckBanner staffId={staffId} />
-                          <EmployeeHeader staffId={staffId} />
-                          {/* Past-closing "count & close" nudge (closing_time
+          <LocationContextProviderWrapper>
+            <SettingsProviderWrapper>
+              <LoyaltyProgramProvider>
+                <BookingModalProviderWrapper>
+                  <CallAvailabilityProvider>
+                    <CallTagsProvider>
+                      <ReputationProvider>
+                        <SidebarProvider>
+                          <EmployeeSidebar staffId={staffId} />
+                          <SidebarInset className="flex min-h-screen flex-col">
+                            <WriteUpAckBanner staffId={staffId} />
+                            <EmployeeHeader staffId={staffId} />
+                            {/* Past-closing "count & close" nudge (closing_time
                               mode) — supports opener ≠ closer. */}
-                          <RegisterCloseWatcher staffId={staffId} />
+                            <RegisterCloseWatcher staffId={staffId} />
 
-                          {/* pb clears the fixed mobile bottom-nav (I1). */}
-                          <main className="flex-1 overflow-x-hidden pb-16 md:pb-0">
-                            {children}
-                          </main>
-                          <footer className="text-muted-foreground flex items-center justify-center border-t px-4 py-3 pb-20 text-xs md:pb-3">
-                            © 2026 Yipyy · Employee Portal
-                          </footer>
-                        </SidebarInset>
-                        <EmployeeBottomNav staffId={staffId} />
-                        {/* Close reminder: pops the count-and-close flow when an
+                            {/* pb clears the fixed mobile bottom-nav (I1). */}
+                            <main className="flex-1 overflow-x-hidden pb-16 md:pb-0">
+                              {children}
+                            </main>
+                            <footer className="text-muted-foreground flex items-center justify-center border-t px-4 py-3 pb-20 text-xs md:pb-3">
+                              © 2026 Yipyy · Employee Portal
+                            </footer>
+                          </SidebarInset>
+                          <EmployeeBottomNav staffId={staffId} />
+                          {/* Close reminder: pops the count-and-close flow when an
                           authorized employee clocks out / logs out with the
                           drawer still open. */}
-                        <RegisterCloseReminder staffId={staffId} />
-                      </SidebarProvider>
-                    </ReputationProvider>
-                  </CallTagsProvider>
-                </CallAvailabilityProvider>
-              </BookingModalProviderWrapper>
-            </LoyaltyProgramProvider>
-          </SettingsProviderWrapper>
-        </LocationContextProviderWrapper>
-      </RegisterOpenGate>
-    </EmployeeRbacBoundary>
+                          <RegisterCloseReminder staffId={staffId} />
+                        </SidebarProvider>
+                      </ReputationProvider>
+                    </CallTagsProvider>
+                  </CallAvailabilityProvider>
+                </BookingModalProviderWrapper>
+              </LoyaltyProgramProvider>
+            </SettingsProviderWrapper>
+          </LocationContextProviderWrapper>
+        </RegisterOpenGate>
+      </EmployeeRbacBoundary>
+    </PermissionsHydration>
   );
 }

--- a/src/app/facility/layout.tsx
+++ b/src/app/facility/layout.tsx
@@ -2,6 +2,7 @@ import { canAccessFacilityPortal, canManageCustomers } from "@/lib/auth/viewer";
 import { guardPortal } from "@/lib/auth/portal-gate";
 import { legacyStaffIdForEmail } from "@/lib/auth/legacy-identity";
 import { FacilityRbacProvider } from "@/hooks/use-facility-rbac";
+import { PermissionsHydration } from "@/components/providers/PermissionsHydration";
 import { FacilitySidebar } from "@/components/layout/facility-admin-sidebar";
 import {
   SidebarInset,
@@ -57,54 +58,60 @@ export default async function FacilityLayout({
   const staffId = await legacyStaffIdForEmail(viewer.email);
 
   return (
-    <FacilityRbacProvider
-      initialViewerId={staffId ?? undefined}
-      // Platform admins keep the switcher: reviewing a facility as one of its
-      // staff is what the tool is for. Anyone else is themselves.
-      allowViewerSwitch={staffId === null || viewer.isPlatformAdmin}
-    >
-      <LocationContextProviderWrapper>
-        <SettingsProviderWrapper>
-          <LoyaltyProgramProvider>
-            <BookingModalProviderWrapper>
-              <CallAvailabilityProvider>
-                <CallTagsProvider>
-                  <ReputationProvider>
-                    <SidebarProvider className="min-h-[calc(100vh-64px)]">
-                      <FacilitySidebar />
-                      <SidebarInset className="flex min-h-[calc(100vh-64px)] min-w-0 flex-col overflow-x-clip">
-                        <header className="from-background to-muted/20 sticky top-0 z-40 flex h-16 shrink-0 items-center justify-between gap-4 border-b bg-linear-to-r px-4 backdrop-blur-sm sm:px-6">
-                          <div className="flex min-w-0 items-center gap-3">
-                            <SidebarTrigger className="hover:bg-muted size-9 rounded-xl transition-colors md:hidden" />
-                            <GlobalSearchNext
-                              className="hidden w-[460px] max-w-[480px] min-w-0 sm:flex"
-                              canCreateCustomer={canCreateCustomer}
-                            />
-                            <MobileSearch
-                              className="sm:hidden"
-                              canCreateCustomer={canCreateCustomer}
-                            />
-                          </div>
-                          <FacilityHeaderActions facilityId={11} />
-                        </header>
-                        <main className="min-w-0 flex-1 overflow-x-clip">
-                          <ImpersonationBanner />
-                          <AnnouncementBanner facilityId={11} />
-                          <FacilityOnboardingBanner />
-                          {children}
-                        </main>
-                        <FacilityMobileBottomNav />
-                      </SidebarInset>
-                      <SupportFab />
-                      <SupportCenter />
-                    </SidebarProvider>
-                  </ReputationProvider>
-                </CallTagsProvider>
-              </CallAvailabilityProvider>
-            </BookingModalProviderWrapper>
-          </LoyaltyProgramProvider>
-        </SettingsProviderWrapper>
-      </LocationContextProviderWrapper>
-    </FacilityRbacProvider>
+    // Permissions resolved HERE, on the server, and handed down. Without this
+    // the first paint comes from the legacy client-side cascade over the mock
+    // roster — owner defaults — and every non-owner watches controls appear and
+    // then disappear. See PermissionsHydration.
+    <PermissionsHydration>
+      <FacilityRbacProvider
+        initialViewerId={staffId ?? undefined}
+        // Platform admins keep the switcher: reviewing a facility as one of its
+        // staff is what the tool is for. Anyone else is themselves.
+        allowViewerSwitch={staffId === null || viewer.isPlatformAdmin}
+      >
+        <LocationContextProviderWrapper>
+          <SettingsProviderWrapper>
+            <LoyaltyProgramProvider>
+              <BookingModalProviderWrapper>
+                <CallAvailabilityProvider>
+                  <CallTagsProvider>
+                    <ReputationProvider>
+                      <SidebarProvider className="min-h-[calc(100vh-64px)]">
+                        <FacilitySidebar />
+                        <SidebarInset className="flex min-h-[calc(100vh-64px)] min-w-0 flex-col overflow-x-clip">
+                          <header className="from-background to-muted/20 sticky top-0 z-40 flex h-16 shrink-0 items-center justify-between gap-4 border-b bg-linear-to-r px-4 backdrop-blur-sm sm:px-6">
+                            <div className="flex min-w-0 items-center gap-3">
+                              <SidebarTrigger className="hover:bg-muted size-9 rounded-xl transition-colors md:hidden" />
+                              <GlobalSearchNext
+                                className="hidden w-[460px] max-w-[480px] min-w-0 sm:flex"
+                                canCreateCustomer={canCreateCustomer}
+                              />
+                              <MobileSearch
+                                className="sm:hidden"
+                                canCreateCustomer={canCreateCustomer}
+                              />
+                            </div>
+                            <FacilityHeaderActions facilityId={11} />
+                          </header>
+                          <main className="min-w-0 flex-1 overflow-x-clip">
+                            <ImpersonationBanner />
+                            <AnnouncementBanner facilityId={11} />
+                            <FacilityOnboardingBanner />
+                            {children}
+                          </main>
+                          <FacilityMobileBottomNav />
+                        </SidebarInset>
+                        <SupportFab />
+                        <SupportCenter />
+                      </SidebarProvider>
+                    </ReputationProvider>
+                  </CallTagsProvider>
+                </CallAvailabilityProvider>
+              </BookingModalProviderWrapper>
+            </LoyaltyProgramProvider>
+          </SettingsProviderWrapper>
+        </LocationContextProviderWrapper>
+      </FacilityRbacProvider>
+    </PermissionsHydration>
   );
 }

--- a/src/components/providers/PermissionsHydration.tsx
+++ b/src/components/providers/PermissionsHydration.tsx
@@ -1,0 +1,59 @@
+import {
+  HydrationBoundary,
+  QueryClient,
+  dehydrate,
+} from "@tanstack/react-query";
+
+import { myPermissions } from "@/lib/auth/permissions";
+import { permissionQueries } from "@/lib/api/permissions";
+
+// ============================================================================
+// Hands the server's answer to the client before it renders.
+//
+// The server holds the session, so it can call `my_permissions()` directly —
+// no HTTP hop, no waiting. Seeding the same cache entry the browser would have
+// fetched means SSR renders the REAL permission map instead of the legacy
+// fallback, and the hydration pass finds it already there.
+//
+// That closes two things at once:
+//
+//   • The flash. Every non-owner used to get a first paint resolved from the
+//     mock roster — owner defaults — swapped a frame later for their own,
+//     narrower set. Controls appeared and then vanished.
+//
+//   • The mismatch it forced. use-db-permissions had to withhold its answer
+//     until after hydration, purely so the two passes would agree. They now
+//     agree by having the same data.
+//
+// Signed out seeds `null`, which is what /api/permissions would have returned
+// (401 -> null), so the legacy path still runs for the signed-out browsing that
+// is most of the app until AUTH_ENFORCED flips.
+//
+// A FRESH QueryClient PER REQUEST is not optional. Reuse one across requests
+// and one visitor's permission map is served to the next.
+// ============================================================================
+
+export async function PermissionsHydration({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const map = await myPermissions().catch(() => null);
+
+  const queryClient = new QueryClient();
+  // setQueryData, not prefetchQuery: the queryFn is a browser `fetch` of a
+  // relative URL, which has no meaning here. The value is already in hand.
+  queryClient.setQueryData(
+    permissionQueries.mine().queryKey,
+    // An empty map means the RPC failed or there is no session. Both are "we
+    // do not know", which is `null` — seeding `{}` would claim every
+    // permission is denied and blank the UI for signed-out visitors.
+    map && Object.keys(map).length > 0 ? map : null,
+  );
+
+  return (
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      {children}
+    </HydrationBoundary>
+  );
+}

--- a/src/hooks/use-db-permissions.ts
+++ b/src/hooks/use-db-permissions.ts
@@ -2,7 +2,7 @@
 
 import { useQuery } from "@tanstack/react-query";
 
-import { useHydrated } from "@/hooks/use-hydrated";
+import { permissionQueries } from "@/lib/api/permissions";
 
 import type {
   AccessScope,
@@ -18,69 +18,37 @@ import type {
 // a mock staff array plus overrides in localStorage — editable from devtools,
 // and a second implementation of rules that already exist in SQL.
 //
-// WHILE IT LOADS, AND WHEN SIGNED OUT, callers keep the legacy answer. That is
-// deliberate: switching hard would blank guarded UI for anyone browsing
-// signed-out, which is most of the app until AUTH_ENFORCED flips. Returning
-// `null` rather than an empty map is what makes "not known yet" distinguishable
-// from "denied" — an empty map would read as "you may do nothing" and hide
-// every guarded control for a frame.
+// WHEN SIGNED OUT, callers keep the legacy answer. That is deliberate:
+// switching hard would blank guarded UI for anyone browsing signed-out, which
+// is most of the app until AUTH_ENFORCED flips. Returning `null` rather than an
+// empty map is what makes "no session" distinguishable from "denied" — an empty
+// map would read as "you may do nothing" and hide every guarded control.
 //
 // None of this is enforcement. RLS refuses the row whatever the client thinks.
 // This only decides which controls are worth drawing.
 // ============================================================================
 
-type PermissionMap = Partial<Record<PermissionKey, AccessScope>>;
-
-async function fetchPermissions(): Promise<PermissionMap | null> {
-  const response = await fetch("/api/permissions");
-  // Signed out — the caller falls back to the legacy client-side cascade.
-  if (response.status === 401) return null;
-  if (!response.ok) {
-    throw new Error(`Failed to load permissions (${response.status})`);
-  }
-  return (await response.json()) as PermissionMap;
-}
-
-export const permissionQueries = {
-  mine: () => ({
-    queryKey: ["permissions", "mine"] as const,
-    queryFn: fetchPermissions,
-    // Permissions change when an admin edits a role, not between renders.
-    staleTime: 5 * 60_000,
-  }),
-};
-
 /**
- * The database's answer, or `null` when there is no session / it has not
- * arrived yet. Callers treat `null` as "use the legacy path".
+ * The database's answer, or `null` when there is no session. Callers treat
+ * `null` as "use the legacy path".
  *
- * WHY THE HYDRATION GATE — and what it is and is not evidence of.
+ * NO HYDRATION GATE, AND THAT IS THE POINT.
  *
- * The server has no answer here: this reads a browser fetch. So SSR always
- * renders the legacy fallback, which resolves against the mock roster and is
- * effectively OWNER defaults. If the client used the real map during the
- * HYDRATION render, the two passes would disagree for everyone who is not that
- * mock owner — a latent mismatch behind every permission-gated control.
+ * This used to withhold its answer until after hydration. It had to: the server
+ * had no map, so SSR always rendered the legacy fallback — mock roster,
+ * effectively OWNER defaults — and letting the client use the real map during
+ * the hydration render would have made the two passes disagree for everyone who
+ * is not that mock owner.
  *
- * `useHydrated` is false during SSR and during hydration, true after, so both
- * passes take the legacy path and the database's answer applies from the first
- * render that cannot contradict server HTML.
- *
- * HONESTLY: this closes the possibility structurally. It is NOT a fix for a
- * reproduction. A mismatch was observed once on the staff page under a loaded
- * test run, and could not be reproduced afterwards with or without this gate —
- * so whatever triggered that specific one is not established. Do not read this
- * comment as "the staff-page bug is fixed".
- *
- * The real fix is resolving permissions on the SERVER, which it is perfectly
- * able to do — it holds the session — and passing them into the tree. That
- * removes the fallback, the legacy cascade beneath it, and the flash of
- * owner-shaped UI that this gate preserves.
+ * The facility layout now resolves permissions on the SERVER and seeds this
+ * exact cache entry (lib/api/permissions.ts, app/facility/layout.tsx), so both
+ * passes read the same map. They agree by having the same data rather than by
+ * both being wrong — and the first paint stops being owner-shaped UI that gets
+ * replaced a frame later.
  */
 export function useDbPermissions(): EffectivePermissions | null {
-  const hydrated = useHydrated();
   const { data } = useQuery(permissionQueries.mine());
-  if (!hydrated || !data) return null;
+  if (!data) return null;
 
   // 'none' is how the database says "not granted"; the client type says
   // `false`. Translated here so no consumer has to know both spellings.

--- a/src/hooks/use-facility-rbac.tsx
+++ b/src/hooks/use-facility-rbac.tsx
@@ -350,12 +350,34 @@ export function FacilityRbacProvider({
     [customRoles, presetOverrides, withOverrides, previewPermissions],
   );
 
+  // What the DATABASE says about the person holding this session, seeded by
+  // the server in the facility layout so it is present on the very first
+  // render. `null` when signed out.
+  const dbPermissions = useDbPermissions();
+
+  // Precedence: preview beats everything (it is a deliberate "show me their
+  // view"), then the database, then the legacy cascade for signed-out browsing.
+  //
+  // `can` reads the database directly rather than going through `resolveFor`,
+  // because resolveFor answers about ANY staff member and the database only
+  // answers about the caller. Callers of `can` were the last group still on the
+  // mock cascade while usePermission/useCan had moved over — same question,
+  // two answers, depending on which hook a component happened to reach for.
   const can = useCallback(
-    (key: PermissionKey) => resolveFor(viewer, key).granted,
-    [viewer, resolveFor],
+    (key: PermissionKey) => {
+      if (previewPermissions) return previewPermissions[key] !== false;
+      // An ABSENT key is not a grant. my_permissions() returns a row for every
+      // key — including 'none' for denials — so a gap means the map is
+      // incomplete, and the safe reading of "no answer" is no.
+      if (dbPermissions) {
+        const scope = dbPermissions[key];
+        return scope !== false && scope !== undefined;
+      }
+      return resolveFor(viewer, key).granted;
+    },
+    [viewer, resolveFor, dbPermissions, previewPermissions],
   );
 
-  // TODO: move to server/JWT — resolve against the mock stores for now.
   const resolvePermissions = useCallback(
     (staffId: string): EffectivePermissions => {
       // Section 7: preview short-circuits — the whole tree sees the role's map.
@@ -690,12 +712,14 @@ export function useEffectivePermissions(): EffectivePermissions {
 /**
  * Does the acting viewer have `key` (with any scope)? The ergonomic check every
  * guard/sidebar/mask should call.
+ *
+ * Now just `can` — the provider applies the same precedence (preview, then the
+ * database, then the legacy cascade), so the two cannot drift apart. They used
+ * to: this hook consulted the database while `can` did not, and which answer a
+ * component got depended on which hook it happened to import.
  */
 export function usePermission(key: PermissionKey): boolean {
   const { can } = useFacilityRbac();
-  const fromDb = useDbPermissions();
-
-  if (fromDb) return fromDb[key] !== false && fromDb[key] !== undefined;
   return can(key);
 }
 

--- a/src/lib/api/permissions.ts
+++ b/src/lib/api/permissions.ts
@@ -1,0 +1,34 @@
+import type { AccessScope, PermissionKey } from "@/types/facility-staff";
+
+// ============================================================================
+// The viewer's permission map, as a query.
+//
+// Lives here rather than beside the hook because BOTH sides need it: the
+// browser fetches it through `queryFn`, and the facility layout seeds the very
+// same cache entry on the server from `my_permissions()` directly. Sharing one
+// key is what makes the two agree — SSR renders the real map instead of an
+// owner-shaped guess, and the hydration pass finds it already there.
+//
+// No "use client": a server component imports the key to seed it.
+// ============================================================================
+
+export type PermissionMap = Partial<Record<PermissionKey, AccessScope>>;
+
+async function fetchPermissions(): Promise<PermissionMap | null> {
+  const response = await fetch("/api/permissions");
+  // Signed out — the caller falls back to the legacy client-side cascade.
+  if (response.status === 401) return null;
+  if (!response.ok) {
+    throw new Error(`Failed to load permissions (${response.status})`);
+  }
+  return (await response.json()) as PermissionMap;
+}
+
+export const permissionQueries = {
+  mine: () => ({
+    queryKey: ["permissions", "mine"] as const,
+    queryFn: fetchPermissions,
+    // Permissions change when an admin edits a role, not between renders.
+    staleTime: 5 * 60_000,
+  }),
+};

--- a/src/lib/api/roles.ts
+++ b/src/lib/api/roles.ts
@@ -7,7 +7,7 @@ import {
 } from "@tanstack/react-query";
 import { facilityRolesStore } from "@/lib/facility-roles-store";
 import { liveWriteOptional } from "@/lib/api/live-fetch";
-import { permissionQueries } from "@/hooks/use-db-permissions";
+import { permissionQueries } from "@/lib/api/permissions";
 import type {
   RoleOverrides,
   RoleOverrideWrite,

--- a/tests/e2e/server-permissions.spec.ts
+++ b/tests/e2e/server-permissions.spec.ts
@@ -1,0 +1,104 @@
+import { test, expect, type Page } from "@playwright/test";
+
+// ============================================================================
+// The SERVER renders the right permissions, not owner defaults.
+//
+// The facility portal used to resolve permissions only in the browser, against
+// a mock staff roster. The server had no map, so server-rendered HTML was
+// effectively OWNER-shaped for everybody: a groomer's first paint carried
+// controls they do not have, replaced a frame later once the real map arrived.
+//
+// These checks read the RAW SERVER RESPONSE rather than the settled page. That
+// distinction is the whole test — by the time Playwright can query the DOM,
+// hydration has already corrected the mistake, so a normal locator assertion
+// would have passed throughout the entire bug.
+//
+// "Add new staff" is the marker: gated on `manage_staff`, which owners and
+// managers hold and groomers do not (src/app/facility/dashboard/staff/page.tsx).
+//
+// TO CONFIRM THESE FAIL WITHOUT THE FIX: remove <PermissionsHydration> from
+// src/app/facility/layout.tsx. The groomer check should go red.
+// ============================================================================
+
+const PASSWORD = "YipyyDev!2026";
+const STAFF_PAGE = "/facility/dashboard/staff";
+const OWNER_ONLY = "Add new staff";
+
+const FACILITY_ENFORCED = (() => {
+  const raw = process.env.AUTH_ENFORCED?.trim();
+  return raw === "true" || (raw?.split(",") ?? []).includes("facility");
+})();
+
+async function signIn(page: Page, email: string) {
+  await page.goto("/login");
+  await page.fill("#email", email);
+  await page.fill("#password", PASSWORD);
+  await page.getByRole("button", { name: /sign in/i }).click();
+  await expect
+    .poll(async () => (await page.request.get("/api/permissions")).status(), {
+      timeout: 30_000,
+    })
+    .toBe(200);
+}
+
+/** The HTML the server sent, before React has touched it. */
+async function serverHtml(page: Page, path: string): Promise<string> {
+  const res = await page.request.get(path);
+  expect(res.status()).toBe(200);
+  return res.text();
+}
+
+test.describe.configure({ mode: "serial" });
+
+test.describe("server-rendered permissions", () => {
+  test("a groomer's first paint carries no manage_staff controls", async ({
+    page,
+  }) => {
+    await signIn(page, "groomer@yipyy.dev");
+
+    const html = await serverHtml(page, STAFF_PAGE);
+    // Sanity: we fetched the staff page and not a redirect or a shell, so the
+    // absence below means "withheld" rather than "nothing rendered".
+    expect(html).toContain("Manage departments");
+    expect(html).not.toContain(OWNER_ONLY);
+  });
+
+  test("an owner's first paint carries them", async ({ page }) => {
+    await signIn(page, "owner@yipyy.dev");
+
+    const html = await serverHtml(page, STAFF_PAGE);
+    // The other half: proves the server is reading real permissions rather
+    // than having simply stopped rendering the control for everyone.
+    expect(html).toContain(OWNER_ONLY);
+  });
+
+  // NO DOM-SAMPLING TEST HERE, DELIBERATELY.
+  //
+  // The obvious next check — load the page, count the button early and again
+  // late, assert it was never there — was written, and it PASSED with the fix
+  // removed. Even at `waitUntil: "commit"` the first queryable DOM is already
+  // past hydration, so the flash is over before Playwright can look. It would
+  // have sat here reading like coverage while catching nothing.
+  //
+  // The raw-HTML checks above are the real observation: they read what the
+  // server sent, which is the only place the mistake was ever visible.
+
+  test("signed out still renders the legacy fallback", async ({ page }) => {
+    // Most of the app is browsed signed-out until AUTH_ENFORCED flips, and
+    // blanking every guarded control would look like a bug rather than a
+    // policy. `null` permissions must keep the old client-side cascade.
+    //
+    // Only meaningful where the facility portal is OPEN. With enforcement on
+    // (this repo's .env.local) a signed-out request never reaches the staff
+    // page at all — it gets the redirect shell — so the check would fail while
+    // describing nothing.
+    test.skip(
+      FACILITY_ENFORCED,
+      "AUTH_ENFORCED includes 'facility' — signed-out never reaches this page.",
+    );
+
+    const res = await page.request.get(STAFF_PAGE);
+    expect(res.status()).toBe(200);
+    expect(await res.text()).toContain(OWNER_ONLY);
+  });
+});


### PR DESCRIPTION
## What was wrong

The facility portal resolved permissions **only in the browser**, against a mock staff roster. The server had no map, so server-rendered HTML was effectively **owner-shaped for everybody**: a groomer's first paint carried controls they do not have — `Add new staff` among them — replaced a frame later once the real map arrived.

That flash wasn't cosmetic, it was load-bearing. `use-db-permissions` had to withhold the database's answer until *after* hydration, purely so the two render passes would agree. **They agreed by both being wrong.**

## The fix

The server holds the session, so it can call `my_permissions()` directly — no HTTP hop, no wait. `PermissionsHydration` seeds the same React Query entry the browser would otherwise have fetched, so SSR renders the real map and the hydration pass finds it already there. Both passes now agree by having the same data, and the hydration gate is gone along with the flash it was covering for.

**Also collapses a fork nobody should have had to know about.** `can` from the provider still resolved through the mock cascade while `usePermission` and `useCan` consulted the database — the same question with two answers, depending on which hook a component happened to import. `can` now applies one precedence (preview → database → legacy) and `usePermission` is just `can`. An absent key reads as *denied*, not granted: `my_permissions()` returns a row for every key including `'none'`, so a gap means the map is incomplete.

**Seeded in both places `FacilityRbacProvider` is mounted.** The employee shell mounts it too; seeding only the facility layout would have left that portal with SSR on the legacy path and the client on the database — the same mismatch, just relocated.

## Verification

Against the live Supabase project, reading the **raw server response** — the only place the mistake was ever visible:

- a groomer's server HTML no longer contains the `manage_staff` control, and still contains `Manage departments` (so the absence means *withheld*, not *nothing rendered*);
- an owner's still does, which proves the server reads real permissions rather than having simply stopped rendering it for everyone;
- signed-out browsing still gets the legacy cascade — checked with `AUTH_ENFORCED` off, which is **production's current state**.

**Confirmed load-bearing:** removed `<PermissionsHydration>` and the groomer check went red on the real string.

24 e2e checks green across `server-permissions`, `hydration`, `facility-identity`, `staff-field-exposure`, `role-editor-writes` and `admin-portal-enforced` (1 skipped by design — the signed-out case can't run with enforcement on). `build`, `typecheck`, `lint` (0 errors) and `format:check` clean. Employee shell probed separately for hydration errors: none.

## A test I deleted on purpose

The obvious next check — load the page, count the button early and again late, assert it was never there — was written, and **it passed with the fix removed.** Even at `waitUntil: "commit"` the first queryable DOM is already past hydration, so the flash is over before Playwright can look. It would have sat in the suite reading like coverage while catching nothing. The note explaining that is in the spec where the test would have been.

## Note on the staff-page hydration mismatch

This removes the structural cause of permission-shaped mismatches, and `hydration.spec.ts` passes for a groomer across all four facility routes. I am **not** claiming it fixes the one-off mismatch seen on the staff page under a loaded run — that was never reproducible, so there is nothing to check against.