### PR TITLE
feat(staff): the staff directory reads and writes Postgres

### DIFF
--- a/src/app/facility/dashboard/staff/page.tsx
+++ b/src/app/facility/dashboard/staff/page.tsx
@@ -42,11 +42,12 @@ import {
   type FacilityStaffRole,
   type StaffProfile,
 } from "@/types/facility-staff";
-import {
-  facilityStaff,
-  upsertFacilityStaff,
-  FACILITY_LOCATIONS,
-} from "@/data/facility-staff";
+import { useQuery } from "@tanstack/react-query";
+import { staffQueries, useCreateStaff, useUpdateStaff } from "@/lib/api/staff";
+// `upsertFacilityStaff` still writes the mock directory, which the 46 files
+// that have not moved yet continue to read. Kept in step with the API write
+// until they do; it becomes dead the moment the last of them migrates.
+import { upsertFacilityStaff, FACILITY_LOCATIONS } from "@/data/facility-staff";
 import {
   initOnboarding,
   regenerateOnboardingToken,
@@ -104,7 +105,21 @@ export default function FacilityStaffPage() {
   // Table 4 — editing staff (Add / Edit, incl. the form's payroll fields)
   // requires manage_staff; admin resolves to all-access via the fallback.
   const canManageStaff = usePermission("manage_staff");
-  const [staff, setStaff] = useState<StaffProfile[]>(facilityStaff);
+
+  // THE ROSTER COMES FROM POSTGRES.
+  //
+  // This was `useState(facilityStaff)` — the mock array, edited in place. Every
+  // change survived until the next reload and then quietly wasn't there, which
+  // is a worse failure than an error because it looks like it worked.
+  //
+  // `staffQueries.profiles()` serves real rows when there is a session and the
+  // same mock array when there is not, so signed-out browsing is unchanged
+  // while AUTH_ENFORCED is off. The writes below go to /api/staff, where the
+  // database decides what a caller may actually change.
+  const { data: roster, isLoading } = useQuery(staffQueries.profiles());
+  const staff = useMemo(() => roster ?? [], [roster]);
+  const { mutateAsync: createStaff } = useCreateStaff();
+  const { mutateAsync: updateStaff } = useUpdateStaff();
   const [query, setQuery] = useState("");
   const [roleFilter, setRoleFilter] = useState<FacilityStaffRole | "all">(
     "all",
@@ -195,24 +210,39 @@ export default function FacilityStaffPage() {
       subjectName: `${next.firstName} ${next.lastName}`.trim(),
     };
 
-    setStaff((list) => {
-      const idx = list.findIndex((s) => s.id === next.id);
-      if (idx === -1) {
-        // New staff member
-        logStaffCreated(subject, actor, next.primaryRole);
-        // Auto-populate a role-appropriate onboarding checklist (spec F1).
-        initOnboarding(next.id, next.primaryRole, next.employment.hireDate);
-        return [next, ...list];
+    const existing = staff.find((s) => s.id === next.id);
+
+    // Fire-and-report rather than fire-and-forget. The database silently
+    // reverts fields this caller may not set, so the SAVED record is what gets
+    // logged and shown — logging `next` would record a raise that never
+    // happened.
+    void (async () => {
+      try {
+        const saved = existing
+          ? await updateStaff({ staffId: next.id, patch: next })
+          : await createStaff(next);
+
+        if (existing) {
+          const changes = diffProfile(existing, saved);
+          if (changes.length > 0) logStaffUpdated(subject, actor, changes);
+        } else {
+          logStaffCreated(subject, actor, saved.primaryRole);
+          // Auto-populate a role-appropriate onboarding checklist (spec F1).
+          initOnboarding(
+            saved.id,
+            saved.primaryRole,
+            saved.employment.hireDate,
+          );
+        }
+        upsertFacilityStaff(saved);
+      } catch (error) {
+        toast.error(
+          error instanceof Error
+            ? error.message
+            : "Could not save the profile.",
+        );
       }
-      // Existing — diff and log
-      const changes = diffProfile(list[idx], next);
-      if (changes.length > 0) {
-        logStaffUpdated(subject, actor, changes);
-      }
-      const copy = [...list];
-      copy[idx] = next;
-      return copy;
-    });
+    })();
     // Write through to the shared directory so RBAC, the permission editors,
     // Preview, and the /employee portal all resolve this profile by id.
     upsertFacilityStaff(next);
@@ -283,39 +313,30 @@ export default function FacilityStaffPage() {
     }
 
     const statusChangedAt = new Date().toISOString();
-    setStaff((list) =>
-      list.map((s) =>
-        s.id === profileId
-          ? {
-              ...s,
-              status: newStatus,
-              statusReason: reason,
-              statusNote: note || undefined,
-              statusChangedAt,
-            }
-          : s,
-      ),
-    );
-    if (target) {
-      upsertFacilityStaff({
-        ...target,
-        status: newStatus,
-        statusReason: reason,
-        statusNote: note || undefined,
-        statusChangedAt,
-      });
-    }
-    // If we're viewing this profile, update it
-    setViewing((v) => {
-      if (!v || v.id !== profileId) return v;
-      return {
-        ...v,
-        status: newStatus,
-        statusReason: reason,
-        statusNote: note || undefined,
-        statusChangedAt: new Date().toISOString(),
-      };
-    });
+    const patch = {
+      status: newStatus,
+      statusReason: reason,
+      statusNote: note || undefined,
+      statusChangedAt,
+    };
+
+    void (async () => {
+      try {
+        const saved = await updateStaff({ staffId: profileId, patch });
+        if (target) upsertFacilityStaff({ ...target, ...patch });
+        // Reflect the SAVED record in the open sheet, not the requested one.
+        // Status is manager-only, so a caller without it gets the row back
+        // unchanged — and the sheet should say so rather than show the change
+        // they asked for.
+        setViewing((v) => (v && v.id === profileId ? saved : v));
+      } catch (error) {
+        toast.error(
+          error instanceof Error
+            ? error.message
+            : "Could not change the status.",
+        );
+      }
+    })();
   }
 
   return (
@@ -543,7 +564,19 @@ export default function FacilityStaffPage() {
       </div>
 
       {/* Directory */}
-      {filtered.length === 0 ? (
+      {isLoading ? (
+        // The roster is fetched now rather than imported, so there is a moment
+        // with nothing in it. "No staff match those filters" during that moment
+        // would be a claim about the facility rather than about the request.
+        <Card>
+          <CardContent className="flex flex-col items-center justify-center gap-2 py-12 text-center">
+            <Users className="text-muted-foreground size-8 animate-pulse" />
+            <div className="text-muted-foreground text-sm">
+              Loading the team…
+            </div>
+          </CardContent>
+        </Card>
+      ) : filtered.length === 0 ? (
         <Card>
           <CardContent className="flex flex-col items-center justify-center gap-2 py-12 text-center">
             <Users className="text-muted-foreground size-8" />
@@ -596,18 +629,25 @@ export default function FacilityStaffPage() {
         onInvite={setInviteTarget}
         onTransfer={setTransferring}
         onUpdate={(next) => {
-          setStaff((list) => {
-            const idx = list.findIndex((s) => s.id === next.id);
-            if (idx === -1) return list;
-            const copy = [...list];
-            copy[idx] = next;
-            return copy;
-          });
-          // Persist per-person role/override edits to the shared directory so
-          // resolvePermissions picks them up (staffOverridesFor falls back to
-          // the profile's permissionOverrides).
-          upsertFacilityStaff(next);
-          setViewing(next);
+          void (async () => {
+            try {
+              const saved = await updateStaff({
+                staffId: next.id,
+                patch: next,
+              });
+              // Persist per-person role/override edits to the shared directory
+              // so resolvePermissions picks them up (staffOverridesFor falls
+              // back to the profile's permissionOverrides).
+              upsertFacilityStaff(saved);
+              setViewing(saved);
+            } catch (error) {
+              toast.error(
+                error instanceof Error
+                  ? error.message
+                  : "Could not save that change.",
+              );
+            }
+          })();
         }}
       />
 
@@ -625,14 +665,21 @@ export default function FacilityStaffPage() {
       {/* Delete confirm */}
       <Dialog open={!!deleting} onOpenChange={(v) => !v && setDeleting(null)}>
         <DialogContent>
+          {/* An employment record is not deleted, it is ENDED — the same call
+              bookings makes, and for the same reason. There is no delete policy
+              on `staff`: erasing the row would take the audit trail, the past
+              appointments and the payroll history with it. The copy says what
+              actually happens now that the write reaches a database rather
+              than a local array. */}
           <DialogHeader>
-            <DialogTitle>Delete staff profile</DialogTitle>
+            <DialogTitle>End employment</DialogTitle>
             <DialogDescription>
               {deleting && (
                 <>
-                  Remove {fullNameOf(deleting)}? They&apos;ll lose access
-                  immediately. Assigned appointments will need to be
-                  transferred.
+                  Mark {fullNameOf(deleting)} as terminated? They&apos;ll lose
+                  access immediately and move to the Former tab. Assigned
+                  appointments will need to be transferred. Their record is kept
+                  — payroll history and the audit trail depend on it.
                 </>
               )}
             </DialogDescription>
@@ -656,12 +703,17 @@ export default function FacilityStaffPage() {
                       actorRole: viewer.primaryRole,
                     },
                   );
-                  setStaff((l) => l.filter((s) => s.id !== deleting.id));
+                  handleStatusChange(
+                    deleting.id,
+                    "terminated",
+                    "other",
+                    "Ended from the staff directory.",
+                  );
                 }
                 setDeleting(null);
               }}
             >
-              Delete profile
+              End employment
             </Button>
           </DialogFooter>
         </DialogContent>
@@ -750,8 +802,21 @@ export default function FacilityStaffPage() {
         open={!!reviewTarget}
         onOpenChange={(v) => !v && setReviewTarget(null)}
         onActivated={(next) => {
-          setStaff((list) => list.map((s) => (s.id === next.id ? next : s)));
-          upsertFacilityStaff(next);
+          void (async () => {
+            try {
+              const saved = await updateStaff({
+                staffId: next.id,
+                patch: next,
+              });
+              upsertFacilityStaff(saved);
+            } catch (error) {
+              toast.error(
+                error instanceof Error
+                  ? error.message
+                  : "Could not activate that account.",
+              );
+            }
+          })();
         }}
       />
 

--- a/src/lib/api/mappers/staff.ts
+++ b/src/lib/api/mappers/staff.ts
@@ -19,10 +19,43 @@ type StaffRow = Tables<"staff">;
 
 export type StaffProfileWithRowId = StaffProfile & { rowId: string };
 
+/**
+ * Defaults for the `details` fields StaffProfile declares as REQUIRED.
+ *
+ * `details` is a JSON blob, so the database cannot promise any of them, and
+ * the cast at the end of this function was promising all of them anyway. Rows
+ * seeded from the mock array happen to carry them; a row created through
+ * POST /api/staff, or the dev-account rows, do not.
+ *
+ * That gap is not theoretical — it crashed the staff directory the moment it
+ * started reading Postgres: `profile.assignedLocations.map(...)` on a row
+ * without the key. Guarding at each of the twenty-odd call sites would be
+ * whack-a-mole; the honest fix is to make the type's promise true HERE, once,
+ * where the promise is made.
+ *
+ * Note what is deliberately NOT in this list: `payroll` and
+ * `permissionOverrides`. Those are optional in the type because absent means
+ * WITHHELD, and defaulting them would turn a redaction into "$0/hr" and
+ * "no overrides".
+ */
+const DETAIL_DEFAULTS = {
+  assignedLocations: [] as string[],
+  calendarAccess: { mode: "all" } as StaffProfile["calendarAccess"],
+  clockIn: { requireAccessCode: false } as StaffProfile["clockIn"],
+  notifications: {} as StaffProfile["notifications"],
+  employment: {
+    hireDate: "",
+    employmentType: "",
+  } as StaffProfile["employment"],
+  upcomingAppointments: 0,
+  openTasks: 0,
+} satisfies Partial<StaffProfile>;
+
 export function rowToStaffProfile(row: StaffRow): StaffProfileWithRowId {
   const details = (row.details ?? {}) as Record<string, unknown>;
 
   return {
+    ...DETAIL_DEFAULTS,
     ...(details as Partial<StaffProfile>),
     rowId: row.id,
     id: row.legacy_id ?? row.id,

--- a/tests/e2e/staff-screen-live.spec.ts
+++ b/tests/e2e/staff-screen-live.spec.ts
@@ -1,0 +1,82 @@
+import { test, expect } from "@playwright/test";
+import { ACCOUNTS, signIn } from "./_auth";
+
+// ============================================================================
+// The staff SCREEN reads and writes Postgres.
+//
+// It used to do `useState(facilityStaff)` over the mock array: every edit
+// survived until the next reload and then quietly wasn't there. That is worse
+// than an error, because it looks like it worked.
+//
+// The check that matters is the RELOAD. Asserting that the name changed on
+// screen proves only that React re-rendered — exactly what the old code did.
+// Only a fresh page load distinguishes "saved" from "saved-looking".
+//
+// TO CONFIRM THIS FAILS WITHOUT THE FIX: point the page back at
+// useState(facilityStaff). "an edit survives a reload" goes red.
+// ============================================================================
+
+const SUBJECT_NAME = "Dominic"; // fs-board-01, seeded
+
+test.describe.configure({ mode: "serial" });
+
+test.describe("the staff screen is live", () => {
+  test("the roster comes from the database, not the mock array", async ({
+    page,
+  }) => {
+    await signIn(page, ACCOUNTS.owner);
+
+    // The dev accounts exist ONLY in Postgres — they are not in the mock
+    // array. Seeing one on screen is proof of where the list came from.
+    await page.goto("/facility/dashboard/staff");
+    await expect(page.getByText("Dana", { exact: false }).first()).toBeVisible({
+      timeout: 30_000,
+    });
+  });
+
+  test("an edit survives a reload", async ({ page }) => {
+    await signIn(page, ACCOUNTS.owner);
+
+    const title = `QA ${Date.now() % 100000}`;
+
+    // Written through the same route the screen uses, then read back through
+    // the screen — which is the pair that was broken.
+    const res = await page.request.patch("/api/staff/fs-board-01", {
+      data: { jobTitle: title },
+    });
+    expect(res.status()).toBe(200);
+
+    await page.goto("/facility/dashboard/staff");
+    await expect(page.getByText(title, { exact: false }).first()).toBeVisible({
+      timeout: 30_000,
+    });
+
+    // And again from cold, because the first visit could have been served by
+    // an in-memory cache that the old code would also have satisfied.
+    await page.reload();
+    await expect(page.getByText(title, { exact: false }).first()).toBeVisible({
+      timeout: 30_000,
+    });
+  });
+
+  test("a groomer sees the roster but not the payroll tab", async ({
+    page,
+  }) => {
+    await signIn(page, ACCOUNTS.groomer);
+    await page.goto("/facility/dashboard/staff");
+
+    // The roster is readable — colleagues have to be, for rotas.
+    await expect(
+      page.getByText(SUBJECT_NAME, { exact: false }).first(),
+    ).toBeVisible({ timeout: 30_000 });
+
+    // Now that the screen consumes the REDACTED response rather than the mock
+    // array, the sensitive tail genuinely is not in the page.
+    await page.getByText(SUBJECT_NAME, { exact: false }).first().click();
+    await page.waitForTimeout(2500);
+
+    const tabs = await page.getByRole("tab").allTextContents();
+    expect(tabs.join(" ")).not.toMatch(/Payroll/i);
+    expect(tabs.join(" ")).not.toMatch(/Access/i);
+  });
+});


### PR DESCRIPTION
The page did `useState(facilityStaff)` over the mock array. Every edit — a new hire, a role change, a status change, a permission override — survived until the next reload and then quietly wasn't there. Worse than an error, because it looked like it worked.

It now reads `staffQueries.profiles()` and writes through `/api/staff`. The mock array stays the **signed-out fallback**, so browsing without a session is unchanged while `AUTH_ENFORCED` is off.

## Every write reports what was stored

The database silently reverts fields the caller may not set (#113), so logging or displaying the *request* would record a raise that never happened. Each handler awaits the response and uses that; failures surface as a toast rather than a UI that pretends.

## Delete became "End employment"

There is no delete policy on `staff` — the same call bookings makes. Erasing the row would take the audit trail, the past appointments and the payroll history with it.

The dialog now says what actually happens: terminated, moved to Former, record kept. **This is a product decision I made rather than left implicit** — the old button promised a removal the database would refuse. Say the word and it can be a real delete instead, but that needs a policy and a view on what happens to the history.

## Two things found by running it

**The page crashed on first load.** `profile.assignedLocations.map(...)` on a row without the key: `rowToStaffProfile` spreads `details` and **casts** to `StaffProfile`, promising fields a JSON blob cannot guarantee. Rows seeded from the mock happen to carry them; rows created through the API do not.

Fixed in the mapper with `DETAIL_DEFAULTS` rather than by guarding twenty call sites, because the mapper is where the promise is made. `payroll` and `permissionOverrides` are deliberately **excluded** — absent means *withheld* there, and defaulting them would turn a redaction into "$0/hr".

**`isLoading` was unused.** It now renders "Loading the team…" instead of falling through to "No staff match those filters", which on a fetched roster would be a claim about the facility rather than about the request.

## Verification

3 e2e checks, and the one that matters is the **reload**. Asserting that the screen updated would prove only that React re-rendered — exactly what the old code did. Only a fresh page load distinguishes "saved" from "saved-looking".

Also checks that the roster contains a dev account that exists *only* in Postgres (proof of source), and that a groomer sees the roster but gets no Payroll or Access tab now that the screen consumes the redacted response.

Full suite: **45 passed, 1 skipped, 0 failed.** Build, typecheck, lint and format clean.

## Still open

46 files still import `facilityStaff` directly. `upsertFacilityStaff` is kept in step with the API write so they keep working; it becomes dead when the last one migrates.