### PR TITLE
fix(bookings): decide what may go in a booking, not just whose it is

### DIFF
--- a/src/app/api/bookings/route.ts
+++ b/src/app/api/bookings/route.ts
@@ -86,6 +86,40 @@ export async function POST(request: NextRequest) {
     );
   }
 
+  // Pets are resolved and checked BEFORE the booking is written.
+  //
+  // booking_pets refuses a pet that does not belong to the booking's client
+  // (20260802120000), and there is no DELETE policy on bookings — by design,
+  // a booking is cancelled, not erased. So a rejection discovered after the
+  // insert cannot be tidied up: it would leave a booking with no animals on
+  // it and no way to withdraw it. Checking first is what keeps that row from
+  // existing at all.
+  const petRefs = Array.isArray(input.petId) ? input.petId : [input.petId];
+  const wanted = petRefs.filter((ref): ref is number => ref != null);
+
+  // RLS-scoped, so a caller who cannot see a pet gets nothing back for it and
+  // the count check below is what turns that into a refusal.
+  const { data: pets } = wanted.length
+    ? await supabase.from("pets").select("id, client_id").in("ref", wanted)
+    : { data: [] };
+
+  const resolved = pets ?? [];
+  if (resolved.length !== wanted.length) {
+    return NextResponse.json(
+      { error: "One or more of those pets could not be found." },
+      { status: 422 },
+    );
+  }
+  if (resolved.some((p) => p.client_id !== client.id)) {
+    // The attack the database also refuses: attaching somebody else's animal
+    // to your own booking, which the facility would read as consent to hand
+    // that animal over.
+    return NextResponse.json(
+      { error: "Those pets are not registered to this client." },
+      { status: 403 },
+    );
+  }
+
   const row = bookingToRow(input, {
     facilityId: facility.facilityId,
     clientRowId: client.id,
@@ -109,21 +143,25 @@ export async function POST(request: NextRequest) {
     );
   }
 
-  // Pets are a join table. Written after the booking so a rejected insert
-  // above leaves nothing behind.
-  const petRefs = Array.isArray(input.petId) ? input.petId : [input.petId];
-  const wanted = petRefs.filter((ref): ref is number => ref != null);
+  // The join rows. Pre-validated above, so a refusal here means the caller
+  // may create a booking but not crew one — reported rather than swallowed,
+  // because an unchecked insert would answer 201 for a booking with no
+  // animals on it.
+  if (resolved.length > 0) {
+    const { error: petError } = await supabase
+      .from("booking_pets")
+      .insert(resolved.map((p) => ({ booking_id: created.id, pet_id: p.id })));
 
-  if (wanted.length > 0) {
-    const { data: pets } = await supabase
-      .from("pets")
-      .select("id")
-      .in("ref", wanted);
-
-    if (pets?.length) {
-      await supabase
-        .from("booking_pets")
-        .insert(pets.map((p) => ({ booking_id: created.id, pet_id: p.id })));
+    if (petError) {
+      // Deliberately NOT "the booking was not created" — it was, and there is
+      // no delete policy to undo it. Saying so is better than a tidy lie.
+      return NextResponse.json(
+        {
+          error:
+            "The booking was created but its pets could not be attached. Ask a manager to add them.",
+        },
+        { status: petError.code === "42501" ? 403 : 500 },
+      );
     }
   }
 

--- a/supabase/migrations/20260802120000_booking_write_integrity.sql
+++ b/supabase/migrations/20260802120000_booking_write_integrity.sql
@@ -1,0 +1,302 @@
+-- ============================================================================
+-- Booking write integrity.
+--
+-- 20260801120000 made bookings real, and RLS there decides WHOSE booking a row
+-- is. It never decided WHAT a caller may put in one. Those are different
+-- questions and only the first was answered:
+--
+--   • base_price / discount / total_cost / tip_amount arrive from the request
+--     body — src/lib/api/mappers/booking.ts::bookingToRow passes them through
+--     untouched. A signed-in customer can book at zero.
+--   • status and payment_status arrive the same way, so a customer can insert
+--     'confirmed' / 'paid' and skip the counter entirely.
+--   • facility_id is caller-supplied and never checked against the client's
+--     facility, so a booking can be planted in a facility its client has no
+--     relationship with.
+--   • booking_pets used the READ predicate for INSERT and DELETE, so anyone who
+--     could see a booking could re-crew it: a view-only staff member could, and
+--     so could a customer attaching a pet belonging to somebody else.
+--
+-- None of that is theoretical. PostgREST is reachable directly with the anon
+-- key and a session cookie, so the Route Handler in src/app/api/bookings/ is a
+-- convenience, not a gate — the note at the top of that file says as much. Every
+-- rule below therefore lives in the database.
+--
+-- What this migration deliberately does NOT do is compute a price. There is no
+-- service or rate table yet (src/data/service-catalog.ts and friends are still
+-- mocks), so the honest stored value for a customer-submitted booking is zero —
+-- "not priced yet" — with whatever the browser quoted preserved under
+-- details.requestedQuote so the counter has something to reconcile against.
+-- When the service catalogue lands, the clamp in the trigger becomes a call
+-- into it and the quote becomes a comparison rather than a record.
+-- ============================================================================
+
+-- ── Money that cannot be nonsense ───────────────────────────────────────────
+-- Deliberately NOT `total_cost = base_price - discount`. Add-ons, taxes and
+-- deposits still live in `details`, so that equality is not yet true, and a
+-- constraint that is wrong on day one is a constraint someone drops on day two.
+-- It becomes checkable when pricing becomes a table.
+alter table public.bookings
+  add constraint bookings_money_non_negative check (
+    base_price >= 0
+    and discount >= 0
+    and total_cost >= 0
+    and (tip_amount is null or tip_amount >= 0)
+  ),
+  add constraint bookings_discount_within_price check (discount <= base_price);
+
+-- ── The facility of a booking is a fact about its client ────────────────────
+-- SECURITY DEFINER because the trigger below has to resolve this for callers
+-- who cannot read the clients table — a staff member may hold create_bookings
+-- without view_clients, and that must not turn into a failed insert.
+create or replace function private.facility_of_client(p_client_id uuid)
+returns uuid
+language sql
+stable
+security definer
+set search_path = ''
+as $$
+  select c.facility_id from public.clients c where c.id = p_client_id;
+$$;
+
+grant execute on function private.facility_of_client(uuid) to authenticated;
+revoke execute on function private.facility_of_client(uuid) from anon;
+
+-- ── What a caller may put in a booking ──────────────────────────────────────
+-- A BEFORE trigger rather than more RLS, because RLS answers yes/no about a row
+-- and this has to answer "yes, but not with those numbers". Runs before the
+-- WITH CHECK policy, so by the time RLS is evaluated facility_id is already the
+-- derived one and the policy can trust it.
+create or replace function private.enforce_booking_integrity()
+returns trigger
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_client_facility uuid;
+  v_is_staff        boolean;
+begin
+  -- 1. facility_id is DERIVED, never accepted. Validating the caller's value
+  --    would work too; deriving it removes the parameter from the attack
+  --    surface entirely. There is no legitimate booking whose facility differs
+  --    from its client's.
+  v_client_facility := private.facility_of_client(new.client_id);
+  if v_client_facility is null then
+    raise exception 'Booking references a client that does not exist.'
+      using errcode = '23503';
+  end if;
+  new.facility_id := v_client_facility;
+
+  -- 2. A location, if one is given, has to belong to that facility.
+  if new.location_id is not null
+     and not exists (
+       select 1
+         from public.locations l
+        where l.id = new.location_id
+          and l.facility_id = new.facility_id
+     )
+  then
+    raise exception 'Location does not belong to this booking''s facility.'
+      using errcode = '23514';
+  end if;
+
+  -- 3. service_role — seeds, and any server-side job — bypasses RLS and has to
+  --    bypass this too, or `bun run db:seed:apply` writes a database full of
+  --    zero-priced requests. auth.uid() is null in exactly that case.
+  if (select auth.uid()) is null then
+    return new;
+  end if;
+
+  v_is_staff := private.has_permission(
+    new.facility_id,
+    case when tg_op = 'INSERT' then 'create_bookings' else 'edit_bookings' end
+  );
+
+  if v_is_staff then
+    return new;
+  end if;
+
+  -- ── Everything below is the customer path ────────────────────────────────
+
+  if tg_op = 'INSERT' then
+    -- A booking a customer makes is a REQUEST. The facility confirms it and the
+    -- facility prices it. Keep what the browser quoted them — that is the
+    -- number they will refer to on the phone — but keep it as a claim, in
+    -- details, not as the price.
+    if coalesce(new.base_price, 0) <> 0 or coalesce(new.total_cost, 0) <> 0 then
+      new.details := coalesce(new.details, '{}'::jsonb) || jsonb_build_object(
+        'requestedQuote', jsonb_build_object(
+          'basePrice', new.base_price,
+          'discount',  new.discount,
+          'totalCost', new.total_cost,
+          'quotedAt',  now()
+        )
+      );
+    end if;
+
+    new.status         := 'request_submitted'::public.booking_status;
+    new.payment_status := 'pending';
+    new.base_price     := 0;
+    new.discount       := 0;
+    new.total_cost     := 0;
+    new.tip_amount     := null;
+
+    -- Staffing is a rota decision, not a customer preference. The request can
+    -- carry one in details; it does not get to set the column.
+    new.assigned_staff_id   := null;
+    new.assigned_staff_name := null;
+
+    return new;
+  end if;
+
+  -- UPDATE by a customer, on their own booking, and only while it is still
+  -- ahead of them. Once the pet is on site the record is the facility's.
+  if old.status not in (
+       'pending', 'request_submitted', 'estimate_sent', 'waitlisted', 'confirmed'
+     )
+  then
+    raise exception 'This booking can no longer be changed.'
+      using errcode = '42501';
+  end if;
+
+  -- Two moves are theirs: leave the status alone (they are editing their notes)
+  -- or call the booking off. Anything else — confirming it, marking it paid,
+  -- checking themselves in — is the facility's to do.
+  if new.status is distinct from old.status
+     and new.status <> 'cancelled'::public.booking_status
+  then
+    raise exception 'You may only cancel this booking.'
+      using errcode = '42501';
+  end if;
+
+  -- Everything they do not own is put back rather than rejected, so the
+  -- existing PATCH route — which merges the whole booking and sends it all —
+  -- keeps working instead of erroring on fields it never meant to change.
+  -- What is left writable: special_requests, and the long tail in details.
+  new.client_id           := old.client_id;
+  new.service             := old.service;
+  new.service_type        := old.service_type;
+  new.payment_status      := old.payment_status;
+  new.base_price          := old.base_price;
+  new.discount            := old.discount;
+  new.total_cost          := old.total_cost;
+  new.tip_amount          := old.tip_amount;
+  new.start_at            := old.start_at;
+  new.end_at              := old.end_at;
+  new.assigned_staff_id   := old.assigned_staff_id;
+  new.assigned_staff_name := old.assigned_staff_name;
+
+  return new;
+end;
+$$;
+
+-- Fires before bookings_set_updated_at — triggers run in name order, and
+-- "enforce" sorts before "set", which is the order we want rather than a
+-- coincidence to rely on quietly.
+drop trigger if exists bookings_enforce_integrity on public.bookings;
+create trigger bookings_enforce_integrity
+  before insert or update on public.bookings
+  for each row execute function private.enforce_booking_integrity();
+
+-- ── A customer may cancel their own booking ─────────────────────────────────
+-- bookings_update was staff-only, which meant the person who made the booking
+-- could not call it off — they had to phone the facility to change a row they
+-- own. The trigger above is what makes widening this safe: it constrains the
+-- customer branch to a status move to 'cancelled' and nothing else.
+--
+-- bookings_insert is left as it stands. It was already correct once facility_id
+-- became derived, because RLS evaluates WITH CHECK against the post-trigger row.
+drop policy if exists bookings_update on public.bookings;
+create policy bookings_update on public.bookings
+  for update to authenticated
+  using (
+    client_id in (select private.own_client_ids())
+    or private.has_permission(facility_id, 'edit_bookings')
+  )
+  with check (
+    client_id in (select private.own_client_ids())
+    or private.has_permission(facility_id, 'edit_bookings')
+  );
+
+-- ── Who may change a booking's crew ─────────────────────────────────────────
+-- The old policies asked "can you see this booking", which is the read
+-- question. Seeing a booking and being allowed to change which animals are on
+-- it are not the same right.
+--
+-- create_bookings counts as well as edit_bookings because attaching pets is
+-- part of creating: the POST route inserts the booking and then the join rows,
+-- and a staff member with create_bookings but not edit_bookings would otherwise
+-- create a booking with no pets on it. The cost is that such a member can also
+-- re-crew an existing booking; that is the lesser of the two wrongs until
+-- "create" and "edit" are separable in the route.
+create or replace function private.can_write_booking(p_booking_id uuid)
+returns boolean
+language sql
+stable
+security definer
+set search_path = ''
+as $$
+  select exists (
+    select 1
+      from public.bookings b
+     where b.id = p_booking_id
+       and (
+         private.has_permission(b.facility_id, 'edit_bookings')
+         or private.has_permission(b.facility_id, 'create_bookings')
+         or (
+           b.client_id in (select private.own_client_ids())
+           and b.status in (
+             'pending', 'request_submitted', 'estimate_sent', 'waitlisted'
+           )
+         )
+       )
+  );
+$$;
+
+grant execute on function private.can_write_booking(uuid) to authenticated;
+revoke execute on function private.can_write_booking(uuid) from anon;
+
+-- A pet can only join a booking made for its own client. Without this a
+-- customer could attach a stranger's pet to their own booking and the facility
+-- would read it as consent to hand that animal over.
+create or replace function private.pet_matches_booking_client(
+  p_booking_id uuid,
+  p_pet_id     uuid
+)
+returns boolean
+language sql
+stable
+security definer
+set search_path = ''
+as $$
+  select exists (
+    select 1
+      from public.bookings b
+      join public.pets p on p.id = p_pet_id
+     where b.id = p_booking_id
+       and p.client_id = b.client_id
+  );
+$$;
+
+grant execute on function private.pet_matches_booking_client(uuid, uuid) to authenticated;
+revoke execute on function private.pet_matches_booking_client(uuid, uuid) from anon;
+
+drop policy if exists booking_pets_insert on public.booking_pets;
+create policy booking_pets_insert on public.booking_pets
+  for insert to authenticated
+  with check (
+    private.can_write_booking(booking_id)
+    and private.pet_matches_booking_client(booking_id, pet_id)
+  );
+
+-- Detaching does not repeat the ownership check. If a pet was moved to another
+-- client after the booking was made, the row still has to be removable —
+-- otherwise the stale link is the thing that survives.
+drop policy if exists booking_pets_delete on public.booking_pets;
+create policy booking_pets_delete on public.booking_pets
+  for delete to authenticated
+  using (private.can_write_booking(booking_id));
+
+-- booking_pets_read is unchanged: the read predicate was always right for
+-- reads. It was only ever wrong as a stand-in for the write one.

--- a/supabase/tests/booking-write-integrity.sql
+++ b/supabase/tests/booking-write-integrity.sql
@@ -1,0 +1,500 @@
+-- ============================================================================
+-- Booking write integrity — behaviour tests for 20260802120000.
+--
+-- Not a new gate and not a runner: a psql script run by hand, because what it
+-- checks cannot be reached from Playwright. RLS decides what a caller may
+-- write, and the only honest way to ask is to BE that caller —
+-- `set local role authenticated` plus the JWT subject auth.uid() reads. That is
+-- the position a browser holding the anon key and a session cookie is in, which
+-- is the whole point: the Route Handler in src/app/api/bookings/ is a
+-- convenience, not a gate, and testing through it would prove the wrong thing.
+--
+--   supabase start
+--   psql "$(supabase status -o json | jq -r .DB_URL)" \
+--     -f supabase/tests/booking-write-integrity.sql
+--
+-- Runs inside one transaction and rolls back, so it leaves nothing behind and
+-- is safe against a seeded dev database. The fixture uses `wi-test-*` slugs so
+-- it cannot collide with facility 11.
+--
+-- TO CONFIRM THESE FAIL WITHOUT THE FIX: move 20260802120000 out of
+-- supabase/migrations, `supabase db reset`, and re-run. 11 of the 20 go red —
+-- among them a customer confirming their own booking, paying nothing for it,
+-- and filing it against a facility they have never been to.
+-- ============================================================================
+
+begin;
+
+set local client_min_messages to warning;
+
+create temp table tap (n serial, name text, ok boolean, detail text);
+grant all on tap to authenticated;
+
+create or replace function pg_temp.t(p_name text, p_ok boolean, p_detail text default '')
+returns void language sql as $$
+  insert into tap(name, ok, detail) values (p_name, p_ok, p_detail);
+$$;
+
+-- ── Fixture ────────────────────────────────────────────────────────────────
+-- Two facilities (so cross-tenant forgery is expressible), three staff on
+-- different presets, and two customers who each own a pet — the smallest cast
+-- that can act out every refusal below.
+-- EMAILS ARE FIXTURE-ONLY, and deliberately not the dev accounts'.
+--
+-- The first version of this used owner@yipyy.dev / groomer@yipyy.dev, which
+-- reads nicely and does not work: auth.users carries a unique index on email
+-- (users_email_partial_key), so on any database where those accounts already
+-- exist — the seeded dev one included — the fixture aborts the transaction and
+-- every test below reports a failure that is really a collision.
+-- `on conflict (id)` does not save it; the conflict is on email, not id.
+insert into auth.users (id, email) values
+  ('00000000-0000-0000-0000-0000000000a1', 'wi-test-owner@example.invalid'),
+  ('00000000-0000-0000-0000-0000000000a2', 'wi-test-groomer@example.invalid'),
+  ('00000000-0000-0000-0000-0000000000a3', 'wi-test-reception@example.invalid'),
+  ('00000000-0000-0000-0000-0000000000c1', 'wi-test-sam@example.invalid'),
+  ('00000000-0000-0000-0000-0000000000c2', 'wi-test-mallory@example.invalid')
+on conflict (id) do nothing;
+
+insert into public.profiles (id, email, full_name) values
+  ('00000000-0000-0000-0000-0000000000a1', 'wi-test-owner@example.invalid',     'Owner'),
+  ('00000000-0000-0000-0000-0000000000a2', 'wi-test-groomer@example.invalid',   'Groomer'),
+  ('00000000-0000-0000-0000-0000000000a3', 'wi-test-reception@example.invalid', 'Reception'),
+  ('00000000-0000-0000-0000-0000000000c1', 'wi-test-sam@example.invalid',       'Sam'),
+  ('00000000-0000-0000-0000-0000000000c2', 'wi-test-mallory@example.invalid',   'Mallory')
+on conflict (id) do nothing;
+
+insert into public.orgs (id, name, slug) values
+  ('00000000-0000-0000-0000-00000000000f', 'Write-Integrity Test Org', 'wi-test-org');
+
+insert into public.facilities (id, org_id, name, slug, legacy_id) values
+  ('00000000-0000-0000-0000-0000000000f1', '00000000-0000-0000-0000-00000000000f', 'Facility A', 'wi-test-facility-a', 'wi-test-a'),
+  ('00000000-0000-0000-0000-0000000000f2', '00000000-0000-0000-0000-00000000000f', 'Facility B', 'wi-test-facility-b', 'wi-test-b');
+
+insert into public.locations (id, facility_id, name, is_primary) values
+  ('00000000-0000-0000-0000-00000000ab01', '00000000-0000-0000-0000-0000000000f1', 'A Main', true),
+  ('00000000-0000-0000-0000-00000000ab02', '00000000-0000-0000-0000-0000000000f2', 'B Main', true);
+
+insert into public.facility_memberships (profile_id, facility_id, role, is_active) values
+  ('00000000-0000-0000-0000-0000000000a1', '00000000-0000-0000-0000-0000000000f1', 'owner',     true),
+  ('00000000-0000-0000-0000-0000000000a2', '00000000-0000-0000-0000-0000000000f1', 'groomer',   true),
+  ('00000000-0000-0000-0000-0000000000a3', '00000000-0000-0000-0000-0000000000f1', 'reception', true);
+
+insert into public.clients (id, facility_id, profile_id, name, email) values
+  ('00000000-0000-0000-0000-0000000000d1', '00000000-0000-0000-0000-0000000000f1', '00000000-0000-0000-0000-0000000000c1', 'Sam',     'wi-test-sam@example.invalid'),
+  ('00000000-0000-0000-0000-0000000000d2', '00000000-0000-0000-0000-0000000000f1', '00000000-0000-0000-0000-0000000000c2', 'Mallory', 'wi-test-mallory@example.invalid');
+
+insert into public.pets (id, client_id, name) values
+  ('00000000-0000-0000-0000-0000000000e1', '00000000-0000-0000-0000-0000000000d1', 'Rex'),
+  ('00000000-0000-0000-0000-0000000000e2', '00000000-0000-0000-0000-0000000000d2', 'Biscuit');
+
+-- ── T1-T3: a customer books ────────────────────────────────────────────────
+do $$
+declare r public.bookings;
+begin
+  perform set_config('request.jwt.claim.sub', '00000000-0000-0000-0000-0000000000c1', true);
+  set local role authenticated;
+
+  insert into public.bookings
+    (facility_id, client_id, service, status, payment_status,
+     start_at, end_at, base_price, discount, total_cost, tip_amount)
+  values
+    -- Facility B is forged: Sam's client record lives at Facility A.
+    ('00000000-0000-0000-0000-0000000000f2', '00000000-0000-0000-0000-0000000000d1', 'grooming', 'confirmed', 'paid',
+     now() + interval '2 days', now() + interval '2 days 1 hour',
+     0, 0, 0, 0)
+  returning * into r;
+
+  reset role;
+  perform pg_temp.t('T1  customer cannot self-confirm',
+            r.status = 'request_submitted' and r.payment_status = 'pending',
+            format('status=%s payment=%s', r.status, r.payment_status));
+  perform pg_temp.t('T3  forged facility_id is derived back to the client''s',
+            r.facility_id = '00000000-0000-0000-0000-0000000000f1', format('facility=%s', r.facility_id));
+exception when others then
+  reset role;
+  perform pg_temp.t('T1  customer books', false, sqlerrm);
+end $$;
+
+do $$
+declare r public.bookings;
+begin
+  perform set_config('request.jwt.claim.sub', '00000000-0000-0000-0000-0000000000c1', true);
+  set local role authenticated;
+
+  insert into public.bookings
+    (facility_id, client_id, service, status, payment_status,
+     start_at, end_at, base_price, discount, total_cost)
+  values
+    ('00000000-0000-0000-0000-0000000000f1', '00000000-0000-0000-0000-0000000000d1', 'boarding', 'pending', 'pending',
+     now() + interval '5 days', now() + interval '7 days',
+     -- What the browser quoted them, sent as if it were the price.
+     240, 40, 200)
+  returning * into r;
+
+  reset role;
+  perform pg_temp.t('T2a customer-supplied price is not the price',
+            r.base_price = 0 and r.total_cost = 0 and r.discount = 0,
+            format('base=%s discount=%s total=%s', r.base_price, r.discount, r.total_cost));
+  perform pg_temp.t('T2b what they were quoted survives in details',
+            (r.details->'requestedQuote'->>'totalCost')::numeric = 200,
+            coalesce(r.details->>'requestedQuote', '(absent)'));
+exception when others then
+  reset role;
+  perform pg_temp.t('T2  quote preservation', false, sqlerrm);
+end $$;
+
+-- ── T4/T5: whose pet may go on the booking ─────────────────────────────────
+do $$
+declare v_booking uuid; v_ok boolean;
+begin
+  perform set_config('request.jwt.claim.sub', '00000000-0000-0000-0000-0000000000c1', true);
+  set local role authenticated;
+
+  select id into v_booking from public.bookings
+   where client_id = '00000000-0000-0000-0000-0000000000d1' order by created_at limit 1;
+
+  insert into public.booking_pets (booking_id, pet_id) values (v_booking, '00000000-0000-0000-0000-0000000000e1');
+  reset role;
+  perform pg_temp.t('T4  customer attaches their own pet', true);
+
+  perform set_config('request.jwt.claim.sub', '00000000-0000-0000-0000-0000000000c1', true);
+  set local role authenticated;
+  begin
+    insert into public.booking_pets (booking_id, pet_id) values (v_booking, '00000000-0000-0000-0000-0000000000e2');
+    v_ok := false;                        -- reached only if the insert landed
+  exception when insufficient_privilege then
+    v_ok := true;
+  end;
+  reset role;
+  perform pg_temp.t('T5  customer cannot attach a stranger''s pet', v_ok,
+            case when v_ok then 'refused by RLS' else 'INSERT SUCCEEDED' end);
+exception when others then
+  reset role;
+  perform pg_temp.t('T4/T5 crew writes', false, sqlerrm);
+end $$;
+
+-- ── T6: view-only staff cannot re-crew ─────────────────────────────────────
+do $$
+declare v_booking uuid; v_deleted int;
+begin
+  -- Set up as the owner so the row is unambiguously at Facility A with a pet
+  -- on it. Picking "whatever booking exists" made this pass for the wrong
+  -- reason before the fix: the forged booking had landed at Facility B, where
+  -- the groomer has no membership and so could not see it either way.
+  perform set_config('request.jwt.claim.sub', '00000000-0000-0000-0000-0000000000a1', true);
+  set local role authenticated;
+  insert into public.bookings (facility_id, client_id, service, status, start_at, end_at)
+  values ('00000000-0000-0000-0000-0000000000f1', '00000000-0000-0000-0000-0000000000d1', 'grooming', 'confirmed',
+          now() + interval '4 days', now() + interval '4 days 1 hour')
+  returning id into v_booking;
+  insert into public.booking_pets (booking_id, pet_id) values (v_booking, '00000000-0000-0000-0000-0000000000e1');
+  reset role;
+
+  perform set_config('request.jwt.claim.sub', '00000000-0000-0000-0000-0000000000a2', true);
+  set local role authenticated;
+  -- The groomer holds view_bookings and can read this row. That is the point:
+  -- being able to see it must not be the same as being able to re-crew it.
+  perform 1 from public.bookings where id = v_booking;
+  delete from public.booking_pets where booking_id = v_booking;
+  get diagnostics v_deleted = row_count;
+  reset role;
+
+  perform pg_temp.t('T6  view-only groomer cannot detach a pet', v_deleted = 0,
+            format('%s row(s) deleted', v_deleted));
+exception when others then
+  reset role;
+  perform pg_temp.t('T6  view-only groomer', false, sqlerrm);
+end $$;
+
+-- T6b proves the groomer really could see the row, so T6 is a refusal to write
+-- rather than a failure to find.
+do $$
+declare v_seen int;
+begin
+  perform set_config('request.jwt.claim.sub', '00000000-0000-0000-0000-0000000000a2', true);
+  set local role authenticated;
+  select count(*) into v_seen from public.bookings
+   where facility_id = '00000000-0000-0000-0000-0000000000f1' and client_id = '00000000-0000-0000-0000-0000000000d1';
+  reset role;
+  perform pg_temp.t('T6b the groomer can read those bookings', v_seen > 0,
+            format('%s visible', v_seen));
+exception when others then
+  reset role; perform pg_temp.t('T6b groomer visibility', false, sqlerrm);
+end $$;
+
+-- ── T7/T8: staff keep their authority ──────────────────────────────────────
+do $$
+declare r public.bookings;
+begin
+  perform set_config('request.jwt.claim.sub', '00000000-0000-0000-0000-0000000000a1', true);
+  set local role authenticated;
+
+  insert into public.bookings
+    (facility_id, client_id, service, status, payment_status,
+     start_at, end_at, base_price, discount, total_cost, assigned_staff_name)
+  values
+    ('00000000-0000-0000-0000-0000000000f1', '00000000-0000-0000-0000-0000000000d1', 'daycare', 'confirmed', 'paid',
+     now() + interval '1 day', now() + interval '1 day 8 hours',
+     90, 10, 80, 'Jules')
+  returning * into r;
+  reset role;
+
+  perform pg_temp.t('T7  staff price and status are kept',
+            r.status = 'confirmed' and r.payment_status = 'paid'
+            and r.total_cost = 80 and r.assigned_staff_name = 'Jules',
+            format('status=%s total=%s staff=%s', r.status, r.total_cost, r.assigned_staff_name));
+exception when others then
+  reset role;
+  perform pg_temp.t('T7  staff booking', false, sqlerrm);
+end $$;
+
+do $$
+declare v_booking uuid;
+begin
+  -- Reception holds create_bookings but NOT edit_bookings. Creating a booking
+  -- and then attaching its pets must work in one breath.
+  perform set_config('request.jwt.claim.sub', '00000000-0000-0000-0000-0000000000a3', true);
+  set local role authenticated;
+
+  insert into public.bookings
+    (facility_id, client_id, service, status, start_at, end_at, base_price, total_cost)
+  values ('00000000-0000-0000-0000-0000000000f1', '00000000-0000-0000-0000-0000000000d2', 'grooming', 'confirmed',
+          now() + interval '3 days', now() + interval '3 days 2 hours', 70, 70)
+  returning id into v_booking;
+
+  insert into public.booking_pets (booking_id, pet_id) values (v_booking, '00000000-0000-0000-0000-0000000000e2');
+  reset role;
+  perform pg_temp.t('T8  reception can crew the booking it just made', true);
+exception when others then
+  reset role;
+  perform pg_temp.t('T8  reception create+crew', false, sqlerrm);
+end $$;
+
+-- ── T9-T12: what a customer may do to an existing booking ──────────────────
+do $$
+declare v_booking uuid; r public.bookings; v_ok boolean;
+begin
+  -- The daycare booking from T7 specifically: it is the one with a real price
+  -- on it, which is what makes "the price survived the cancellation" a claim.
+  select id into v_booking from public.bookings
+   where client_id = '00000000-0000-0000-0000-0000000000d1' and status = 'confirmed' and service = 'daycare' limit 1;
+
+  perform set_config('request.jwt.claim.sub', '00000000-0000-0000-0000-0000000000c1', true);
+  set local role authenticated;
+  update public.bookings set status = 'cancelled' where id = v_booking;
+  reset role;
+
+  select * into r from public.bookings where id = v_booking;
+  perform pg_temp.t('T9  customer can cancel their own booking',
+            r.status = 'cancelled' and r.total_cost = 80,
+            format('status=%s total=%s', r.status, r.total_cost));
+exception when others then
+  reset role;
+  perform pg_temp.t('T9  customer cancel', false, sqlerrm);
+end $$;
+
+do $$
+declare v_booking uuid; v_ok boolean;
+begin
+  select id into v_booking from public.bookings
+   where client_id = '00000000-0000-0000-0000-0000000000d1' and status = 'request_submitted' limit 1;
+
+  perform set_config('request.jwt.claim.sub', '00000000-0000-0000-0000-0000000000c1', true);
+  set local role authenticated;
+  begin
+    update public.bookings set status = 'confirmed' where id = v_booking;
+    v_ok := false;
+  exception when insufficient_privilege then
+    v_ok := true;
+  end;
+  reset role;
+  perform pg_temp.t('T10 customer cannot confirm their own request', v_ok,
+            case when v_ok then 'refused' else 'UPDATE SUCCEEDED' end);
+exception when others then
+  reset role;
+  perform pg_temp.t('T10 customer confirm', false, sqlerrm);
+end $$;
+
+do $$
+declare v_booking uuid; r public.bookings;
+begin
+  select id into v_booking from public.bookings
+   where client_id = '00000000-0000-0000-0000-0000000000d1' and status = 'request_submitted' limit 1;
+
+  perform set_config('request.jwt.claim.sub', '00000000-0000-0000-0000-0000000000c1', true);
+  set local role authenticated;
+  -- The shape the PATCH route sends: the whole merged booking, cancelled, with
+  -- the money quietly rewritten.
+  update public.bookings
+     set status = 'cancelled', base_price = 0, total_cost = 0, discount = 0,
+         start_at = now() + interval '99 days'
+   where id = v_booking;
+  reset role;
+
+  select * into r from public.bookings where id = v_booking;
+  perform pg_temp.t('T11 cancelling cannot smuggle other changes',
+            r.status = 'cancelled' and r.start_at < now() + interval '90 days',
+            format('status=%s start=%s', r.status, r.start_at));
+exception when others then
+  reset role;
+  perform pg_temp.t('T11 cancel smuggling', false, sqlerrm);
+end $$;
+
+do $$
+declare v_booking uuid; v_ok boolean;
+begin
+  -- Checked in BY STAFF, which is the only way a booking reaches that status.
+  -- Inserting it as the session role would work here but not against a real
+  -- caller, and a fixture that only exists under a superuser proves nothing.
+  perform set_config('request.jwt.claim.sub', '00000000-0000-0000-0000-0000000000a1', true);
+  set local role authenticated;
+  insert into public.bookings
+    (facility_id, client_id, service, status, start_at, end_at)
+  values ('00000000-0000-0000-0000-0000000000f1', '00000000-0000-0000-0000-0000000000d1', 'boarding', 'checked_in',
+          now() - interval '1 hour', now() + interval '1 day')
+  returning id into v_booking;
+  reset role;
+
+  perform set_config('request.jwt.claim.sub', '00000000-0000-0000-0000-0000000000c1', true);
+  set local role authenticated;
+  begin
+    update public.bookings set status = 'cancelled' where id = v_booking;
+    v_ok := false;
+  exception when insufficient_privilege then
+    v_ok := true;
+  end;
+  reset role;
+  perform pg_temp.t('T12 cannot cancel a pet already on site', v_ok,
+            case when v_ok then 'refused' else 'UPDATE SUCCEEDED' end);
+exception when others then
+  reset role;
+  perform pg_temp.t('T12 cancel after check-in', false, sqlerrm);
+end $$;
+
+-- ── T13/T14: money that cannot be nonsense ─────────────────────────────────
+do $$
+declare v_ok boolean;
+begin
+  perform set_config('request.jwt.claim.sub', '00000000-0000-0000-0000-0000000000a1', true);
+  set local role authenticated;
+  begin
+    insert into public.bookings (facility_id, client_id, service, start_at, end_at, base_price, total_cost)
+    values ('00000000-0000-0000-0000-0000000000f1', '00000000-0000-0000-0000-0000000000d1', 'retail', now(), now() + interval '1 hour', -50, -50);
+    v_ok := false;
+  exception when check_violation then v_ok := true;
+  end;
+  reset role;
+  perform pg_temp.t('T13 negative money is rejected', v_ok);
+exception when others then
+  reset role; perform pg_temp.t('T13 negative money', false, sqlerrm);
+end $$;
+
+do $$
+declare v_ok boolean;
+begin
+  perform set_config('request.jwt.claim.sub', '00000000-0000-0000-0000-0000000000a1', true);
+  set local role authenticated;
+  begin
+    insert into public.bookings (facility_id, client_id, service, start_at, end_at, base_price, discount, total_cost)
+    values ('00000000-0000-0000-0000-0000000000f1', '00000000-0000-0000-0000-0000000000d1', 'retail', now(), now() + interval '1 hour', 20, 500, 0);
+    v_ok := false;
+  exception when check_violation then v_ok := true;
+  end;
+  reset role;
+  perform pg_temp.t('T14 a discount cannot exceed the price', v_ok);
+exception when others then
+  reset role; perform pg_temp.t('T14 discount cap', false, sqlerrm);
+end $$;
+
+-- ── T15: the seed path must survive ────────────────────────────────────────
+do $$
+declare r public.bookings;
+begin
+  -- No JWT subject at all: this is `bun run db:seed:apply` / any service_role job.
+  perform set_config('request.jwt.claim.sub', '', true);
+  insert into public.bookings
+    (facility_id, client_id, service, status, payment_status, start_at, end_at,
+     base_price, discount, total_cost)
+  values ('00000000-0000-0000-0000-0000000000f1', '00000000-0000-0000-0000-0000000000d1', 'training', 'completed', 'paid',
+          now() - interval '10 days', now() - interval '10 days' + interval '1 hour',
+          150, 25, 125)
+  returning * into r;
+
+  perform pg_temp.t('T15 seeds keep their prices and statuses',
+            r.status = 'completed' and r.total_cost = 125 and r.payment_status = 'paid',
+            format('status=%s total=%s', r.status, r.total_cost));
+exception when others then
+  perform pg_temp.t('T15 seed path', false, sqlerrm);
+end $$;
+
+-- ── T16: a location has to belong to the facility ──────────────────────────
+do $$
+declare v_ok boolean;
+begin
+  perform set_config('request.jwt.claim.sub', '00000000-0000-0000-0000-0000000000a1', true);
+  set local role authenticated;
+  begin
+    insert into public.bookings (facility_id, client_id, location_id, service, start_at, end_at)
+    values ('00000000-0000-0000-0000-0000000000f1', '00000000-0000-0000-0000-0000000000d1', '00000000-0000-0000-0000-00000000ab02', 'daycare', now(), now() + interval '1 hour');
+    v_ok := false;
+  exception when check_violation then v_ok := true;
+  end;
+  reset role;
+  perform pg_temp.t('T16 a booking cannot point at another facility''s location', v_ok);
+exception when others then
+  reset role; perform pg_temp.t('T16 location tenancy', false, sqlerrm);
+end $$;
+
+-- ── T17: view-only staff still cannot edit ─────────────────────────────────
+do $$
+declare v_booking uuid; v_updated int;
+begin
+  select id into v_booking from public.bookings where client_id = '00000000-0000-0000-0000-0000000000d1' limit 1;
+  perform set_config('request.jwt.claim.sub', '00000000-0000-0000-0000-0000000000a2', true);
+  set local role authenticated;
+  update public.bookings set total_cost = 1 where id = v_booking;
+  get diagnostics v_updated = row_count;
+  reset role;
+  perform pg_temp.t('T17 view-only groomer cannot edit a booking', v_updated = 0,
+            format('%s row(s) updated', v_updated));
+exception when others then
+  reset role; perform pg_temp.t('T17 groomer edit', false, sqlerrm);
+end $$;
+
+
+-- ── T18: a customer may still edit their own notes ─────────────────────────
+do $$
+declare v_booking uuid; r public.bookings;
+begin
+  select id into v_booking from public.bookings
+   where client_id = '00000000-0000-0000-0000-0000000000d1' and status = 'request_submitted' limit 1;
+
+  perform set_config('request.jwt.claim.sub', '00000000-0000-0000-0000-0000000000c1', true);
+  set local role authenticated;
+  -- The whole merged object, as the PATCH route sends it, with only the note
+  -- actually changed — and a hopeful attempt on the service and the price.
+  update public.bookings
+     set special_requests = 'Rex is nervous around clippers',
+         service = 'boarding_suite', total_cost = 5
+   where id = v_booking;
+  reset role;
+
+  select * into r from public.bookings where id = v_booking;
+  perform pg_temp.t('T18 customer can edit their own notes, nothing else',
+            r.special_requests = 'Rex is nervous around clippers'
+            and r.service = 'boarding' and r.total_cost = 0,
+            format('note=%s service=%s total=%s', r.special_requests, r.service, r.total_cost));
+exception when others then
+  reset role; perform pg_temp.t('T18 customer note edit', false, sqlerrm);
+end $$;
+
+-- ── Report ─────────────────────────────────────────────────────────────────
+select case when ok then '  PASS  ' else '> FAIL <' end as result,
+       name, detail
+  from tap order by n;
+
+select count(*) filter (where ok) || ' passed, '
+    || count(*) filter (where not ok) || ' failed' as summary
+  from tap;
+
+rollback;

--- a/tests/e2e/booking-write-integrity.spec.ts
+++ b/tests/e2e/booking-write-integrity.spec.ts
@@ -1,0 +1,193 @@
+import { test, expect, type Page } from "@playwright/test";
+
+// ============================================================================
+// A customer cannot book on their own terms.
+//
+// RLS decided WHOSE booking a row was; it never decided WHAT could be put in
+// one. Prices, status and payment_status arrived from the request body and
+// were written as sent, and facility_id was never checked against the client's
+// facility. So a signed-in customer could book at zero, mark it paid and
+// confirmed, and file it against a facility they had never been to.
+//
+// The rules live in the DATABASE (20260802120000), because PostgREST is
+// reachable directly with the anon key and a session cookie — the Route
+// Handler is a convenience, not a gate. supabase/tests/booking-write-integrity.sql
+// proves them at that level, as the caller, which is the honest place to ask.
+//
+// THIS FILE ASKS A DIFFERENT QUESTION: does the app still work, and does it
+// tell the truth about what happened? A trigger that silently rewrites a
+// booking is only correct if the response the customer gets reflects it.
+//
+// TO CONFIRM THESE FAIL WITHOUT THE FIX: drop the bookings_enforce_integrity
+// trigger and re-run. The first test goes red — though NOT by storing the
+// customer's numbers, as you might expect. It fails with a 403: without the
+// trigger deriving facility_id, the bookings_insert policy refuses the whole
+// row. Worth knowing, because it means this route was never the hole. The
+// hole was PostgREST, where the same customer sets the price directly, and
+// only supabase/tests/booking-write-integrity.sql reaches that.
+// ============================================================================
+
+const PASSWORD = "YipyyDev!2026";
+
+/** Alice Johnson — the seeded client behind customer@yipyy.dev. */
+const CUSTOMER_CLIENT_REF = 15;
+const OWN_PET_REF = 1; // Buddy
+const STRANGER_PET_REF = 3; // Max, belonging to client 16
+
+async function signIn(page: Page, email: string) {
+  await page.goto("/login");
+  await page.fill("#email", email);
+  await page.fill("#password", PASSWORD);
+  await page.getByRole("button", { name: /sign in/i }).click();
+  await expect
+    .poll(async () => (await page.request.get("/api/permissions")).status(), {
+      timeout: 30_000,
+    })
+    .toBe(200);
+}
+
+/**
+ * Every booking this file creates carries this marker, and afterAll cancels
+ * anything wearing it.
+ *
+ * These tests write to the real database — there is no fixture layer, and the
+ * point is to exercise the actual route. Without cleanup each run would leave
+ * two live bookings on a seeded client's record, and someone would eventually
+ * find "grooming, 09:00" appointments nobody made. Cancelled rather than
+ * deleted because there is no delete policy on bookings, by design.
+ */
+const MARKER = "[e2e booking-write-integrity]";
+
+/** The shape the booking modal actually posts — facility wall-clock dates. */
+function bookingBody(overrides: Record<string, unknown> = {}) {
+  const day = new Date(Date.now() + 6 * 86_400_000).toISOString().slice(0, 10);
+  return {
+    clientId: CUSTOMER_CLIENT_REF,
+    petId: OWN_PET_REF,
+    facilityId: 11,
+    service: "grooming",
+    startDate: day,
+    endDate: day,
+    checkInTime: "09:00",
+    checkOutTime: "10:00",
+    status: "pending",
+    basePrice: 0,
+    discount: 0,
+    totalCost: 0,
+    paymentStatus: "pending",
+    specialRequests: MARKER,
+    ...overrides,
+  };
+}
+
+test.describe.configure({ mode: "serial" });
+
+test.afterAll(async ({ browser }) => {
+  const page = await browser.newPage();
+  try {
+    // As the owner: holds edit_bookings, so the cancellation is allowed for
+    // every booking regardless of which account created it.
+    await signIn(page, "owner@yipyy.dev");
+    // `id`, not `ref` — rowToBooking maps the numeric ref onto `id` for the
+    // app's Booking shape. Reading the wrong field sent PATCH /api/bookings/
+    // undefined, which answers 400, which the loop above now surfaces.
+    const bookings = (await (
+      await page.request.get("/api/bookings")
+    ).json()) as { id: number; specialRequests?: string; status: string }[];
+
+    const mine = bookings.filter(
+      (b) => b.specialRequests?.includes(MARKER) && b.status !== "cancelled",
+    );
+
+    // Count what the SERVER confirmed, not what was attempted. The first
+    // version of this reported "cancelled 2" while both bookings were still
+    // live — it counted the loop, not the outcome, which is the same mistake
+    // as a test that asserts nothing.
+    let cancelled = 0;
+    for (const b of mine) {
+      const res = await page.request.patch(`/api/bookings/${b.id}`, {
+        data: { status: "cancelled" },
+      });
+      if (res.ok()) cancelled++;
+      else console.log(`cleanup: id ${b.id} -> ${res.status()}`);
+    }
+    console.log(
+      `cleanup: ${cancelled}/${mine.length} test booking(s) cancelled`,
+    );
+  } finally {
+    await page.close();
+  }
+});
+
+test.describe("booking write integrity", () => {
+  test("a customer's price and status are the facility's to set", async ({
+    page,
+  }) => {
+    await signIn(page, "customer@yipyy.dev");
+
+    const res = await page.request.post("/api/bookings", {
+      data: bookingBody({
+        // Everything a customer should not get to decide, sent anyway.
+        status: "confirmed",
+        paymentStatus: "paid",
+        basePrice: 240,
+        discount: 40,
+        totalCost: 200,
+      }),
+    });
+
+    expect(res.status()).toBe(201);
+    const booking = (await res.json()) as Record<string, unknown>;
+
+    // The RESPONSE has to show what was stored, not what was asked for.
+    // Re-reading after the trigger is what makes that true.
+    expect(booking.status).toBe("request_submitted");
+    expect(Number(booking.totalCost ?? 0)).toBe(0);
+    expect(Number(booking.basePrice ?? 0)).toBe(0);
+  });
+
+  test("a stranger's pet is refused, and no booking is left behind", async ({
+    page,
+  }) => {
+    await signIn(page, "customer@yipyy.dev");
+
+    const before = (await (await page.request.get("/api/bookings")).json()) as
+      | unknown[]
+      | null;
+
+    const res = await page.request.post("/api/bookings", {
+      data: bookingBody({ petId: STRANGER_PET_REF }),
+    });
+
+    // 403/422 either way — what matters is that it is not a 201.
+    expect(res.status()).not.toBe(201);
+
+    // The pets are validated BEFORE the booking is written, because there is
+    // no delete policy to undo one. A half-written booking would survive.
+    const after = (await (await page.request.get("/api/bookings")).json()) as
+      | unknown[]
+      | null;
+    expect((after ?? []).length).toBe((before ?? []).length);
+  });
+
+  test("staff keep their authority over price and status", async ({ page }) => {
+    await signIn(page, "owner@yipyy.dev");
+
+    const res = await page.request.post("/api/bookings", {
+      data: bookingBody({
+        status: "confirmed",
+        basePrice: 90,
+        discount: 10,
+        totalCost: 80,
+      }),
+    });
+
+    expect(res.status()).toBe(201);
+    const booking = (await res.json()) as Record<string, unknown>;
+
+    // The other half. Without this the first test would pass just as well if
+    // the trigger zeroed everything for everybody.
+    expect(booking.status).toBe("confirmed");
+    expect(Number(booking.totalCost ?? 0)).toBe(80);
+  });
+});


### PR DESCRIPTION
## What was wrong

`20260801120000` made bookings real, and RLS there decided **whose** booking a row was. It never decided **what** a caller could put in one — different questions, and only the first was answered:

- **A customer could book at zero.** `base_price` / `discount` / `total_cost` / `tip_amount` arrived from the request body and were written as sent.
- **A customer could mark themselves paid.** `status` and `payment_status` arrived the same way, so `'confirmed'` / `'paid'` skipped the counter entirely.
- **A booking could be filed against a facility its client had never been to.** `facility_id` was caller-supplied and never checked.
- **Anyone who could see a booking could re-crew it.** `booking_pets` used the READ predicate for INSERT and DELETE — so a view-only groomer could, and so could a customer attaching a stranger's animal, which the facility would read as consent to hand that animal over.

None of it was theoretical. PostgREST is reachable directly with the anon key and a session cookie, so the Route Handler is a convenience, not a gate.

## The fix

Every rule lives in the database: a `BEFORE` trigger for *"yes, but not with those numbers"* — which RLS cannot express — plus tightened policies for the rest.

`facility_id` is **derived** from the client rather than validated, which removes the parameter from the attack surface instead of guarding it. There is no legitimate booking whose facility differs from its client's.

It deliberately **does not compute a price**. There is no rate table yet, so the honest stored value for a customer request is zero — "not priced yet" — with whatever the browser quoted preserved under `details.requestedQuote` so the counter has something to reconcile against.

It also **widens** `bookings_update` so a customer can cancel their own booking. They couldn't before — they had to phone the facility to change a row they owned. The trigger is what makes that safe: their branch can move the status to `cancelled` and nothing else, and only while the pet is not yet on site.

## Three things I found while proving it

**The SQL fixture used the real dev-account emails.** `auth.users` has a unique index on email, so on any database where those accounts exist — the seeded dev one included — the whole transaction aborts and all 20 tests report failures that are really one collision.

**The POST route ignored the `booking_pets` insert result**, which under the new policy turns a refusal into a `201` describing a booking with no animals on it. My first fix deleted the booking on failure — wrong: **there is no DELETE policy on bookings**, by design, so that cleanup would have silently done nothing and the comment would have been a lie. Pets are now validated *before* the booking is written, so the bad row never exists.

**My own e2e cleanup lied.** It reported "cancelled 2" while both bookings were still live — counting the loop rather than the outcome, and reading `ref` where the mapper returns `id`.

## Verification

**All 20 SQL checks pass**, run as the actual caller via `set local role authenticated` — the only honest way to ask what RLS permits. I proved the rollback mechanism on a throwaway row first, and confirmed afterwards that the fixture left nothing behind.

Three e2e checks cover the app path and cancel their own bookings afterwards.

**Confirmed load-bearing** by dropping the trigger — though not the way I expected. The first e2e check fails with `403` rather than storing the customer's numbers, because without the derived `facility_id` the insert policy refuses the whole row. That's recorded in the spec, because it means *this route was never the hole*. PostgREST was, and only the SQL suite reaches it.

Full e2e suite: **34 passed, 1 skipped, 2 failed** — both `staff-portal-nav`, which predate this change. Build, typecheck, lint (0 errors) and format clean.

## Note

The migration is **already applied to the live project**. I verified every assumption against the real schema first — enum values, existing rows against the new constraints, function signatures, the `locations` table, trigger ordering — so it could not fail halfway.