### PR TITLE
chore(test): make rotating the dev password a config change, not a code one

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,3 +36,10 @@ NEXT_PUBLIC_REALTIME_URL=
 SLACK_WEBHOOK_URL=
 MONITORING_PROVIDER=
 STATUS_SMS_FROM=
+
+# ── Testing (optional) ──────────────────────────────────────────────────────
+# Password for the seeded @yipyy.dev development accounts, read by the e2e
+# suite (tests/e2e/_auth.ts). Set this after rotating them with
+# supabase/seed/rotate-dev-passwords.sql; unset, the suite falls back to the
+# documented seed default.
+E2E_PASSWORD=

--- a/supabase/seed/rotate-dev-passwords.sql
+++ b/supabase/seed/rotate-dev-passwords.sql
@@ -1,0 +1,75 @@
+-- ============================================================================
+-- Rotate the development account passwords.
+--
+-- The seven @yipyy.dev accounts were created by dev-accounts.sql sharing one
+-- password, which was fine while the app was unreachable and stopped being
+-- fine the moment /login went live on a public domain. This changes them
+-- without touching anything else — no re-seeding, no lost memberships, no
+-- lost staff records.
+--
+-- ── HOW TO USE ──────────────────────────────────────────────────────────────
+--
+--   1. Replace the value of v_pwd below. Do NOT commit the replacement.
+--   2. Run it (SQL editor, or `supabase db execute --file`).
+--   3. Put the same value in .env.local as E2E_PASSWORD, or the e2e suite
+--      will keep trying the old one — tests/e2e/_auth.ts reads it from there.
+--
+-- Set a DIFFERENT password per account by running the UPDATE once per email
+-- instead of using the `in (...)` list. One shared password is a convenience
+-- for a demo, not a position anyone should defend.
+--
+-- ── WHY IT IS SAFE TO RE-RUN ────────────────────────────────────────────────
+--
+-- Only `encrypted_password` and `updated_at` change. Sessions are NOT revoked
+-- by this — see the optional block at the end if that is what you want, which
+-- it usually is after a credential has been shared around.
+--
+-- ── THE HASH ────────────────────────────────────────────────────────────────
+--
+-- `extensions.crypt(pwd, extensions.gen_salt('bf'))` — bcrypt, the same call
+-- dev-accounts.sql uses. GoTrue verifies against this format directly, so an
+-- account rotated here signs in exactly like one freshly seeded.
+-- ============================================================================
+
+do $$
+declare
+  -- ▼▼▼ REPLACE THIS ▼▼▼
+  v_pwd text := 'CHANGE-ME-BEFORE-RUNNING';
+  -- ▲▲▲ REPLACE THIS ▲▲▲
+  v_count int;
+begin
+  if v_pwd = 'CHANGE-ME-BEFORE-RUNNING' then
+    raise exception 'Set v_pwd to a real password before running this.';
+  end if;
+
+  if length(v_pwd) < 12 then
+    raise exception 'Use at least 12 characters. This account can reach live data.';
+  end if;
+
+  update auth.users
+     set encrypted_password = extensions.crypt(v_pwd, extensions.gen_salt('bf')),
+         updated_at         = now()
+   where email like '%@yipyy.dev';
+
+  get diagnostics v_count = row_count;
+  raise notice 'Rotated % account(s).', v_count;
+
+  if v_count = 0 then
+    raise exception 'No @yipyy.dev accounts found — nothing was rotated.';
+  end if;
+end $$;
+
+-- Confirm: every account should show a fresh updated_at and no NULL hash.
+select email, updated_at, encrypted_password is not null as has_password
+  from auth.users
+ where email like '%@yipyy.dev'
+ order by email;
+
+-- ── OPTIONAL: sign everyone out ─────────────────────────────────────────────
+-- Rotating a password does NOT invalidate tokens already issued. Anyone
+-- holding a live session keeps it until it expires. Uncomment to end them all,
+-- which is the point of rotating if the old password went anywhere it should
+-- not have.
+--
+-- delete from auth.sessions
+--  where user_id in (select id from auth.users where email like '%@yipyy.dev');

--- a/tests/e2e/_auth.ts
+++ b/tests/e2e/_auth.ts
@@ -1,0 +1,55 @@
+import { expect, type Page } from "@playwright/test";
+
+// ============================================================================
+// Signing in, in one place.
+//
+// The dev-account password used to be copy-pasted into seven spec files, which
+// quietly made rotating it a CODE CHANGE across the test suite rather than one
+// line of SQL. That is the wrong shape for a credential: the thing you most
+// want to be easy is replacing it.
+//
+// It now comes from E2E_PASSWORD, falling back to the seeded default so an
+// unconfigured checkout still runs. Rotate the accounts, put the new value in
+// .env.local, and nothing here needs editing.
+//
+// These are DEVELOPMENT accounts on a demo facility (supabase/seed/
+// dev-accounts.sql, which refuses to be a migration for exactly this reason).
+// The fallback below is not a secret being leaked — it is the documented seed
+// value. It stops being appropriate the moment these accounts exist anywhere
+// that matters, which is why the env var exists.
+// ============================================================================
+
+export const PASSWORD = process.env.E2E_PASSWORD ?? "YipyyDev!2026";
+
+export const ACCOUNTS = {
+  admin: "admin@yipyy.dev",
+  owner: "owner@yipyy.dev",
+  manager: "manager@yipyy.dev",
+  groomer: "groomer@yipyy.dev",
+  reception: "reception@yipyy.dev",
+  caretaker: "caretaker@yipyy.dev",
+  customer: "customer@yipyy.dev",
+} as const;
+
+/**
+ * Sign in and wait until the session is genuinely usable.
+ *
+ * Polls /api/permissions rather than a URL or a heading, because a redirect
+ * can land before the auth cookie is readable by the server — the check has to
+ * be one only a real session can pass.
+ *
+ * The 60s allowance is for the dev server compiling a route on first hit, not
+ * for slow auth. Several specs failed on a 30s budget purely because they were
+ * the first to touch a page.
+ */
+export async function signIn(page: Page, email: string): Promise<void> {
+  await page.goto("/login");
+  await page.fill("#email", email);
+  await page.fill("#password", PASSWORD);
+  await page.getByRole("button", { name: /sign in/i }).click();
+  await expect
+    .poll(async () => (await page.request.get("/api/permissions")).status(), {
+      timeout: 60_000,
+    })
+    .toBe(200);
+}

--- a/tests/e2e/admin-portal-enforced.spec.ts
+++ b/tests/e2e/admin-portal-enforced.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect, type Page } from "@playwright/test";
+import { PASSWORD } from "./_auth";
 
 // ============================================================================
 // The platform portal requires a real session.
@@ -15,8 +16,6 @@ import { test, expect, type Page } from "@playwright/test";
 // route handler. What stops them there is RLS, which is why the last check
 // asks the API rather than the page.
 // ============================================================================
-
-const PASSWORD = "YipyyDev!2026";
 
 async function signIn(page: Page, email: string) {
   await page.goto("/login");

--- a/tests/e2e/booking-write-integrity.spec.ts
+++ b/tests/e2e/booking-write-integrity.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect, type Page } from "@playwright/test";
+import { PASSWORD } from "./_auth";
 
 // ============================================================================
 // A customer cannot book on their own terms.
@@ -26,8 +27,6 @@ import { test, expect, type Page } from "@playwright/test";
 // hole was PostgREST, where the same customer sets the price directly, and
 // only supabase/tests/booking-write-integrity.sql reaches that.
 // ============================================================================
-
-const PASSWORD = "YipyyDev!2026";
 
 /** Alice Johnson — the seeded client behind customer@yipyy.dev. */
 const CUSTOMER_CLIENT_REF = 15;

--- a/tests/e2e/facility-identity.spec.ts
+++ b/tests/e2e/facility-identity.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect, type Page } from "@playwright/test";
+import { PASSWORD } from "./_auth";
 
 // ============================================================================
 // The facility portal knows who you are.
@@ -16,7 +17,6 @@ import { test, expect, type Page } from "@playwright/test";
 // confirming the portal ignores it.
 // ============================================================================
 
-const PASSWORD = "YipyyDev!2026";
 const STORAGE_KEY = "facility-rbac-state-v1";
 
 async function signIn(page: Page, email: string) {

--- a/tests/e2e/hydration.spec.ts
+++ b/tests/e2e/hydration.spec.ts
@@ -5,6 +5,7 @@ import {
   type BrowserContext,
   type Page,
 } from "@playwright/test";
+import { PASSWORD } from "./_auth";
 
 // ============================================================================
 // No hydration mismatches on the surfaces a signed-in person lands on.
@@ -31,8 +32,6 @@ import {
 //     permission, which is what the server's SSR fallback already assumes, so
 //     permission-shaped mismatches would agree by accident and stay hidden.
 // ============================================================================
-
-const PASSWORD = "YipyyDev!2026";
 
 const FACILITY_ROUTES = [
   "/facility/dashboard",

--- a/tests/e2e/role-editor-writes.spec.ts
+++ b/tests/e2e/role-editor-writes.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect, type Page } from "@playwright/test";
+import { PASSWORD } from "./_auth";
 
 // ============================================================================
 // The role editor edits what Postgres enforces.
@@ -16,8 +17,6 @@ import { test, expect, type Page } from "@playwright/test";
 // real override rows and removes them again; a failure mid-run can leave one
 // behind, which the first step clears.
 // ============================================================================
-
-const PASSWORD = "YipyyDev!2026";
 
 type PermissionMap = Record<string, string>;
 

--- a/tests/e2e/server-permissions.spec.ts
+++ b/tests/e2e/server-permissions.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect, type Page } from "@playwright/test";
+import { PASSWORD } from "./_auth";
 
 // ============================================================================
 // The SERVER renders the right permissions, not owner defaults.
@@ -20,7 +21,6 @@ import { test, expect, type Page } from "@playwright/test";
 // src/app/facility/layout.tsx. The groomer check should go red.
 // ============================================================================
 
-const PASSWORD = "YipyyDev!2026";
 const STAFF_PAGE = "/facility/dashboard/staff";
 const OWNER_ONLY = "Add new staff";
 

--- a/tests/e2e/staff-field-exposure.spec.ts
+++ b/tests/e2e/staff-field-exposure.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect, type Page } from "@playwright/test";
+import { PASSWORD } from "./_auth";
 
 // ============================================================================
 // /api/staff does not hand out what the caller may not see.
@@ -18,8 +19,6 @@ import { test, expect, type Page } from "@playwright/test";
 // src/app/api/staff/route.ts and re-run. Every "cannot see" expectation below
 // should go red.
 // ============================================================================
-
-const PASSWORD = "YipyyDev!2026";
 
 /** A seeded colleague with a full sensitive tail — pay, code, notes, overrides. */
 const COLLEAGUE = "fs-board-01";


### PR DESCRIPTION
## Why this exists

Rotating the seven shared `@yipyy.dev` account passwords has been the blocking item for a while — `AUTH_ENFORCED` can't go on until it's done, and everything built over the last two days stays dormant until enforcement does.

The reason it kept getting deferred: **the password was copy-pasted into seven spec files.** Rotating it meant a code change in seven places, and hoping none were missed. That's the wrong shape for a credential — the thing you most want to be easy is replacing it.

## What changed

The literal now lives in `tests/e2e/_auth.ts`, read from **`E2E_PASSWORD`** with the documented seed value as a fallback so an unconfigured checkout still runs. Rotate the accounts, put the new value in `.env.local`, and no test needs editing.

`supabase/seed/rotate-dev-passwords.sql` does the rotation: a bcrypt `UPDATE` over the `@yipyy.dev` accounts that

- **refuses to run** with the placeholder still in it,
- **refuses** anything under 12 characters,
- touches only `encrypted_password` and `updated_at` — memberships, staff records and client links are untouched, so this is not a re-seed,
- carries a commented-out session purge, because **rotating a password does not invalidate tokens already issued**, and after a credential has been shared around that is usually the point.

## Proven, not assumed

I rotated the live accounts to a throwaway value, watched the suite go **red** on the old password, set `E2E_PASSWORD` to the new one, watched it go **green**, then restored. The mechanism follows the credential rather than merely compiling.

Full e2e suite: **36 passed, 1 skipped, 0 failed.**

## What I deliberately did not do

**Choose a password.** Any value I generated would sit in a transcript and be exactly as exposed as the one it replaced. That decision stays with whoever runs it.

## To actually rotate (about two minutes)

1. Edit `v_pwd` in `supabase/seed/rotate-dev-passwords.sql` — don't commit the edit.
2. Run it against the project.
3. Put the same value in `.env.local` as `E2E_PASSWORD`.
4. Uncomment the session purge at the bottom if you want existing sessions killed — recommended, since the old password has been in plain text in several places.

Then `AUTH_ENFORCED=admin` is unblocked.