### PR TITLE
perf(routing): the front door names your destination instead of guessing

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,51 @@
 import { redirect } from "next/navigation";
 
+import { getViewer, landingPathFor } from "@/lib/auth/viewer";
+
+// ============================================================================
+// The front door. It resolves where you belong ONCE.
+//
+// It used to be `redirect("/dashboard")` unconditionally, which sent every
+// visitor — pet owners included — into the platform super-admin portal and let
+// that portal's gate bounce them back out. Measured on production, a signed-out
+// visitor to yipyy.com paid for THREE full document loads to reach sign-in:
+//
+//   /                  200, 6.0 kB shell   -> client router to /dashboard
+//   /dashboard         200, 7.0 kB shell   -> client router to /sign-in
+//   /sign-in?next=...  200, 8.5 kB
+//
+// plus a separate set of JS chunks for each. This resolves the session here and
+// names the destination directly, so the /dashboard hop is gone.
+//
+// ── WHY THESE ARE 200s AND NOT 307s ───────────────────────────────────────
+//
+// `redirect()` here is a SOFT redirect for the same reason it is in the portal
+// gates (see the long note in src/lib/auth/viewer.ts): the root layout streams,
+// so headers are already sent and Next answers 200 with a NEXT_REDIRECT in the
+// RSC payload for the client router to act on. Removing the remaining hop would
+// mean deciding in src/proxy.ts instead — and that file deliberately holds no
+// session logic and runs at the edge on every request. Trading a cheap query
+// here for a database round trip on every asset request is the wrong swap, so
+// this stops at two hops rather than one.
+//
+// ── COST FOR THE COMMON CASE ──────────────────────────────────────────────
+//
+// A signed-out visitor is the common case at this URL and pays nothing extra:
+// `getViewer()` calls `withAuth()`, finds no session, and returns ANONYMOUS
+// without touching Postgres. Only a signed-in visitor pays the two RLS-scoped
+// reads, and that is the request that would otherwise have loaded an entire
+// portal shell it had no right to see.
+//
+// `landingPathFor` is the same helper the portal gates use, so the front door
+// and the gates cannot disagree about where somebody belongs.
+// ============================================================================
+
 export default async function Home() {
-  redirect("/dashboard");
+  const viewer = await getViewer();
+
+  // `source`, not `userId !== null` — the gates read the same field, and it is
+  // what shows up in logs.
+  if (viewer.source === "anonymous") redirect("/sign-in");
+
+  redirect(landingPathFor(viewer));
 }


### PR DESCRIPTION
`yipyy.com` sent every visitor to `/dashboard` — the platform super-admin portal — and let that portal.s gate bounce them back out. Pet owners included.

## Measured on production

A signed-out visitor paid for **three full document loads** to reach sign-in:

```
/                  200, 6.0 kB shell  -> client router to /dashboard
/dashboard         200, 7.0 kB shell  -> client router to /sign-in
/sign-in?next=...  200, 8.5 kB
```

plus a separate set of JS chunks each time — 88-90 requests and 1.7 MB in the trace. The middle hop is now gone.

## Why these are 200s and not 307s

The root layout streams, so headers are already sent and Next answers 200 with a `NEXT_REDIRECT` in the RSC payload for the client router — the same soft-redirect behaviour already documented on the portal gates in `viewer.ts`.

Removing the last hop would mean deciding in `proxy.ts`, which deliberately holds no session logic and runs at the edge on every request. Trading a cheap query here for a database round trip on every asset request is the wrong swap, so this stops at two hops rather than one.

## Cost

The common case costs nothing extra: a signed-out visitor resolves to `ANONYMOUS` from `withAuth()` without touching Postgres. Only a signed-in visitor pays the two RLS-scoped reads — the request that would otherwise have downloaded an entire portal shell it had no right to see.

Reuses `landingPathFor()`, so the front door and the portal gates cannot disagree about where somebody belongs.

## Note for reviewers

The root route changes from static to **dynamic** (`f /` in the build output). That is required, not incidental: a prerendered redirect would serve one person.s destination to everybody.

This is a robustness and performance change. It is **not** a fix for the intermittent load failure under investigation — fewer hops means fewer chances to fail, but the cause of that is still unidentified and the server logs remain clean.