### PR TITLE
feat(auth): real people live in Production, fixtures live in Staging

### DIFF
--- a/scripts/migrate-clerk-era-identities.ts
+++ b/scripts/migrate-clerk-era-identities.ts
@@ -73,8 +73,41 @@ import { WorkOS } from "@workos-inc/node";
 import { applyWorkosTestKeys } from "../tests/e2e/_workos-keys";
 
 const APPLY = process.argv.includes("--apply");
+const PRODUCTION = process.argv.includes("--production");
 
-const keys = applyWorkosTestKeys();
+/**
+ * ── WHY THIS DOES NOT CALL applyWorkosTestKeys() WHEN --production ─────────
+ *
+ * That helper refuses anything but `sk_test_`, which is exactly right for the
+ * e2e suite: it provisions seven accounts and must never touch production.
+ * Pointing profiles at the production environment is a DIFFERENT job that
+ * legitimately needs a production key, so it takes an explicit flag rather than
+ * loosening the guard the suite depends on. Weakening `_workos-keys.ts` would
+ * silently expose all 179 specs to production.
+ *
+ * The assertion is inverted here on purpose: with --production a `sk_test_` key
+ * is the error, because it would mean quietly rewriting every subject to the
+ * environment you were trying to migrate away from.
+ */
+function resolveKeys(): { apiKey: string; clientId: string } {
+  if (!PRODUCTION) return applyWorkosTestKeys();
+
+  const apiKey = process.env.WORKOS_API_KEY?.trim();
+  const clientId = process.env.WORKOS_CLIENT_ID?.trim();
+  if (!apiKey || !clientId) {
+    throw new Error(
+      "--production needs WORKOS_API_KEY and WORKOS_CLIENT_ID for the PRODUCTION environment.",
+    );
+  }
+  if (apiKey.startsWith("sk_test_")) {
+    throw new Error(
+      "--production was passed but WORKOS_API_KEY is a staging key (sk_test_).",
+    );
+  }
+  return { apiKey, clientId };
+}
+
+const keys = resolveKeys();
 const workos = new WorkOS(keys.apiKey, { clientId: keys.clientId });
 
 const db = createClient(
@@ -83,9 +116,34 @@ const db = createClient(
   { auth: { persistSession: false } },
 );
 
-/** A Clerk subject; WorkOS mints `user_01…`, Clerk minted `user_3H…`. */
-const isClerkEra = (id: string) =>
-  id.startsWith("user_") && !id.startsWith("user_01");
+/**
+ * The seven e2e fixtures live at @yipyy.dev and belong to STAGING.
+ *
+ * One Supabase project serves both WorkOS environments, and `profiles.id` holds
+ * exactly one subject — so every person exists in one environment at a time.
+ * The split is: **fixtures in Staging, real people in Production.** Migrating
+ * the fixtures to production would take all 179 specs and local sign-in down
+ * with them, so --production skips them.
+ */
+const isFixture = (email: string) => email.toLowerCase().endsWith("@yipyy.dev");
+
+/**
+ * Does this subject exist in the environment we are pointing at?
+ *
+ * Started as a `user_3H…` prefix test for Clerk, which stopped working the
+ * moment the first migration landed: a staging WorkOS subject and a production
+ * one are both `user_01…` and no string test can separate them. Asking the
+ * environment is the only honest check, and it makes this script work for any
+ * future provider or environment move.
+ */
+async function existsInTarget(id: string): Promise<boolean> {
+  try {
+    await workos.userManagement.getUser(id);
+    return true;
+  } catch {
+    return false;
+  }
+}
 
 interface Stale {
   id: string;
@@ -111,15 +169,30 @@ async function main() {
     .select("id, email, full_name, avatar_url");
   if (error) throw error;
 
-  const stale = (profiles as Stale[]).filter((p) => isClerkEra(p.id));
+  // Symmetric on purpose. Without the second half, running this with no flag
+  // after a production migration would drag all eight real people BACK to
+  // Staging -- silently, reporting success, and taking production sign-in and
+  // both platform-admin grants down with them. The invariant is the guard:
+  // fixtures belong to Staging, real people belong to Production, and neither
+  // invocation can touch the other's half.
+  const candidates = (profiles as Stale[]).filter((p) =>
+    PRODUCTION ? !isFixture(p.email) : isFixture(p.email),
+  );
+
+  const stale: Stale[] = [];
+  for (const p of candidates) {
+    if (!(await existsInTarget(p.id))) stale.push(p);
+  }
+
+  const target = PRODUCTION ? "PRODUCTION" : "Staging";
 
   if (stale.length === 0) {
-    console.log("Nothing to migrate — no Clerk-era subjects remain.");
+    console.log(`Nothing to migrate — every profile resolves in ${target}.`);
     return;
   }
 
   console.log(
-    `${stale.length} Clerk-era ${stale.length === 1 ? "identity" : "identities"}` +
+    `${stale.length} ${stale.length === 1 ? "identity" : "identities"} to point at ${target}` +
       `${APPLY ? "" : "  (DRY RUN — nothing will be changed)"}\n`,
   );
 
@@ -164,7 +237,8 @@ async function main() {
 
   if (!APPLY) {
     console.log(
-      "\nRe-run with --apply to perform it. Nothing was created or changed.\n" +
+      `\nRe-run with --apply${PRODUCTION ? " --production" : ""} to perform it. ` +
+        "Nothing was created or changed.\n" +
         "Note: --apply needs the migrate_profile_subject() function to exist.",
     );
   }

--- a/specs/003-workos-authkit/plan.md
+++ b/specs/003-workos-authkit/plan.md
@@ -30,18 +30,53 @@ serving `yipyy.com`, `pawradise.yipyy.com` and `doggieville-mtl.yipyy.com`. An
 earlier note in this plan said nothing was deployed; that was inferred from a
 missing `.vercel/project.json` and was **wrong** — the repo simply was not linked.
 
-| item                            | state                                                                 |
-| ------------------------------- | --------------------------------------------------------------------- |
-| Redirect URIs                   | ✅ `yipyy.com`, `www.yipyy.com`, **`*.yipyy.com`** → `/auth/callback` |
-| JWT template                    | ✅ `{"role": "authenticated"}`                                        |
-| Webhook endpoint                | ✅ `we_01M07TQ4QAPEKX0DBPX679DJNH`, Active, the 3 user events         |
-| Vercel env (6 `WORKOS_*`)       | ✅ set on Production                                                  |
-| Supabase trusts the prod issuer | ✅ **proved** — see below                                             |
-| Google OAuth (Production)       | ✅ `state: Valid`, enabled, redirect URI verified, app published      |
-| Google OAuth (Staging)          | ❌ empty — Google sign-in does not work locally                       |
-| Apple OAuth                     | ❌ empty in both; needs an Apple Developer account                    |
-| Deployed code                   | ❌ still Clerk (`pk_live_`, `clerk.yipyy.com`)                        |
-| The 8 real identities           | ❌ exist in Staging only; Production has 0 users                      |
+| item                             | state                                                                 |
+| -------------------------------- | --------------------------------------------------------------------- |
+| Redirect URIs                    | ✅ `yipyy.com`, `www.yipyy.com`, **`*.yipyy.com`** → `/auth/callback` |
+| JWT template                     | ✅ `{"role": "authenticated"}`                                        |
+| Webhook endpoint                 | ✅ `we_01M07TQ4QAPEKX0DBPX679DJNH`, Active, the 3 user events         |
+| Vercel env (6 `WORKOS_*`)        | ✅ set on Production                                                  |
+| Supabase trusts the prod issuer  | ✅ **proved** — see below                                             |
+| Google OAuth (Production)        | ✅ `state: Valid`, enabled, redirect URI verified, app published      |
+| Google OAuth (Staging)           | ❌ empty — Google sign-in does not work locally                       |
+| Apple OAuth                      | ❌ empty in both; needs an Apple Developer account                    |
+| Deployed code                    | ✅ WorkOS live on `www.yipyy.com` (PR #120, 2026-08-17)               |
+| Webhook writes `profiles` (prod) | ✅ proved by a real user, not just a signature check                  |
+| `CLERK_*` Vercel vars            | ✅ removed                                                            |
+| Password reset URL               | ✅ set — was `null`, see below                                        |
+| The 8 real identities            | ✅ now on Production subjects                                         |
+
+### One person, one environment — the constraint that shapes all of this
+
+`profiles.id` holds exactly one subject, and Staging and Production mint
+different subjects for the same address. One Supabase project serves both, so
+**every person exists in exactly one environment at a time.** The split is now:
+
+- **Fixtures (`@yipyy.dev`) → Staging.** Local dev and all 179 specs.
+- **Real people → Production.** Including both platform-admin grants.
+
+`scripts/migrate-clerk-era-identities.ts` enforces this **symmetrically**: the
+default run only considers fixtures, `--production` only considers real people.
+Without that symmetry, running it with no flag after a production migration
+would drag all eight back to Staging — silently, reporting success, taking
+production sign-in and both platform-admin grants with it. Both invocations now
+report "nothing to migrate", which is what settled looks like.
+
+`--production` deliberately does **not** call `applyWorkosTestKeys()`; it
+asserts the opposite (a `sk_test_` key is the error). Loosening that helper
+would have exposed all 179 specs to production.
+
+### `passwordResetUrl` was null in both environments
+
+WorkOS puts that URL in the reset email. Unset, the link goes to WorkOS's hosted
+AuthKit page — which ADR 0004 §4 explicitly does not use, so
+`src/app/reset-password/page.tsx` would never have been reached. It is the only
+way in for the eight migrated accounts, which have **no password**. Now set to
+`https://www.yipyy.com/reset-password` and the localhost equivalent.
+
+Logout URIs also lacked the `https://*.yipyy.com/sign-in` wildcard that the
+redirect URIs already had, so signing out from a facility host would have been
+refused.
 
 **The trust relationship was proved, not assumed.** A throwaway user was created
 in the Production environment, authenticated, and its token presented to
@@ -64,12 +99,17 @@ assumed in three places and was wrong. It matters because a denylist on
 `sk_live_` would pass every production key; `tests/e2e/_workos-keys.ts`
 allowlists `sk_test_` instead, which is why its guard was correct anyway.
 
-> **PRODUCTION AUTH IS CURRENTLY BROKEN, and deregistering Clerk is what broke
-> it.** The deployed code signs in through Clerk, whose tokens Supabase no longer
-> accepts, so sign-in appears to work and every read then fails. Two ways out:
-> re-register Clerk in Supabase as a stopgap, or deploy the WorkOS code. Which is
-> right depends on whether the site has real users — deploy is the real fix
-> either way.
+> **Production auth WAS broken for several hours on 2026-08-17, and
+> deregistering Clerk is what broke it.** The deployed code still signed in
+> through Clerk, whose tokens Supabase had stopped accepting, so sign-in appeared
+> to work and every read then failed. **Fixed by the deploy** (PR #120).
+>
+> The lesson is the ordering, not the outage: **deregistering an identity
+> provider takes effect instantly and everywhere, while replacing the code that
+> uses it requires a deploy.** Do the deploy first. The mistake behind it was
+> concluding "nothing is deployed" from a missing `.vercel/project.json` — a
+> local file that says nothing about what is serving traffic. Check the hosting
+> provider, not the working tree.
 
 ### 🟢 Eight Clerk-era profiles outlived the cutover — migrated 2026-08-17
 


### PR DESCRIPTION
Follow-up to #120.

`profiles.id` holds one subject; Staging and Production mint different ones for the same address. One Supabase project serves both, so **every person exists in exactly one environment**.

The eight real accounts are now on Production subjects — including both platform-admin grants, without which nobody could be a platform admin on www.yipyy.com. The seven `@yipyy.dev` fixtures stay on Staging, so local dev and all 179 specs are untouched.

**The guard is the point.** Running the script with no flag after a production migration would previously have dragged all eight back to Staging — silently, reporting success, taking production sign-in and both platform-admin grants with it. The filter is now symmetric, and both invocations report "nothing to migrate".

`--production` deliberately does not call `applyWorkosTestKeys()` and asserts the opposite (a `sk_test_` key is the error). Loosening that helper would have exposed the whole e2e suite to production.

The subject test also had to change: a `user_3H…` prefix identified Clerk subjects, but a staging and a production WorkOS subject are both `user_01…` and no string test separates them. The environment is now asked directly.

## Verified after

15 profiles, 9 facility grants, 3 platform grants, 3 admins, 2 client links, 3 attributed payments, 1 attributed connection — all unchanged. Zero orphans, zero stuck `@migration.invalid` placeholders. Both dry runs report "nothing to migrate".