### PR TITLE
feat(staff): a write path for the roster

### DIFF
--- a/src/app/api/staff/[id]/route.ts
+++ b/src/app/api/staff/[id]/route.ts
@@ -1,0 +1,122 @@
+import { NextResponse, type NextRequest } from "next/server";
+
+import { createServerClient, getCurrentUser } from "@/lib/supabase/server";
+import {
+  STAFF_SELECT,
+  rowToStaffProfile,
+  staffToRow,
+} from "@/lib/api/mappers/staff";
+import { staffResponder } from "@/lib/api/staff-response";
+import type { StaffProfile } from "@/types/facility-staff";
+
+// ============================================================================
+// One staff member, by the app-facing "fs-*" id.
+//
+// PATCH rather than PUT: callers send what they changed, and staffToRow maps
+// only what it is given. A full replace would blank every column the caller
+// omitted, which on this table means losing someone's payroll because their
+// phone number was corrected.
+//
+// WHAT MAY ACTUALLY BE CHANGED is not decided here. The staff row feeds the
+// permission cascade — resolve_permission reads roles from it — so the rules
+// live in the database (20260802140000) where PostgREST cannot go round them:
+//
+//   raises   role, additional_roles, legacy_id, status, membership_id, and any
+//            change of facility_id, when the caller lacks manage_staff
+//   reverts  payroll without edit_payroll, permission overrides without
+//            manage_roles, HR notes and the clock-in code without manage_staff
+//
+// This handler's job is to merge honestly and to report what the database
+// actually stored.
+// ============================================================================
+
+export const dynamic = "force-dynamic";
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const user = await getCurrentUser().catch(() => null);
+  if (!user) {
+    return NextResponse.json({ error: "Not signed in." }, { status: 401 });
+  }
+
+  const { id } = await params;
+  if (!id) {
+    return NextResponse.json({ error: "Invalid staff id." }, { status: 400 });
+  }
+
+  const input = (await request.json()) as Partial<StaffProfile>;
+  const supabase = await createServerClient();
+
+  // Read the stored row first and merge onto it, because `details` is replaced
+  // wholesale rather than deep-merged. Without this, a caller sending only
+  // `phone` would drop the notification preferences, the clock-in settings and
+  // everything else in the tail.
+  //
+  // Note this reads the FULL row: RLS gates rows, not columns, so the merge
+  // base includes fields this caller may not see. That is exactly why it is
+  // safe — the salary they cannot read is preserved rather than blanked — and
+  // exactly why the RESPONSE below must go back through the redaction.
+  const { data: current } = await supabase
+    .from("staff")
+    .select(STAFF_SELECT)
+    .eq("legacy_id", id)
+    .maybeSingle();
+
+  if (!current) {
+    return NextResponse.json(
+      { error: "Staff member not found." },
+      { status: 404 },
+    );
+  }
+
+  const merged = { ...rowToStaffProfile(current), ...input };
+  const row = staffToRow(merged, {});
+
+  const { data: written, error } = await supabase
+    .from("staff")
+    .update(row as never)
+    .eq("legacy_id", id)
+    .select("id");
+
+  if (error) {
+    // The trigger raises 42501 for an escalation attempt — changing a role,
+    // a status, or the facility. Its message is written for a person, so it
+    // is passed through rather than replaced with something vaguer.
+    if (error.code === "42501") {
+      return NextResponse.json({ error: error.message }, { status: 403 });
+    }
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  // An UPDATE filtered out by RLS is not an error in Postgres — it affects
+  // zero rows and reports success. Without this the route answers 200 with the
+  // unchanged record, so someone not allowed to edit is told their edit
+  // worked. A write that silently does nothing is worse than one that fails.
+  if (!written || written.length === 0) {
+    return NextResponse.json(
+      { error: "Not allowed to edit this staff member." },
+      { status: 403 },
+    );
+  }
+
+  const { data: updated } = await supabase
+    .from("staff")
+    .select(STAFF_SELECT)
+    .eq("legacy_id", id)
+    .single();
+
+  if (!updated) {
+    return NextResponse.json(
+      { error: "Staff member not found." },
+      { status: 404 },
+    );
+  }
+
+  // Through the same redaction as GET. The trigger silently reverts fields the
+  // caller may not set, so the response has to show what was STORED, not what
+  // was sent — otherwise the UI displays an edit the database threw away.
+  const responder = await staffResponder(user.email);
+  return NextResponse.json(responder.toResponse(updated));
+}

--- a/src/app/api/staff/route.ts
+++ b/src/app/api/staff/route.ts
@@ -1,12 +1,10 @@
-import { NextResponse } from "next/server";
+import { NextResponse, type NextRequest } from "next/server";
 
 import { createServerClient, getCurrentUser } from "@/lib/supabase/server";
-import { holds, myPermissions } from "@/lib/auth/permissions";
-import {
-  STAFF_SELECT,
-  redactStaffProfile,
-  rowToStaffProfile,
-} from "@/lib/api/mappers/staff";
+import { STAFF_SELECT, staffToRow } from "@/lib/api/mappers/staff";
+import { staffResponder } from "@/lib/api/staff-response";
+import { getFacilityContext } from "@/lib/api/facility-context";
+import type { StaffProfile } from "@/types/facility-staff";
 
 // ============================================================================
 // Staff at the caller's facility.
@@ -19,11 +17,14 @@ import {
 //
 // RLS cannot help with that. It gates rows, not columns, so a policy that lets
 // you see a colleague lets you see every column of them. Column-level access
-// has to be decided above the database, which is here.
+// has to be decided above the database, which is here — via staffResponder, so
+// that GET and the writes below cannot drift apart.
 //
-// The permissions used are the DATABASE's answer (`my_permissions()`), not the
-// client's opinion of itself — the same map /api/permissions returns, resolved
-// server-side where it can decide what leaves rather than what gets drawn.
+// WHAT MAY BE WRITTEN is decided BELOW this file, in the database
+// (20260802140000). A staff row feeds the permission cascade — resolve_permission
+// reads roles from it — so "who may change which column" is not something a
+// route handler can be trusted with. PostgREST is reachable directly with the
+// anon key and a session cookie; this file is a convenience, not a gate.
 // ============================================================================
 
 export const dynamic = "force-dynamic";
@@ -36,34 +37,84 @@ export async function GET() {
 
   const supabase = await createServerClient();
 
-  const [{ data, error }, permissions] = await Promise.all([
+  const [{ data, error }, responder] = await Promise.all([
     supabase.from("staff").select(STAFF_SELECT).order("legacy_id"),
-    myPermissions(),
+    staffResponder(user.email),
   ]);
 
   if (error) {
     return NextResponse.json({ error: error.message }, { status: 500 });
   }
 
-  const grants = {
-    payroll: holds(permissions, "view_payroll"),
-    permissions: holds(permissions, "view_staff_permissions"),
-    hr: holds(permissions, "manage_staff"),
-  };
+  return NextResponse.json(data.map(responder.toResponse));
+}
 
-  // Which row is the caller's own. Matched on the VERIFIED session email, the
-  // same bridge lib/auth/legacy-identity.ts uses. Lowercased both sides
-  // because the staff table does not constrain case and a mismatch here fails
-  // in the safe direction — you would be redacted from your own record, which
-  // is confusing but not a leak.
-  const email = user.email?.trim().toLowerCase();
+export async function POST(request: NextRequest) {
+  const user = await getCurrentUser().catch(() => null);
+  if (!user) {
+    return NextResponse.json({ error: "Not signed in." }, { status: 401 });
+  }
 
-  const profiles = data.map((row) => {
-    const profile = rowToStaffProfile(row);
-    const isSelf =
-      email != null && profile.email?.trim().toLowerCase() === email;
-    return redactStaffProfile(profile, grants, isSelf);
+  const input = (await request.json()) as Partial<StaffProfile>;
+
+  if (!input.firstName || !input.lastName || !input.email) {
+    return NextResponse.json(
+      { error: "A name and an email address are required." },
+      { status: 422 },
+    );
+  }
+  if (!input.primaryRole) {
+    return NextResponse.json(
+      { error: "A primary role is required." },
+      { status: 422 },
+    );
+  }
+
+  const supabase = await createServerClient();
+  const facility = await getFacilityContext();
+  if (!facility) {
+    return NextResponse.json({ error: "Facility not found." }, { status: 500 });
+  }
+
+  // A fresh "fs-*" id rather than letting legacy_id fall back to the uuid.
+  // 47 files still key people by that shape, and a new hire whose id does not
+  // look like the others is a person who quietly goes missing from whichever
+  // screen has not moved onto the API yet.
+  const legacyId = `fs-${crypto.randomUUID().slice(0, 8)}`;
+
+  const row = staffToRow(input, {
+    facilityId: facility.facilityId,
+    legacyId,
   });
 
-  return NextResponse.json(profiles);
+  const { data: created, error } = await supabase
+    .from("staff")
+    .insert(row as never)
+    .select(STAFF_SELECT)
+    .single();
+
+  if (error) {
+    // 42501 is the RLS refusal (no manage_staff here); 23505 is a duplicate,
+    // which for this table means the email is already on the roster.
+    if (error.code === "42501") {
+      return NextResponse.json(
+        { error: "Not allowed to add staff at this facility." },
+        { status: 403 },
+      );
+    }
+    if (error.code === "23505") {
+      return NextResponse.json(
+        { error: "Someone with that email is already on the roster." },
+        { status: 409 },
+      );
+    }
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  // Echoed back through the SAME redaction as GET. The trigger may have
+  // stripped a salary this caller was not allowed to set, and the response has
+  // to show what was stored rather than what was sent — otherwise the UI
+  // displays a figure the database rejected.
+  const responder = await staffResponder(user.email);
+  return NextResponse.json(responder.toResponse(created), { status: 201 });
 }

--- a/src/lib/api/mappers/staff.ts
+++ b/src/lib/api/mappers/staff.ts
@@ -1,5 +1,5 @@
 import type { StaffProfile } from "@/types/facility-staff";
-import type { Tables } from "@/types/database";
+import type { Tables, TablesInsert } from "@/types/database";
 
 // ============================================================================
 // Database row -> the StaffProfile the app already expects.
@@ -46,6 +46,99 @@ export function rowToStaffProfile(row: StaffRow): StaffProfileWithRowId {
 }
 
 export const STAFF_SELECT = `*` as const;
+
+// ── The way back ────────────────────────────────────────────────────────────
+// Mirrors rowToStaffProfile. Fields that are COLUMNS are written as columns;
+// everything else is the `details` tail, exactly as the read direction assumes.
+//
+// Only what it is GIVEN is mapped, so a partial update stays partial. That
+// matters more here than elsewhere: this shape carries payroll and permission
+// overrides, and a full-replace mapper would blank whichever of them the
+// caller left out.
+const COLUMN_FIELDS = [
+  "id",
+  "rowId",
+  "firstName",
+  "lastName",
+  "email",
+  "phone",
+  "jobTitle",
+  "avatarUrl",
+  "colorHex",
+  "primaryRole",
+  "additionalRoles",
+  "serviceAssignments",
+  "status",
+  "statusChangedAt",
+  "statusReason",
+  "statusNote",
+  "showOnCalendar",
+  "lastActive",
+];
+
+/**
+ * `""` is not a timestamp, and it is what comes back out of the read mapper.
+ *
+ * `rowToStaffProfile` turns a null `last_active` into an empty string, because
+ * the client type says `lastActive: string`. Round-trip that — read a profile,
+ * change a phone number, send it back — and Postgres is asked to store `""` in
+ * a `timestamptz`, which is a 500 rather than a null.
+ *
+ * It only bites on staff who have never been active, which is why the first
+ * test to hit it was the one editing a dev account rather than a seeded one.
+ */
+function timestampOrNull(value: string | undefined): string | null {
+  return value && value.trim() !== "" ? value : null;
+}
+
+export function staffToRow(
+  input: Partial<StaffProfile>,
+  context: { facilityId?: string; legacyId?: string },
+): Partial<TablesInsert<"staff">> {
+  const row: Partial<TablesInsert<"staff">> = {};
+
+  if (context.facilityId) row.facility_id = context.facilityId;
+  if (context.legacyId) row.legacy_id = context.legacyId;
+
+  if (input.firstName !== undefined) row.first_name = input.firstName;
+  if (input.lastName !== undefined) row.last_name = input.lastName;
+  if (input.email !== undefined) row.email = input.email;
+  if (input.phone !== undefined) row.phone = input.phone;
+  if (input.jobTitle !== undefined) row.job_title = input.jobTitle;
+  if (input.avatarUrl !== undefined) row.avatar_url = input.avatarUrl;
+  if (input.colorHex !== undefined) row.color_hex = input.colorHex;
+  if (input.primaryRole !== undefined) row.primary_role = input.primaryRole;
+  if (input.additionalRoles !== undefined) {
+    row.additional_roles = input.additionalRoles;
+  }
+  if (input.serviceAssignments !== undefined) {
+    row.service_assignments = input.serviceAssignments;
+  }
+  if (input.status !== undefined) row.status = input.status;
+  if (input.statusChangedAt !== undefined) {
+    row.status_changed_at = timestampOrNull(input.statusChangedAt);
+  }
+  if (input.statusReason !== undefined) row.status_reason = input.statusReason;
+  if (input.statusNote !== undefined) row.status_note = input.statusNote;
+  if (input.showOnCalendar !== undefined) {
+    row.show_on_calendar = input.showOnCalendar;
+  }
+  if (input.lastActive !== undefined) {
+    row.last_active = timestampOrNull(input.lastActive);
+  }
+
+  const details: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(input)) {
+    if (!COLUMN_FIELDS.includes(key) && value !== undefined) {
+      details[key] = value;
+    }
+  }
+  if (Object.keys(details).length > 0) {
+    row.details = details as TablesInsert<"staff">["details"];
+  }
+
+  return row;
+}
 
 // ============================================================================
 // Redaction — because RLS gates rows, not columns.

--- a/src/lib/api/staff-response.ts
+++ b/src/lib/api/staff-response.ts
@@ -1,0 +1,56 @@
+import "server-only";
+
+import { holds, myPermissions } from "@/lib/auth/permissions";
+import {
+  redactStaffProfile,
+  rowToStaffProfile,
+  type StaffProfileWithRowId,
+} from "@/lib/api/mappers/staff";
+import type { Tables } from "@/types/database";
+
+// ============================================================================
+// One place that turns a staff row into a response.
+//
+// Every route that returns a staff record has to trim it the same way, and
+// "the same way" is not something to reimplement per handler. The write path
+// is the easy one to forget: POST and PATCH both echo the row back, so a
+// handler that skips this hands payroll to a caller the GET route was
+// carefully keeping it from. Same data, same person, different verb.
+//
+// The redaction rules themselves live in mappers/staff.ts; this resolves the
+// permissions behind them once and applies them.
+// ============================================================================
+
+export interface StaffResponder {
+  /** Trim one row to what the caller may see. */
+  toResponse: (row: Tables<"staff">) => StaffProfileWithRowId;
+}
+
+/**
+ * Resolve the caller's grants once, then reuse them per row.
+ *
+ * `email` is the caller's VERIFIED session email, used to spot their own
+ * record — you always see yourself in full. Lowercased on both sides because
+ * the staff table does not constrain case, and a mismatch fails safe: you get
+ * redacted from your own record, which is confusing but not a leak.
+ */
+export async function staffResponder(
+  email: string | null | undefined,
+): Promise<StaffResponder> {
+  const permissions = await myPermissions();
+  const grants = {
+    payroll: holds(permissions, "view_payroll"),
+    permissions: holds(permissions, "view_staff_permissions"),
+    hr: holds(permissions, "manage_staff"),
+  };
+  const self = email?.trim().toLowerCase();
+
+  return {
+    toResponse(row) {
+      const profile = rowToStaffProfile(row);
+      const isSelf =
+        self != null && profile.email?.trim().toLowerCase() === self;
+      return redactStaffProfile(profile, grants, isSelf);
+    },
+  };
+}

--- a/src/lib/api/staff.ts
+++ b/src/lib/api/staff.ts
@@ -1,3 +1,7 @@
+"use client";
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
 import {
   taskTemplates,
   staffTasks,
@@ -7,7 +11,7 @@ import {
 } from "@/data/staff-tasks";
 import { facilityStaff } from "@/data/facility-staff";
 import type { StaffProfile } from "@/types/facility-staff";
-import { liveFetch } from "./live-fetch";
+import { liveFetch, liveWrite } from "./live-fetch";
 import {
   shiftTasks,
   shiftSwapRequests,
@@ -102,3 +106,46 @@ export const staffQueries = {
     queryFn: async () => shiftTemplates,
   }),
 };
+
+// ============================================================================
+// Writes.
+//
+// `liveWrite`, not `liveWriteOptional`: a staff edit has nowhere else to go.
+// Signed out these must fail loudly rather than pretend, because the only
+// alternative — a local copy — is what the screens are being moved OFF.
+//
+// The RESPONSE is the source of truth for what happened, not the payload that
+// was sent. The database silently reverts fields the caller may not set
+// (20260802140000), so a mutation that optimistically kept its own input would
+// show an edit that was thrown away. Every hook below returns what came back.
+// ============================================================================
+
+/** Add someone to the roster. Requires `manage_staff`, enforced by RLS. */
+export function useCreateStaff() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (profile: Partial<StaffProfile>) =>
+      liveWrite<StaffProfile>("/api/staff", "POST", profile),
+    onSuccess: () =>
+      queryClient.invalidateQueries({ queryKey: ["staff", "profiles"] }),
+  });
+}
+
+/**
+ * Change someone's record. Send only what changed — the route merges onto the
+ * stored row, so a partial patch cannot blank the fields it omits.
+ */
+export function useUpdateStaff() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      staffId,
+      patch,
+    }: {
+      staffId: string;
+      patch: Partial<StaffProfile>;
+    }) => liveWrite<StaffProfile>(`/api/staff/${staffId}`, "PATCH", patch),
+    onSuccess: () =>
+      queryClient.invalidateQueries({ queryKey: ["staff", "profiles"] }),
+  });
+}

--- a/tests/e2e/staff-write-path.spec.ts
+++ b/tests/e2e/staff-write-path.spec.ts
@@ -1,0 +1,190 @@
+import { test, expect } from "@playwright/test";
+import { ACCOUNTS, signIn } from "./_auth";
+
+// ============================================================================
+// POST and PATCH /api/staff — does the app tell the truth about what happened?
+//
+// The RULES live in the database (20260802140000), and
+// supabase/tests/staff-write-integrity.sql proves them as the actual caller,
+// which is the honest place to ask: PostgREST is reachable directly with the
+// anon key and a session cookie, so these routes are a convenience, not a gate.
+//
+// THIS FILE ASKS THE OTHER HALF. The trigger silently reverts fields a caller
+// may not set, so a route that echoed back the REQUEST would show an edit the
+// database threw away. And the write path has to redact exactly like the read
+// path — same data, same person, different verb.
+//
+// TO CONFIRM THESE FAIL WITHOUT THE FIX: return `input` instead of the stored
+// row from PATCH. "an edit reports what was stored" goes red.
+// ============================================================================
+
+const SUBJECT = "fs-board-01"; // Dominic — a seeded colleague with a full tail
+
+interface StaffRow {
+  id: string;
+  firstName: string;
+  phone?: string;
+  jobTitle?: string;
+  primaryRole: string;
+  payroll?: { hourlyRate: number };
+  employment: { notes?: string };
+  clockIn?: { accessCode?: string };
+}
+
+test.describe.configure({ mode: "serial" });
+
+test.describe("staff write path", () => {
+  test("an owner's edit reports what was stored", async ({ page }) => {
+    await signIn(page, ACCOUNTS.owner);
+
+    const title = `Lead Bather ${Date.now() % 100000}`;
+    const res = await page.request.patch(`/api/staff/${SUBJECT}`, {
+      data: { jobTitle: title },
+    });
+    expect(res.status()).toBe(200);
+
+    const body = (await res.json()) as StaffRow;
+    expect(body.jobTitle).toBe(title);
+    // The partial patch must not have blanked the tail it did not mention.
+    expect(body.payroll?.hourlyRate).toBeGreaterThan(0);
+    expect(body.employment.notes).toBeTruthy();
+
+    // And it is genuinely stored, not just echoed.
+    const after = (await (await page.request.get("/api/staff")).json()) as
+      | StaffRow[]
+      | null;
+    expect(after?.find((s) => s.id === SUBJECT)?.jobTitle).toBe(title);
+  });
+
+  test("a groomer cannot promote themselves", async ({ page }) => {
+    await signIn(page, ACCOUNTS.groomer);
+
+    const res = await page.request.patch("/api/staff/fs-dev-groomer", {
+      data: { primaryRole: "owner" },
+    });
+
+    // 403 with the database's own message, which is written for a person.
+    expect(res.status()).toBe(403);
+    expect((await res.json()).error).toMatch(/role/i);
+
+    // And nothing moved: the permission map is the thing that would have
+    // changed, so it is the thing worth checking.
+    const perms = (await (
+      await page.request.get("/api/permissions")
+    ).json()) as Record<string, string>;
+    expect(perms.manage_roles).toBe("none");
+  });
+
+  test("a groomer cannot give themselves a raise", async ({ page }) => {
+    await signIn(page, ACCOUNTS.groomer);
+
+    const res = await page.request.patch("/api/staff/fs-dev-groomer", {
+      data: {
+        payroll: {
+          hourlyRate: 999,
+          generalServiceCommission: 0,
+          tipsRate: 0,
+          overrides: [],
+        },
+      },
+    });
+
+    // Reverted rather than refused — the whole-object PATCH has to keep
+    // working — so the check is on what came BACK, not on the status.
+    expect(res.status()).toBe(200);
+    const body = (await res.json()) as StaffRow;
+    expect(body.payroll?.hourlyRate).not.toBe(999);
+  });
+
+  test("a groomer may still edit their own phone", async ({ page }) => {
+    await signIn(page, ACCOUNTS.groomer);
+
+    const phone = `555-${String(Date.now() % 10000).padStart(4, "0")}`;
+    const res = await page.request.patch("/api/staff/fs-dev-groomer", {
+      data: { phone },
+    });
+
+    expect(res.status()).toBe(200);
+    expect(((await res.json()) as StaffRow).phone).toBe(phone);
+  });
+
+  test("the write path redacts exactly like the read path", async ({
+    page,
+  }) => {
+    // THE CALLER HAS TO BE ABLE TO EDIT, or this proves nothing.
+    //
+    // The first version used the groomer, who gets a 403 on a colleague — so
+    // the assertions never ran, and the test passed with the redaction
+    // deliberately removed. Checked, which is the only reason I know.
+    //
+    // What is needed is someone who may WRITE the row but not SEE its pay:
+    // the manager, with view_payroll revoked. That combination is the whole
+    // point — a handler that echoed the stored row back unredacted would hand
+    // them the salary the GET route is careful to withhold.
+    await signIn(page, ACCOUNTS.owner);
+    const revoke = await page.request.put("/api/roles/overrides", {
+      data: {
+        kind: "staff",
+        staffId: "fs-dev-manager",
+        key: "view_payroll",
+        setting: { granted: false, scope: "none" },
+      },
+    });
+    expect(revoke.status()).toBe(200);
+
+    try {
+      await page.context().clearCookies();
+      await signIn(page, ACCOUNTS.manager);
+
+      // Sanity: they really cannot see it on the READ path.
+      const list = (await (await page.request.get("/api/staff")).json()) as
+        | StaffRow[]
+        | null;
+      expect(
+        list?.find((s) => s.id === SUBJECT)?.payroll,
+        "precondition: payroll withheld on GET",
+      ).toBeUndefined();
+
+      const res = await page.request.patch(`/api/staff/${SUBJECT}`, {
+        data: { phone: "555-0000" },
+      });
+      expect(res.status(), "the manager may edit this row").toBe(200);
+
+      const body = (await res.json()) as StaffRow;
+      expect(
+        body.payroll,
+        "payroll must not come back from a write",
+      ).toBeUndefined();
+
+      // The clock-in code IS returned, and should be: it is gated on
+      // manage_staff, which this caller holds. Asserted rather than omitted,
+      // because "everything is missing" would pass just as well if the
+      // redaction were stripping indiscriminately.
+      expect(body.clockIn?.accessCode).toBeTruthy();
+    } finally {
+      await page.context().clearCookies();
+      await signIn(page, ACCOUNTS.owner);
+      await page.request.put("/api/roles/overrides", {
+        data: {
+          kind: "staff",
+          staffId: "fs-dev-manager",
+          key: "view_payroll",
+          setting: null,
+        },
+      });
+    }
+  });
+
+  test("signed out cannot write at all", async ({ page }) => {
+    expect(
+      (
+        await page.request.post("/api/staff", { data: { firstName: "X" } })
+      ).status(),
+    ).toBe(401);
+    expect(
+      (
+        await page.request.patch(`/api/staff/${SUBJECT}`, { data: {} })
+      ).status(),
+    ).toBe(401);
+  });
+});


### PR DESCRIPTION
`POST /api/staff` and `PATCH /api/staff/[id]`.

The read side moved to Postgres weeks ago; the screens couldn't follow, because there was nowhere to send an edit — no POST, no PATCH, no mutations in the query layer. Six `setStaff` calls in a 933-line page write to a React array that vanishes on reload.

## The rules are not in this layer

They're in the database (#113), because a staff row feeds the permission cascade and PostgREST is reachable directly with the anon key and a session cookie. This layer's job is narrower — and easier to get wrong than it looks:

- **Merge onto the stored row.** `details` is replaced wholesale, not deep-merged, so a caller sending only `phone` would otherwise drop the notification preferences, the clock-in settings, and the payroll along with them.
- **Report what was stored.** The trigger silently reverts fields the caller may not set. Echoing back the request would show an edit the database threw away — the UI would display a raise nobody got.
- **Redact like the read path.** Same data, same person, different verb. Both routes go through one `staffResponder`, so GET and the writes cannot drift apart.

## Two bugs the tests found, both mine

**A 500 on any staff who had never been active.** `rowToStaffProfile` turns a null `last_active` into `""` (the client type says `string`). Round-trip that — read a profile, change a phone number, send it back — and Postgres is asked to store `""` in a `timestamptz`. It only bites on rows with a null value, which is why the first test to hit it was editing a dev account rather than a seeded one. Fixed in the mapper, where the empty string originates.

**The redaction test passed with the redaction removed.** It used the groomer, who gets a 403 on a colleague, so the assertions never ran — the same "reads like coverage, catches nothing" shape as the DOM-sampling test I deleted earlier. It now uses a **manager with `view_payroll` revoked**: someone who may *write* the row but not *see* its pay, which is the only combination that proves anything. Re-checked by removing the redaction again — it now fails on `"hourlyRate": 23`.

It also asserts the clock-in code **is** returned, since that caller holds `manage_staff`. "Everything is missing" would pass just as well if the redaction were stripping indiscriminately.

## Verification

6 e2e checks: an owner's edit reports what was stored and doesn't blank the untouched tail; a groomer can't promote themselves (403, and `manage_roles` stays `none`); can't give themselves a raise (reverted, checked on the response); can still edit their own phone; the write path redacts like the read path; signed out can't write at all.

Full suite: **42 passed, 1 skipped, 0 failed.** Build, typecheck, lint and format clean.

## What this unblocks

The staff screens can now move off `useState(facilityStaff)` onto `staffQueries.profiles()` plus these mutations — which is what finally makes the "Hidden — requires…" notices live rather than staged.