### PR TITLE
test(staff-nav): fix two tests that were red about the wrong thing

### DIFF
--- a/tests/e2e/staff-portal-nav.spec.ts
+++ b/tests/e2e/staff-portal-nav.spec.ts
@@ -55,6 +55,25 @@ const NAV_KEYS = [
 const GRANT = { granted: true, scope: "anytime" as const };
 const REVOKE = { granted: false, scope: "none" as const };
 
+/**
+ * Why every sign-in below revokes `open_close_register`.
+ *
+ * The employee shell is wrapped in RegisterOpenGate: anyone who can open the
+ * till is blocked by a full-screen "Start your day — count the drawer" panel
+ * until today's drawer is counted open, and the sidebar is not rendered at all
+ * while that is up. Nathalie is a manager, so she holds the permission, so
+ * these two tests were reading a sidebar that did not exist — they failed on
+ * `sidebar.getByRole("link").first()` being invisible and read as a nav
+ * regression, which is not what was wrong.
+ *
+ * Revoking it rather than counting the drawer open keeps each test about one
+ * thing; register-gate.spec.ts already owns the gate itself and uses this same
+ * escape for its "never gated" case. The only nav consequence is that "Daily
+ * Register" is absent from the sidebar under test, and nothing here asserts on
+ * it.
+ */
+const NO_REGISTER: Overrides = { open_close_register: REVOKE };
+
 type Overrides = Record<string, { granted: boolean; scope: string }>;
 
 /** Seed the cookie + RBAC localStorage BEFORE any app JS runs, then land in the
@@ -113,7 +132,7 @@ test.describe("Staff portal nav parity", () => {
     page,
     context,
   }) => {
-    await signInAs(context, page, "fs-mgr-01"); // Nathalie, primaryRole manager
+    await signInAs(context, page, "fs-mgr-01", NO_REGISTER); // Nathalie, manager
 
     const items = await sidebarItems(page);
 
@@ -160,10 +179,14 @@ test.describe("Staff portal nav parity", () => {
     page,
     context,
   }) => {
-    await signInAs(context, page, "fs-mgr-01");
+    await signInAs(context, page, "fs-mgr-01", NO_REGISTER);
     const sidebar = page.locator('[data-slot="sidebar-inner"]').first();
     await sidebar.getByRole("link", { name: "Grooming", exact: true }).click();
-    await expect(page).toHaveURL(/\/employee\/grooming/);
+    // Generous, because the dev server compiles /employee/grooming on the first
+    // hit and that can outlast the default assertion timeout. It passed
+    // whenever the route happened to be warm and failed when it was not, which
+    // is the worst kind of red: real-looking and about nothing.
+    await expect(page).toHaveURL(/\/employee\/grooming/, { timeout: 90_000 });
     // The facility grooming module renders its Check-In board, NOT a bespoke
     // "Grooming Queue" screen.
     await expect(page.getByText("Grooming Queue", { exact: true })).toHaveCount(


### PR DESCRIPTION
The two `#1` nav-parity tests have been red across every full-suite run this session, and they read like a nav regression: the sidebar had no links, so `sidebar.getByRole("link").first()` was never visible.

## The sidebar was never the problem

The employee shell is wrapped in `RegisterOpenGate`, which blocks the **entire portal** with a *"Start your day — count the drawer"* panel until today's drawer is counted open, and renders no sidebar while it is up. Nathalie is a manager, so she holds `open_close_register`, so both tests were reading a sidebar that did not exist.

The gate is correct, and `register-gate.spec.ts` covers it deliberately. Only these two tests didn't account for it — which is why they failed in a way that pointed at the wrong subsystem.

Revoking the permission rather than counting the drawer open keeps each test about one thing; it's the same escape `register-gate.spec.ts` already uses for its own "never gated" case. The only nav consequence is that "Daily Register" is absent from the sidebar under test, and nothing here asserts on it.

## Then the second test failed on something else

`toHaveURL` after clicking Grooming, timing out at the default 20s. Not a routing bug: the dev server compiles `/employee/grooming` on first hit, and the assertion outlasted it **only when the route happened to be warm already**. That's the worst kind of red — real-looking, intermittent, and about nothing.

Verified by probing the click in isolation (both the `href` and the landing path were correct), then re-running the whole file against a **deleted `.next`** — the exact condition that was failing. 5/5 cold.

## Result

Full e2e suite: **36 passed, 1 skipped, 0 failed.** First fully green run of the suite.

No production code changed — this is a test-only fix.