### PR TITLE
release: close the staff privilege escalation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,3 +36,10 @@ NEXT_PUBLIC_REALTIME_URL=
 SLACK_WEBHOOK_URL=
 MONITORING_PROVIDER=
 STATUS_SMS_FROM=
+
+# ── Testing (optional) ──────────────────────────────────────────────────────
+# Password for the seeded @yipyy.dev development accounts, read by the e2e
+# suite (tests/e2e/_auth.ts). Set this after rotating them with
+# supabase/seed/rotate-dev-passwords.sql; unset, the suite falls back to the
+# documented seed default.
+E2E_PASSWORD=

--- a/supabase/migrations/20260802140000_staff_write_integrity.sql
+++ b/supabase/migrations/20260802140000_staff_write_integrity.sql
@@ -1,0 +1,213 @@
+-- ============================================================================
+-- Staff write integrity — and the privilege escalation it closes.
+--
+-- `staff_update` lets you write your own row: `id in own_staff_ids OR
+-- has_permission(facility_id, 'manage_staff')`. Reasonable-sounding, and it
+-- was reasonable while a staff row was a directory entry.
+--
+-- It stopped being reasonable when private.resolve_permission started reading
+-- roles from it. That function computes `held_roles` as the union of the
+-- MEMBERSHIP role, staff.primary_role, and staff.additional_roles — so the
+-- staff row is an input to the permission cascade, and every staff member
+-- could write their own.
+--
+-- Demonstrated against the live project before writing this, as the groomer:
+--
+--     BEFORE  manage_roles=none     view_payroll=none    manage_staff=none
+--       update public.staff set primary_role = 'owner'
+--        where legacy_id = 'fs-dev-groomer';
+--     AFTER   manage_roles=anytime  view_payroll=anytime
+--
+-- One statement, reachable from PostgREST with the anon key and a session
+-- cookie. Not a missing feature — a live escalation.
+--
+-- There is a second, quieter half. RLS gates rows, so `manage_staff` was all
+-- you needed to write ANY column, including the ones 20260802... withholds on
+-- READ. Someone allowed to manage the roster but not to see payroll could
+-- still set it. Read and write have to agree, or the redaction is decoration.
+--
+-- ── SHAPE ───────────────────────────────────────────────────────────────────
+--
+-- A BEFORE trigger, for the same reason bookings has one: RLS answers yes/no
+-- about a row, and this has to answer "yes, but not that column".
+--
+-- Escalation attempts RAISE. Field-level overreach REVERTS silently, because
+-- the app PATCHes the whole merged object and a caller who legitimately cannot
+-- see payroll will send it back absent — that must preserve the stored value,
+-- not delete it. Reverting is what makes a redacted read safe to write back.
+-- ============================================================================
+
+create or replace function private.enforce_staff_integrity()
+returns trigger
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_can_manage  boolean;
+  v_can_payroll boolean;
+  v_can_roles   boolean;
+  v_is_self     boolean;
+  v_details     jsonb;
+  v_key         text;
+  -- Everything in `details` that is nobody's business but management's.
+  -- `notifications` is deliberately absent: your own alert preferences are
+  -- yours to set, and they carry no authority.
+  c_managed_keys constant text[] := array[
+    'employment', 'clockIn', 'calendarAccess', 'assignedLocations',
+    'upcomingAppointments', 'openTasks', 'invitationSentAt'
+  ];
+begin
+  -- service_role: seeds and server-side jobs. No JWT subject, no restriction —
+  -- the same carve-out the bookings trigger makes, and for the same reason.
+  if (select auth.uid()) is null then
+    return new;
+  end if;
+
+  v_can_manage  := private.has_permission(new.facility_id, 'manage_staff');
+  v_can_payroll := private.has_permission(new.facility_id, 'edit_payroll');
+  v_can_roles   := private.has_permission(new.facility_id, 'manage_roles');
+
+  -- ── INSERT ────────────────────────────────────────────────────────────────
+  -- The row-level right is already the staff_insert policy's job. What is left
+  -- is making sure a new row cannot be born carrying what its author may not
+  -- grant: a starting salary, or a set of permission overrides.
+  if tg_op = 'INSERT' then
+    if not v_can_payroll then
+      new.details := (coalesce(new.details, '{}'::jsonb)) - 'payroll';
+    end if;
+    if not v_can_roles then
+      new.details := (coalesce(new.details, '{}'::jsonb)) - 'permissionOverrides';
+    end if;
+    return new;
+  end if;
+
+  -- ── UPDATE ────────────────────────────────────────────────────────────────
+  v_is_self := old.id in (select private.own_staff_ids());
+
+  -- A staff row does not move between facilities. There is no transfer flow,
+  -- and `own_staff_ids` is keyed on the row id — so without this, writing your
+  -- own row lets you re-file yourself under another facility and, with the
+  -- role fields below, own it. Harmless today with one facility; a hole the
+  -- moment there are two.
+  if new.facility_id is distinct from old.facility_id then
+    raise exception 'A staff record cannot be moved between facilities.'
+      using errcode = '42501';
+  end if;
+
+  -- Pointing your staff row at somebody else's membership is the same attack
+  -- wearing a different hat: resolve_permission reaches roles THROUGH
+  -- membership_id.
+  if new.membership_id is distinct from old.membership_id and not v_can_manage then
+    raise exception 'You may not change which account a staff record belongs to.'
+      using errcode = '42501';
+  end if;
+
+  -- THE ESCALATION. These three feed held_roles in resolve_permission, so
+  -- writing them is writing your own permissions. Raising rather than
+  -- reverting: there is no legitimate path where a non-manager submits a role
+  -- change and should be told it worked.
+  if not v_can_manage
+     and (new.primary_role     is distinct from old.primary_role
+       or new.additional_roles is distinct from old.additional_roles
+       or new.legacy_id        is distinct from old.legacy_id)
+  then
+    raise exception 'You may not change your own role.'
+      using errcode = '42501';
+  end if;
+
+  if not v_can_manage
+     and (new.status        is distinct from old.status
+       or new.status_reason is distinct from old.status_reason
+       or new.status_note   is distinct from old.status_note)
+  then
+    raise exception 'Employment status is set by a manager.'
+      using errcode = '42501';
+  end if;
+
+  -- Columns that are the facility's record of a person rather than the
+  -- person's own contact details. Reverted rather than raised, so a
+  -- whole-object PATCH that happens to echo them back is not an error.
+  if not v_can_manage then
+    new.first_name          := old.first_name;
+    new.last_name           := old.last_name;
+    -- Email is the identity bridge (lib/auth/legacy-identity.ts matches the
+    -- session email against this column). Letting someone edit it lets them
+    -- detach themselves from their own record, or claim another.
+    new.email               := old.email;
+    new.job_title           := old.job_title;
+    new.service_assignments := old.service_assignments;
+    new.show_on_calendar    := old.show_on_calendar;
+    new.last_active         := old.last_active;
+    new.status_changed_at   := old.status_changed_at;
+  end if;
+
+  -- ── details ───────────────────────────────────────────────────────────────
+  -- Rebuilt from the STORED value, with permitted subtrees layered on. Built
+  -- this way round on purpose: a caller who cannot see payroll receives a row
+  -- without it (20260802... redaction) and will send it back without it. Take
+  -- `new.details` as the base and that read-side protection quietly becomes a
+  -- delete on every save.
+  v_details := coalesce(old.details, '{}'::jsonb);
+
+  if v_can_manage then
+    -- Everything except the two subtrees with their own permission.
+    v_details := coalesce(new.details, '{}'::jsonb)
+                 - 'payroll' - 'permissionOverrides';
+    v_details := v_details
+      || case when coalesce(old.details, '{}'::jsonb) ? 'payroll'
+              then jsonb_build_object('payroll', old.details -> 'payroll')
+              else '{}'::jsonb end
+      || case when coalesce(old.details, '{}'::jsonb) ? 'permissionOverrides'
+              then jsonb_build_object('permissionOverrides',
+                                      old.details -> 'permissionOverrides')
+              else '{}'::jsonb end;
+  elsif v_is_self then
+    -- Your own preferences, and nothing else. Note this branch never reaches
+    -- the managed keys, so HR notes and the clock-in code are safe from the
+    -- person they describe as well as from their colleagues.
+    if coalesce(new.details, '{}'::jsonb) ? 'notifications' then
+      v_details := v_details || jsonb_build_object(
+        'notifications', new.details -> 'notifications');
+    end if;
+  end if;
+
+  -- Belt and braces on the managed keys for the self branch: if the shape of
+  -- `details` grows a new sensitive key, it is denied by default rather than
+  -- granted by omission.
+  if not v_can_manage then
+    foreach v_key in array c_managed_keys loop
+      if coalesce(old.details, '{}'::jsonb) ? v_key then
+        v_details := v_details || jsonb_build_object(
+          v_key, old.details -> v_key);
+      else
+        v_details := v_details - v_key;
+      end if;
+    end loop;
+  end if;
+
+  -- The two subtrees with their own permission, layered last so they win.
+  if v_can_payroll and coalesce(new.details, '{}'::jsonb) ? 'payroll' then
+    v_details := v_details || jsonb_build_object('payroll', new.details -> 'payroll');
+  elsif v_can_payroll and not (coalesce(new.details, '{}'::jsonb) ? 'payroll') then
+    v_details := v_details - 'payroll';   -- genuine removal by someone allowed to
+  end if;
+
+  if v_can_roles and coalesce(new.details, '{}'::jsonb) ? 'permissionOverrides' then
+    v_details := v_details || jsonb_build_object(
+      'permissionOverrides', new.details -> 'permissionOverrides');
+  elsif v_can_roles and not (coalesce(new.details, '{}'::jsonb) ? 'permissionOverrides') then
+    v_details := v_details - 'permissionOverrides';
+  end if;
+
+  new.details := v_details;
+  return new;
+end;
+$$;
+
+-- "enforce" sorts before "set", so this runs before staff_set_updated_at if
+-- one exists — stated rather than relied on silently.
+drop trigger if exists staff_enforce_integrity on public.staff;
+create trigger staff_enforce_integrity
+  before insert or update on public.staff
+  for each row execute function private.enforce_staff_integrity();

--- a/supabase/seed/rotate-dev-passwords.sql
+++ b/supabase/seed/rotate-dev-passwords.sql
@@ -1,0 +1,75 @@
+-- ============================================================================
+-- Rotate the development account passwords.
+--
+-- The seven @yipyy.dev accounts were created by dev-accounts.sql sharing one
+-- password, which was fine while the app was unreachable and stopped being
+-- fine the moment /login went live on a public domain. This changes them
+-- without touching anything else — no re-seeding, no lost memberships, no
+-- lost staff records.
+--
+-- ── HOW TO USE ──────────────────────────────────────────────────────────────
+--
+--   1. Replace the value of v_pwd below. Do NOT commit the replacement.
+--   2. Run it (SQL editor, or `supabase db execute --file`).
+--   3. Put the same value in .env.local as E2E_PASSWORD, or the e2e suite
+--      will keep trying the old one — tests/e2e/_auth.ts reads it from there.
+--
+-- Set a DIFFERENT password per account by running the UPDATE once per email
+-- instead of using the `in (...)` list. One shared password is a convenience
+-- for a demo, not a position anyone should defend.
+--
+-- ── WHY IT IS SAFE TO RE-RUN ────────────────────────────────────────────────
+--
+-- Only `encrypted_password` and `updated_at` change. Sessions are NOT revoked
+-- by this — see the optional block at the end if that is what you want, which
+-- it usually is after a credential has been shared around.
+--
+-- ── THE HASH ────────────────────────────────────────────────────────────────
+--
+-- `extensions.crypt(pwd, extensions.gen_salt('bf'))` — bcrypt, the same call
+-- dev-accounts.sql uses. GoTrue verifies against this format directly, so an
+-- account rotated here signs in exactly like one freshly seeded.
+-- ============================================================================
+
+do $$
+declare
+  -- ▼▼▼ REPLACE THIS ▼▼▼
+  v_pwd text := 'CHANGE-ME-BEFORE-RUNNING';
+  -- ▲▲▲ REPLACE THIS ▲▲▲
+  v_count int;
+begin
+  if v_pwd = 'CHANGE-ME-BEFORE-RUNNING' then
+    raise exception 'Set v_pwd to a real password before running this.';
+  end if;
+
+  if length(v_pwd) < 12 then
+    raise exception 'Use at least 12 characters. This account can reach live data.';
+  end if;
+
+  update auth.users
+     set encrypted_password = extensions.crypt(v_pwd, extensions.gen_salt('bf')),
+         updated_at         = now()
+   where email like '%@yipyy.dev';
+
+  get diagnostics v_count = row_count;
+  raise notice 'Rotated % account(s).', v_count;
+
+  if v_count = 0 then
+    raise exception 'No @yipyy.dev accounts found — nothing was rotated.';
+  end if;
+end $$;
+
+-- Confirm: every account should show a fresh updated_at and no NULL hash.
+select email, updated_at, encrypted_password is not null as has_password
+  from auth.users
+ where email like '%@yipyy.dev'
+ order by email;
+
+-- ── OPTIONAL: sign everyone out ─────────────────────────────────────────────
+-- Rotating a password does NOT invalidate tokens already issued. Anyone
+-- holding a live session keeps it until it expires. Uncomment to end them all,
+-- which is the point of rotating if the old password went anywhere it should
+-- not have.
+--
+-- delete from auth.sessions
+--  where user_id in (select id from auth.users where email like '%@yipyy.dev');

--- a/supabase/tests/staff-write-integrity.sql
+++ b/supabase/tests/staff-write-integrity.sql
@@ -1,0 +1,418 @@
+-- ============================================================================
+-- Staff write integrity — behaviour tests for 20260802140000.
+--
+-- Run as the caller (`set local role authenticated` + a JWT subject), which is
+-- the position a browser holding the anon key and a session cookie is in.
+-- Testing through /api/staff would prove the wrong thing: PostgREST is
+-- reachable directly, so the route is a convenience and not a gate.
+--
+--   psql "$(supabase status -o json | jq -r .DB_URL)" \
+--     -f supabase/tests/staff-write-integrity.sql
+--
+-- One transaction, rolled back. Fixture slugs are `sw-test-*` and fixture
+-- emails are @example.invalid, so it cannot collide with a seeded database —
+-- the booking suite learned that the hard way when it borrowed the real
+-- dev-account addresses and hit the unique index on auth.users.email.
+--
+-- TO CONFIRM THESE FAIL WITHOUT THE FIX: drop the staff_enforce_integrity
+-- trigger and re-run. T1 is the one that matters — it is a live privilege
+-- escalation, not a missing feature.
+-- ============================================================================
+
+begin;
+
+set local client_min_messages to warning;
+
+create temp table tap (n serial, name text, ok boolean, detail text);
+grant all on tap to authenticated;
+
+create or replace function pg_temp.t(p_name text, p_ok boolean, p_detail text default '')
+returns void language sql as $$
+  insert into tap(name, ok, detail) values (p_name, p_ok, p_detail);
+$$;
+
+-- ── Fixture ─────────────────────────────────────────────────────────────────
+-- FOUR CALLERS, because the interesting cases are the partial ones.
+--
+--   owner    — everything, including edit_payroll and manage_roles
+--   manager  — manage_staff and VIEW payroll, but NOT edit_payroll or
+--              manage_roles. This is the preset as shipped, not a contrivance:
+--              a manager runs the roster, the owner sets the wages.
+--   clerk    — manage_staff with view_payroll revoked too, so they receive a
+--              REDACTED row. The round-trip case.
+--   groomer  — the subject, and the attacker in T1-T9.
+--
+-- The first version of this file assumed a manager could set pay and reported
+-- three failures that were really one wrong assumption about the role model.
+-- The trigger was right; the test was not.
+insert into auth.users (id, email) values
+  ('00000000-0000-0000-0000-0000000000b0', 'sw-test-owner@example.invalid'),
+  ('00000000-0000-0000-0000-0000000000b1', 'sw-test-manager@example.invalid'),
+  ('00000000-0000-0000-0000-0000000000b2', 'sw-test-groomer@example.invalid'),
+  ('00000000-0000-0000-0000-0000000000b3', 'sw-test-clerk@example.invalid')
+on conflict (id) do nothing;
+
+insert into public.profiles (id, email, full_name) values
+  ('00000000-0000-0000-0000-0000000000b0', 'sw-test-owner@example.invalid',   'Owner'),
+  ('00000000-0000-0000-0000-0000000000b1', 'sw-test-manager@example.invalid', 'Manager'),
+  ('00000000-0000-0000-0000-0000000000b2', 'sw-test-groomer@example.invalid', 'Groomer'),
+  ('00000000-0000-0000-0000-0000000000b3', 'sw-test-clerk@example.invalid',   'Clerk')
+on conflict (id) do nothing;
+
+insert into public.orgs (id, name, slug) values
+  ('00000000-0000-0000-0000-0000000000e0', 'Staff-Write Test Org', 'sw-test-org');
+
+insert into public.facilities (id, org_id, name, slug, legacy_id) values
+  ('00000000-0000-0000-0000-0000000000e1', '00000000-0000-0000-0000-0000000000e0',
+   'SW Facility', 'sw-test-facility', 'sw-test-a'),
+  ('00000000-0000-0000-0000-0000000000e2', '00000000-0000-0000-0000-0000000000e0',
+   'SW Facility Two', 'sw-test-facility-2', 'sw-test-b');
+
+insert into public.facility_memberships (id, profile_id, facility_id, role, is_active) values
+  ('00000000-0000-0000-0000-0000000000c0', '00000000-0000-0000-0000-0000000000b0',
+   '00000000-0000-0000-0000-0000000000e1', 'owner',   true),
+  ('00000000-0000-0000-0000-0000000000c1', '00000000-0000-0000-0000-0000000000b1',
+   '00000000-0000-0000-0000-0000000000e1', 'manager', true),
+  ('00000000-0000-0000-0000-0000000000c2', '00000000-0000-0000-0000-0000000000b2',
+   '00000000-0000-0000-0000-0000000000e1', 'groomer', true),
+  ('00000000-0000-0000-0000-0000000000c3', '00000000-0000-0000-0000-0000000000b3',
+   '00000000-0000-0000-0000-0000000000e1', 'manager', true);
+
+-- The clerk keeps manage_staff but loses the ability to SEE pay, which is what
+-- makes them the redacted-round-trip case. The manager needs no override: the
+-- shipped preset already grants view_payroll without edit_payroll.
+insert into public.membership_permissions (membership_id, permission_key, scope) values
+  ('00000000-0000-0000-0000-0000000000c3', 'view_payroll',  'none');
+
+insert into public.staff
+  (id, facility_id, membership_id, legacy_id, first_name, last_name, email,
+   phone, primary_role, status, details)
+values
+  ('00000000-0000-0000-0000-0000000000d1', '00000000-0000-0000-0000-0000000000e1',
+   '00000000-0000-0000-0000-0000000000c2', 'sw-groomer', 'Gina', 'Groomer',
+   'sw-test-groomer@example.invalid', '555-0100', 'groomer', 'active',
+   jsonb_build_object(
+     'payroll', jsonb_build_object('hourlyRate', 24, 'generalServiceCommission', 8,
+                                   'tipsRate', 100, 'overrides', '[]'::jsonb),
+     'permissionOverrides', jsonb_build_object('view_petcams',
+       jsonb_build_object('granted', true, 'scope', 'anytime')),
+     'employment', jsonb_build_object('hireDate', '2025-01-05',
+                                      'employmentType', 'full_time',
+                                      'notes', 'Confidential HR note.'),
+     'clockIn', jsonb_build_object('requireAccessCode', true, 'accessCode', '4242'),
+     'notifications', jsonb_build_object('invoice_paid', 'related_to_them')));
+
+-- ── T1: the escalation ──────────────────────────────────────────────────────
+do $$
+declare v_ok boolean; v_scope text;
+begin
+  perform set_config('request.jwt.claim.sub', '00000000-0000-0000-0000-0000000000b2', true);
+  set local role authenticated;
+  begin
+    update public.staff set primary_role = 'owner'
+     where id = '00000000-0000-0000-0000-0000000000d1';
+    v_ok := false;
+  exception when insufficient_privilege then v_ok := true;
+  end;
+  select scope::text into v_scope from public.my_permissions() where permission_key = 'manage_roles';
+  reset role;
+  perform pg_temp.t('T1  a groomer cannot make themselves owner', v_ok and v_scope = 'none',
+            format('refused=%s manage_roles=%s', v_ok, v_scope));
+exception when others then
+  reset role; perform pg_temp.t('T1  self role escalation', false, sqlerrm);
+end $$;
+
+-- ── T2: additional_roles is the same door ───────────────────────────────────
+do $$
+declare v_ok boolean;
+begin
+  perform set_config('request.jwt.claim.sub', '00000000-0000-0000-0000-0000000000b2', true);
+  set local role authenticated;
+  begin
+    update public.staff set additional_roles = array['owner']::public.facility_staff_role[]
+     where id = '00000000-0000-0000-0000-0000000000d1';
+    v_ok := false;
+  exception when insufficient_privilege then v_ok := true;
+  end;
+  reset role;
+  perform pg_temp.t('T2  nor via additional_roles', v_ok);
+exception when others then
+  reset role; perform pg_temp.t('T2  additional_roles', false, sqlerrm);
+end $$;
+
+-- ── T3: nor by re-filing under another facility ─────────────────────────────
+do $$
+declare v_ok boolean;
+begin
+  perform set_config('request.jwt.claim.sub', '00000000-0000-0000-0000-0000000000b2', true);
+  set local role authenticated;
+  begin
+    update public.staff set facility_id = '00000000-0000-0000-0000-0000000000e2'
+     where id = '00000000-0000-0000-0000-0000000000d1';
+    v_ok := false;
+  exception when insufficient_privilege then v_ok := true;
+  end;
+  reset role;
+  perform pg_temp.t('T3  nor by moving to another facility', v_ok);
+exception when others then
+  reset role; perform pg_temp.t('T3  facility move', false, sqlerrm);
+end $$;
+
+-- ── T4: nor by claiming another account's membership ────────────────────────
+do $$
+declare v_ok boolean;
+begin
+  perform set_config('request.jwt.claim.sub', '00000000-0000-0000-0000-0000000000b2', true);
+  set local role authenticated;
+  begin
+    update public.staff set membership_id = '00000000-0000-0000-0000-0000000000c1'
+     where id = '00000000-0000-0000-0000-0000000000d1';
+    v_ok := false;
+  exception when insufficient_privilege then v_ok := true;
+  end;
+  reset role;
+  perform pg_temp.t('T4  nor by claiming a manager''s membership', v_ok);
+exception when others then
+  reset role; perform pg_temp.t('T4  membership claim', false, sqlerrm);
+end $$;
+
+-- ── T5: nor by promoting themselves out of "inactive" ───────────────────────
+do $$
+declare v_ok boolean;
+begin
+  perform set_config('request.jwt.claim.sub', '00000000-0000-0000-0000-0000000000b2', true);
+  set local role authenticated;
+  begin
+    update public.staff set status = 'terminated'
+     where id = '00000000-0000-0000-0000-0000000000d1';
+    v_ok := false;
+  exception when insufficient_privilege then v_ok := true;
+  end;
+  reset role;
+  perform pg_temp.t('T5  employment status is a manager''s to set', v_ok);
+exception when others then
+  reset role; perform pg_temp.t('T5  status', false, sqlerrm);
+end $$;
+
+-- ── T6: self-service still works ────────────────────────────────────────────
+do $$
+declare r public.staff;
+begin
+  perform set_config('request.jwt.claim.sub', '00000000-0000-0000-0000-0000000000b2', true);
+  set local role authenticated;
+  update public.staff
+     set phone = '555-0199',
+         details = coalesce(details, '{}'::jsonb) || jsonb_build_object(
+           'notifications', jsonb_build_object('invoice_paid', 'do_not_notify'))
+   where id = '00000000-0000-0000-0000-0000000000d1';
+  reset role;
+  select * into r from public.staff where id = '00000000-0000-0000-0000-0000000000d1';
+  perform pg_temp.t('T6  you may still change your own phone and alerts',
+            r.phone = '555-0199'
+            and r.details->'notifications'->>'invoice_paid' = 'do_not_notify',
+            format('phone=%s notif=%s', r.phone, r.details->'notifications'->>'invoice_paid'));
+exception when others then
+  reset role; perform pg_temp.t('T6  self-service', false, sqlerrm);
+end $$;
+
+-- ── T7: and that self-edit must not have touched anything else ──────────────
+do $$
+declare r public.staff;
+begin
+  select * into r from public.staff where id = '00000000-0000-0000-0000-0000000000d1';
+  perform pg_temp.t('T7  the self-edit left pay, HR notes and the code alone',
+            (r.details->'payroll'->>'hourlyRate')::numeric = 24
+            and r.details->'employment'->>'notes' = 'Confidential HR note.'
+            and r.details->'clockIn'->>'accessCode' = '4242'
+            and r.details ? 'permissionOverrides',
+            format('rate=%s note=%s code=%s',
+                   r.details->'payroll'->>'hourlyRate',
+                   r.details->'employment'->>'notes',
+                   r.details->'clockIn'->>'accessCode'));
+end $$;
+
+-- ── T8: a groomer cannot give themselves a raise ────────────────────────────
+do $$
+declare r public.staff;
+begin
+  perform set_config('request.jwt.claim.sub', '00000000-0000-0000-0000-0000000000b2', true);
+  set local role authenticated;
+  update public.staff
+     set details = coalesce(details, '{}'::jsonb) || jsonb_build_object(
+       'payroll', jsonb_build_object('hourlyRate', 999, 'generalServiceCommission', 50,
+                                     'tipsRate', 100, 'overrides', '[]'::jsonb))
+   where id = '00000000-0000-0000-0000-0000000000d1';
+  reset role;
+  select * into r from public.staff where id = '00000000-0000-0000-0000-0000000000d1';
+  perform pg_temp.t('T8  a groomer cannot write their own pay',
+            (r.details->'payroll'->>'hourlyRate')::numeric = 24,
+            format('rate=%s', r.details->'payroll'->>'hourlyRate'));
+exception when others then
+  reset role; perform pg_temp.t('T8  self payroll', false, sqlerrm);
+end $$;
+
+-- ── T9: nor grant themselves a permission override ──────────────────────────
+do $$
+declare r public.staff;
+begin
+  perform set_config('request.jwt.claim.sub', '00000000-0000-0000-0000-0000000000b2', true);
+  set local role authenticated;
+  update public.staff
+     set details = coalesce(details, '{}'::jsonb) || jsonb_build_object(
+       'permissionOverrides', jsonb_build_object('manage_roles',
+         jsonb_build_object('granted', true, 'scope', 'anytime')))
+   where id = '00000000-0000-0000-0000-0000000000d1';
+  reset role;
+  select * into r from public.staff where id = '00000000-0000-0000-0000-0000000000d1';
+  perform pg_temp.t('T9  nor grant themselves a permission override',
+            not (r.details->'permissionOverrides' ? 'manage_roles'),
+            coalesce(r.details->>'permissionOverrides', '(absent)'));
+exception when others then
+  reset role; perform pg_temp.t('T9  self override', false, sqlerrm);
+end $$;
+
+-- ── T10: an owner can do the things an owner does ───────────────────────────
+do $$
+declare r public.staff;
+begin
+  perform set_config('request.jwt.claim.sub', '00000000-0000-0000-0000-0000000000b0', true);
+  set local role authenticated;
+  update public.staff
+     set primary_role = 'reception',
+         status = 'inactive',
+         status_note = 'On leave',
+         details = coalesce(details, '{}'::jsonb) || jsonb_build_object(
+           'payroll', jsonb_build_object('hourlyRate', 30, 'generalServiceCommission', 8,
+                                         'tipsRate', 100, 'overrides', '[]'::jsonb))
+   where id = '00000000-0000-0000-0000-0000000000d1';
+  reset role;
+  select * into r from public.staff where id = '00000000-0000-0000-0000-0000000000d1';
+  perform pg_temp.t('T10 an owner sets roles, status and pay',
+            r.primary_role = 'reception' and r.status = 'inactive'
+            and r.status_note = 'On leave'
+            and (r.details->'payroll'->>'hourlyRate')::numeric = 30,
+            format('role=%s status=%s rate=%s', r.primary_role, r.status,
+                   r.details->'payroll'->>'hourlyRate'));
+exception when others then
+  reset role; perform pg_temp.t('T10 manager authority', false, sqlerrm);
+end $$;
+
+-- ── T11: THE ONE THAT MATTERS FOR DATA LOSS ─────────────────────────────────
+-- The clerk holds manage_staff but not view_payroll. /api/staff therefore
+-- sends them a row with `payroll` ABSENT. Saving the profile sends it back
+-- absent — and that must not read as "delete their salary".
+do $$
+declare r public.staff;
+begin
+  perform set_config('request.jwt.claim.sub', '00000000-0000-0000-0000-0000000000b3', true);
+  set local role authenticated;
+  update public.staff
+     set job_title = 'Senior Groomer',
+         details = jsonb_build_object(
+           'employment', jsonb_build_object('hireDate', '2025-01-05',
+                                            'employmentType', 'full_time',
+                                            'notes', 'Confidential HR note.'),
+           'clockIn', jsonb_build_object('requireAccessCode', true, 'accessCode', '4242'),
+           'notifications', jsonb_build_object('invoice_paid', 'do_not_notify'))
+   where id = '00000000-0000-0000-0000-0000000000d1';
+  reset role;
+  select * into r from public.staff where id = '00000000-0000-0000-0000-0000000000d1';
+  perform pg_temp.t('T11 a redacted read written back does not delete the pay',
+            (r.details->'payroll'->>'hourlyRate')::numeric = 30
+            and r.job_title = 'Senior Groomer',
+            format('rate=%s title=%s', r.details->'payroll'->>'hourlyRate', r.job_title));
+exception when others then
+  reset role; perform pg_temp.t('T11 redacted round-trip', false, sqlerrm);
+end $$;
+
+-- ── T12: seeing pay is not setting pay ──────────────────────────────────────
+-- The MANAGER, on the shipped preset: manage_staff + view_payroll, no
+-- edit_payroll. The sharpest version of "read and write are different rights",
+-- because this caller can see the exact number they are forbidden to change.
+do $$
+declare r public.staff;
+begin
+  perform set_config('request.jwt.claim.sub', '00000000-0000-0000-0000-0000000000b1', true);
+  set local role authenticated;
+  update public.staff
+     set details = coalesce(details, '{}'::jsonb) || jsonb_build_object(
+       'payroll', jsonb_build_object('hourlyRate', 1, 'generalServiceCommission', 0,
+                                     'tipsRate', 0, 'overrides', '[]'::jsonb))
+   where id = '00000000-0000-0000-0000-0000000000d1';
+  reset role;
+  select * into r from public.staff where id = '00000000-0000-0000-0000-0000000000d1';
+  perform pg_temp.t('T12 a manager may SEE pay without being able to SET it',
+            (r.details->'payroll'->>'hourlyRate')::numeric = 30,
+            format('rate=%s', r.details->'payroll'->>'hourlyRate'));
+exception when others then
+  reset role; perform pg_temp.t('T12 manager payroll', false, sqlerrm);
+end $$;
+
+-- ── T13: nor rewrite someone's permission overrides ─────────────────────────
+do $$
+declare r public.staff;
+begin
+  perform set_config('request.jwt.claim.sub', '00000000-0000-0000-0000-0000000000b3', true);
+  set local role authenticated;
+  update public.staff
+     set details = coalesce(details, '{}'::jsonb) || jsonb_build_object(
+       'permissionOverrides', jsonb_build_object('manage_roles',
+         jsonb_build_object('granted', true, 'scope', 'anytime')))
+   where id = '00000000-0000-0000-0000-0000000000d1';
+  reset role;
+  select * into r from public.staff where id = '00000000-0000-0000-0000-0000000000d1';
+  perform pg_temp.t('T13 manage_staff alone does not let you grant permissions',
+            not (r.details->'permissionOverrides' ? 'manage_roles')
+            and (r.details->'permissionOverrides' ? 'view_petcams'),
+            coalesce(r.details->>'permissionOverrides', '(absent)'));
+exception when others then
+  reset role; perform pg_temp.t('T13 clerk overrides', false, sqlerrm);
+end $$;
+
+-- ── T14: a new hire cannot be born with a salary its author may not set ─────
+do $$
+declare r public.staff;
+begin
+  perform set_config('request.jwt.claim.sub', '00000000-0000-0000-0000-0000000000b3', true);
+  set local role authenticated;
+  insert into public.staff
+    (id, facility_id, legacy_id, first_name, last_name, email, primary_role, status, details)
+  values ('00000000-0000-0000-0000-0000000000d2', '00000000-0000-0000-0000-0000000000e1',
+          'sw-new', 'New', 'Hire', 'sw-test-new@example.invalid', 'groomer', 'active',
+          jsonb_build_object('payroll', jsonb_build_object('hourlyRate', 500)))
+  returning * into r;
+  reset role;
+  perform pg_temp.t('T14 a new hire cannot arrive pre-paid by someone who may not pay',
+            not (r.details ? 'payroll'),
+            coalesce(r.details->>'payroll', '(absent)'));
+exception when others then
+  reset role; perform pg_temp.t('T14 insert payroll', false, sqlerrm);
+end $$;
+
+-- ── T15: the seed path must survive ─────────────────────────────────────────
+do $$
+declare r public.staff;
+begin
+  perform set_config('request.jwt.claim.sub', '', true);
+  insert into public.staff
+    (id, facility_id, legacy_id, first_name, last_name, email, primary_role, status, details)
+  values ('00000000-0000-0000-0000-0000000000d3', '00000000-0000-0000-0000-0000000000e1',
+          'sw-seed', 'Seed', 'Person', 'sw-test-seed@example.invalid', 'owner', 'active',
+          jsonb_build_object('payroll', jsonb_build_object('hourlyRate', 42)))
+  returning * into r;
+  perform pg_temp.t('T15 seeds keep everything they are given',
+            (r.details->'payroll'->>'hourlyRate')::numeric = 42 and r.primary_role = 'owner',
+            format('rate=%s role=%s', r.details->'payroll'->>'hourlyRate', r.primary_role));
+exception when others then
+  perform pg_temp.t('T15 seed path', false, sqlerrm);
+end $$;
+
+-- ── Report ──────────────────────────────────────────────────────────────────
+select case when ok then '  PASS  ' else '> FAIL <' end as result, name, detail
+  from tap order by n;
+
+select count(*) filter (where ok) || ' passed, '
+    || count(*) filter (where not ok) || ' failed' as summary
+  from tap;
+
+rollback;

--- a/tests/e2e/_auth.ts
+++ b/tests/e2e/_auth.ts
@@ -1,0 +1,55 @@
+import { expect, type Page } from "@playwright/test";
+
+// ============================================================================
+// Signing in, in one place.
+//
+// The dev-account password used to be copy-pasted into seven spec files, which
+// quietly made rotating it a CODE CHANGE across the test suite rather than one
+// line of SQL. That is the wrong shape for a credential: the thing you most
+// want to be easy is replacing it.
+//
+// It now comes from E2E_PASSWORD, falling back to the seeded default so an
+// unconfigured checkout still runs. Rotate the accounts, put the new value in
+// .env.local, and nothing here needs editing.
+//
+// These are DEVELOPMENT accounts on a demo facility (supabase/seed/
+// dev-accounts.sql, which refuses to be a migration for exactly this reason).
+// The fallback below is not a secret being leaked — it is the documented seed
+// value. It stops being appropriate the moment these accounts exist anywhere
+// that matters, which is why the env var exists.
+// ============================================================================
+
+export const PASSWORD = process.env.E2E_PASSWORD ?? "YipyyDev!2026";
+
+export const ACCOUNTS = {
+  admin: "admin@yipyy.dev",
+  owner: "owner@yipyy.dev",
+  manager: "manager@yipyy.dev",
+  groomer: "groomer@yipyy.dev",
+  reception: "reception@yipyy.dev",
+  caretaker: "caretaker@yipyy.dev",
+  customer: "customer@yipyy.dev",
+} as const;
+
+/**
+ * Sign in and wait until the session is genuinely usable.
+ *
+ * Polls /api/permissions rather than a URL or a heading, because a redirect
+ * can land before the auth cookie is readable by the server — the check has to
+ * be one only a real session can pass.
+ *
+ * The 60s allowance is for the dev server compiling a route on first hit, not
+ * for slow auth. Several specs failed on a 30s budget purely because they were
+ * the first to touch a page.
+ */
+export async function signIn(page: Page, email: string): Promise<void> {
+  await page.goto("/login");
+  await page.fill("#email", email);
+  await page.fill("#password", PASSWORD);
+  await page.getByRole("button", { name: /sign in/i }).click();
+  await expect
+    .poll(async () => (await page.request.get("/api/permissions")).status(), {
+      timeout: 60_000,
+    })
+    .toBe(200);
+}

--- a/tests/e2e/admin-portal-enforced.spec.ts
+++ b/tests/e2e/admin-portal-enforced.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect, type Page } from "@playwright/test";
+import { PASSWORD } from "./_auth";
 
 // ============================================================================
 // The platform portal requires a real session.
@@ -15,8 +16,6 @@ import { test, expect, type Page } from "@playwright/test";
 // route handler. What stops them there is RLS, which is why the last check
 // asks the API rather than the page.
 // ============================================================================
-
-const PASSWORD = "YipyyDev!2026";
 
 async function signIn(page: Page, email: string) {
   await page.goto("/login");

--- a/tests/e2e/booking-write-integrity.spec.ts
+++ b/tests/e2e/booking-write-integrity.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect, type Page } from "@playwright/test";
+import { PASSWORD } from "./_auth";
 
 // ============================================================================
 // A customer cannot book on their own terms.
@@ -26,8 +27,6 @@ import { test, expect, type Page } from "@playwright/test";
 // hole was PostgREST, where the same customer sets the price directly, and
 // only supabase/tests/booking-write-integrity.sql reaches that.
 // ============================================================================
-
-const PASSWORD = "YipyyDev!2026";
 
 /** Alice Johnson — the seeded client behind customer@yipyy.dev. */
 const CUSTOMER_CLIENT_REF = 15;

--- a/tests/e2e/facility-identity.spec.ts
+++ b/tests/e2e/facility-identity.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect, type Page } from "@playwright/test";
+import { PASSWORD } from "./_auth";
 
 // ============================================================================
 // The facility portal knows who you are.
@@ -16,7 +17,6 @@ import { test, expect, type Page } from "@playwright/test";
 // confirming the portal ignores it.
 // ============================================================================
 
-const PASSWORD = "YipyyDev!2026";
 const STORAGE_KEY = "facility-rbac-state-v1";
 
 async function signIn(page: Page, email: string) {

--- a/tests/e2e/hydration.spec.ts
+++ b/tests/e2e/hydration.spec.ts
@@ -5,6 +5,7 @@ import {
   type BrowserContext,
   type Page,
 } from "@playwright/test";
+import { PASSWORD } from "./_auth";
 
 // ============================================================================
 // No hydration mismatches on the surfaces a signed-in person lands on.
@@ -31,8 +32,6 @@ import {
 //     permission, which is what the server's SSR fallback already assumes, so
 //     permission-shaped mismatches would agree by accident and stay hidden.
 // ============================================================================
-
-const PASSWORD = "YipyyDev!2026";
 
 const FACILITY_ROUTES = [
   "/facility/dashboard",

--- a/tests/e2e/role-editor-writes.spec.ts
+++ b/tests/e2e/role-editor-writes.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect, type Page } from "@playwright/test";
+import { PASSWORD } from "./_auth";
 
 // ============================================================================
 // The role editor edits what Postgres enforces.
@@ -16,8 +17,6 @@ import { test, expect, type Page } from "@playwright/test";
 // real override rows and removes them again; a failure mid-run can leave one
 // behind, which the first step clears.
 // ============================================================================
-
-const PASSWORD = "YipyyDev!2026";
 
 type PermissionMap = Record<string, string>;
 

--- a/tests/e2e/server-permissions.spec.ts
+++ b/tests/e2e/server-permissions.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect, type Page } from "@playwright/test";
+import { PASSWORD } from "./_auth";
 
 // ============================================================================
 // The SERVER renders the right permissions, not owner defaults.
@@ -20,7 +21,6 @@ import { test, expect, type Page } from "@playwright/test";
 // src/app/facility/layout.tsx. The groomer check should go red.
 // ============================================================================
 
-const PASSWORD = "YipyyDev!2026";
 const STAFF_PAGE = "/facility/dashboard/staff";
 const OWNER_ONLY = "Add new staff";
 

--- a/tests/e2e/staff-field-exposure.spec.ts
+++ b/tests/e2e/staff-field-exposure.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect, type Page } from "@playwright/test";
+import { PASSWORD } from "./_auth";
 
 // ============================================================================
 // /api/staff does not hand out what the caller may not see.
@@ -18,8 +19,6 @@ import { test, expect, type Page } from "@playwright/test";
 // src/app/api/staff/route.ts and re-run. Every "cannot see" expectation below
 // should go red.
 // ============================================================================
-
-const PASSWORD = "YipyyDev!2026";
 
 /** A seeded colleague with a full sensitive tail — pay, code, notes, overrides. */
 const COLLEAGUE = "fs-board-01";

--- a/tests/e2e/staff-portal-nav.spec.ts
+++ b/tests/e2e/staff-portal-nav.spec.ts
@@ -55,6 +55,25 @@ const NAV_KEYS = [
 const GRANT = { granted: true, scope: "anytime" as const };
 const REVOKE = { granted: false, scope: "none" as const };
 
+/**
+ * Why every sign-in below revokes `open_close_register`.
+ *
+ * The employee shell is wrapped in RegisterOpenGate: anyone who can open the
+ * till is blocked by a full-screen "Start your day — count the drawer" panel
+ * until today's drawer is counted open, and the sidebar is not rendered at all
+ * while that is up. Nathalie is a manager, so she holds the permission, so
+ * these two tests were reading a sidebar that did not exist — they failed on
+ * `sidebar.getByRole("link").first()` being invisible and read as a nav
+ * regression, which is not what was wrong.
+ *
+ * Revoking it rather than counting the drawer open keeps each test about one
+ * thing; register-gate.spec.ts already owns the gate itself and uses this same
+ * escape for its "never gated" case. The only nav consequence is that "Daily
+ * Register" is absent from the sidebar under test, and nothing here asserts on
+ * it.
+ */
+const NO_REGISTER: Overrides = { open_close_register: REVOKE };
+
 type Overrides = Record<string, { granted: boolean; scope: string }>;
 
 /** Seed the cookie + RBAC localStorage BEFORE any app JS runs, then land in the
@@ -113,7 +132,7 @@ test.describe("Staff portal nav parity", () => {
     page,
     context,
   }) => {
-    await signInAs(context, page, "fs-mgr-01"); // Nathalie, primaryRole manager
+    await signInAs(context, page, "fs-mgr-01", NO_REGISTER); // Nathalie, manager
 
     const items = await sidebarItems(page);
 
@@ -160,10 +179,14 @@ test.describe("Staff portal nav parity", () => {
     page,
     context,
   }) => {
-    await signInAs(context, page, "fs-mgr-01");
+    await signInAs(context, page, "fs-mgr-01", NO_REGISTER);
     const sidebar = page.locator('[data-slot="sidebar-inner"]').first();
     await sidebar.getByRole("link", { name: "Grooming", exact: true }).click();
-    await expect(page).toHaveURL(/\/employee\/grooming/);
+    // Generous, because the dev server compiles /employee/grooming on the first
+    // hit and that can outlast the default assertion timeout. It passed
+    // whenever the route happened to be warm and failed when it was not, which
+    // is the worst kind of red: real-looking and about nothing.
+    await expect(page).toHaveURL(/\/employee\/grooming/, { timeout: 90_000 });
     // The facility grooming module renders its Check-In board, NOT a bespoke
     // "Grooming Queue" screen.
     await expect(page.getByText("Grooming Queue", { exact: true })).toHaveCount(


### PR DESCRIPTION
Three commits. One of them closes a live privilege escalation, which is why this is going out now rather than waiting.

## 1. Staff privilege escalation (#113) — the reason for this release

Any staff member with a linked account could make themselves the owner:

```
BEFORE  manage_roles=none     view_payroll=none    manage_staff=none
  update public.staff set primary_role = 'owner' where legacy_id = 'fs-dev-groomer';
AFTER   manage_roles=anytime  view_payroll=anytime
```

`staff_update` lets you write your own row, and `resolve_permission` reads roles *from that row* — so the staff record was an input to the permission cascade that everyone could edit. Reachable from PostgREST with the anon key and a session cookie.

Also closed: `manage_staff` alone let you write **any** column, including the ones the read path withholds. Someone allowed to run the roster but not see payroll could still set it.

## 2. Two test fixes (#111, #112)

The red `staff-portal-nav` pair turned out to be blocked by `RegisterOpenGate`, not a nav regression, plus a first-compile timeout. And the dev-account password moved out of seven spec files into `E2E_PASSWORD`, so rotating it is a config change rather than a code change.

## Risk

**Low, and it only removes capability from callers who should never have had it.**

- **The migration is already applied to the live database** — it closes an active escalation, so it went in when it was proven rather than when this PR merged. This ships the record and the tests.
- **Owners and managers are unaffected** in everything they legitimately do: an owner still sets roles, status and pay; a manager still runs the roster and sees pay.
- **Self-service still works** — phone and notification preferences remain editable by the person they belong to.
- **The seed path is untouched** — `service_role` has no `auth.uid()` and bypasses the trigger entirely.
- **No application code changed** in the escalation fix. The other two commits are test-only.
- Nothing here depends on `AUTH_ENFORCED`, which stays unset.

## Verified

**15/15** SQL checks as the actual caller (`set local role authenticated`), covering the escalation by role, by `additional_roles`, by facility move and by membership claim; self-service still working; a groomer unable to pay themselves or grant themselves an override; an owner retaining full authority; the redacted round-trip preserving pay it could not see; and the seed path unaffected. Fixture confirmed to leave nothing behind.

Full e2e suite: **36 passed, 1 skipped, 0 failed.** Build, typecheck, lint and format clean.