### PR TITLE
feat(auth): pick your language before you have an account

### DIFF
--- a/docs/quality/debt-map.md
+++ b/docs/quality/debt-map.md
@@ -1953,6 +1953,44 @@ Route Handler, not a page with `redirect()`. Verify with
 `curl -i` that it is a 307 — a 200 with a `text/x-component` body means the
 client router is doing the work and this bug is in range.
 
+## Snapshot (2026-08-17, i18n turned out to be scaffolding)
+
+### 🟡 next-intl was installed, configured, and never connected
+
+`next-intl@4.5.8` was a dependency, `src/i18n/request.ts` existed and returned a
+locale, `messages/en.json` and `messages/fr.json` held ~1,100 strings between
+them, and `src/lib/language-settings.ts` resolved a preference from three
+cookies. There were **zero** calls to `useTranslations` or `getTranslations`, no
+`NextIntlClientProvider`, and no plugin in `next.config.ts` — so `request.ts` was
+dead code and the first `getTranslations()` anyone wrote would have thrown.
+`<html lang>` was the literal string `"en"`.
+
+Both AGENTS.md and the architecture overview listed "next-intl (en/fr)" as a
+fact about the system. It was a fact about `package.json`.
+
+**Fixed for the auth screens only** (PR #125): the plugin is wired, so
+`getTranslations()` now works anywhere, and sign-in, sign-up and reset-password
+render from an `auth` namespace with a language switcher for people who have no
+session and therefore no settings screen to change it on.
+
+**Everything else is still hardcoded English**, including `/join` — which is why
+`AuthCard` takes `signedOut` rather than always drawing the switcher. Putting a
+language control over untranslated copy makes a control that pretends to work.
+
+**Two things that stay English on a French screen**, both deliberate:
+
+- Whatever `readableError` lifts out of a WorkOS exception
+  (`src/lib/auth/workos-actions.ts`). It is the vendor's wording; preferring our
+  translated fallback would trade "that password was found in a data breach" for
+  "could not sign in", which is worse in any language.
+- A facility's own `tagline`. It is one stored string in the words the business
+  chose, and machine-translating someone's brand copy is not ours to do.
+
+**Do instead:** when translating a new screen, add its namespace to BOTH
+catalogues in the same change and check key parity — nothing enforces it, and
+next-intl renders a missing key as the key itself, so a gap ships as
+`auth.fields.email` printed on the page rather than as an error.
+
 ## How to add to this map
 
 Append under a new dated heading. For each item: a one-line description, a severity, **why it's risky**, and **what to do instead** of casually touching it. Don't delete items — strike them through with the date and PR when genuinely resolved.

--- a/messages/en.json
+++ b/messages/en.json
@@ -1,4 +1,80 @@
 {
+  "auth": {
+    "language": {
+      "label": "Language"
+    },
+    "meta": {
+      "signIn": "Sign in — Yipyy",
+      "signInBranded": "Sign in — {name}",
+      "signUp": "Create an account — Yipyy",
+      "signUpBranded": "Create an account — {name}",
+      "reset": "Choose a new password — Yipyy"
+    },
+    "signIn": {
+      "title": "Sign in",
+      "description": "Use your Yipyy account — we'll take you to the right place.",
+      "brandedDescription": "Sign in to {name}.",
+      "noAccount": "Don't have an account?",
+      "signUpLink": "Sign up"
+    },
+    "signUp": {
+      "title": "Create your account",
+      "description": "One account for booking, your pets and your visits.",
+      "descriptionJoin": "Create your Yipyy account, then join {name}.",
+      "descriptionNoSelfSignup": "Create your Yipyy account. {name} adds customers themselves — we'll find your record afterwards.",
+      "haveAccount": "Already have an account?",
+      "signInLink": "Sign in"
+    },
+    "reset": {
+      "title": "Choose a new password",
+      "description": "Then we'll sign you in.",
+      "badLinkTitle": "That link didn't work",
+      "badLinkDescription": "Password reset links can only be used once, and they expire.",
+      "badLinkBody": "Request a new one from the sign-in page.",
+      "backToSignIn": "Back to sign in",
+      "remembered": "Remembered it?",
+      "signInLink": "Sign in",
+      "confirmLabel": "Confirm new password",
+      "mismatch": "Those two passwords do not match.",
+      "submit": "Set new password",
+      "submitting": "Saving…"
+    },
+    "fields": {
+      "firstName": "First name",
+      "lastName": "Last name",
+      "email": "Email",
+      "emailPlaceholder": "you@example.com",
+      "password": "Password",
+      "newPassword": "New password",
+      "verificationCode": "Verification code",
+      "codePlaceholder": "6-digit code",
+      "passwordHint": "At least 8 characters, and not a password known to have been breached."
+    },
+    "actions": {
+      "signIn": "Sign in",
+      "signingIn": "Signing in…",
+      "createAccount": "Create account",
+      "creatingAccount": "Creating account…",
+      "verify": "Verify and continue",
+      "verifying": "Verifying…",
+      "forgotPassword": "Forgot password?",
+      "continueWith": "Continue with {provider}",
+      "redirecting": "Redirecting…",
+      "or": "or"
+    },
+    "notices": {
+      "codeSent": "We've sent a verification code to {email}.",
+      "enterEmailFirst": "Enter your email first, then choose Forgot password.",
+      "resetSent": "If that address has an account, we've emailed a link to reset the password.",
+      "resetOpenLink": "Open the link in that email to choose a new password. You can close this page."
+    },
+    "callbackErrors": {
+      "state": "That sign-in could not be verified. Please try again from this page.",
+      "missing_code": "The sign-in did not complete. Please try again.",
+      "exchange": "We could not finish signing you in. Please try again.",
+      "provider": "That sign-in was cancelled."
+    }
+  },
   "common": {
     "save": "Save",
     "cancel": "Cancel",
@@ -15,7 +91,6 @@
     "reset": "Reset",
     "apply": "Apply",
     "submit": "Submit",
-
     "next": "Next",
     "previous": "Previous",
     "close": "Close",
@@ -25,7 +100,6 @@
     "actions": "Actions",
     "details": "Details",
     "total": "Total",
-
     "inactive": "Inactive",
     "all": "All",
     "today": "Today",
@@ -132,8 +206,7 @@
     "systemStatus": "System Status",
     "alertsNotifications": "Alerts & Notifications",
     "promotionsDiscounts": "Promotions & Discounts",
-    "promoCodeSystem": "Promo Code System",
-    "performanceMetrics": "Performance Metrics"
+    "promoCodeSystem": "Promo Code System"
   },
   "dashboard": {
     "title": "Dashboard",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -1,4 +1,80 @@
 {
+  "auth": {
+    "language": {
+      "label": "Langue"
+    },
+    "meta": {
+      "signIn": "Connexion — Yipyy",
+      "signInBranded": "Connexion — {name}",
+      "signUp": "Créer un compte — Yipyy",
+      "signUpBranded": "Créer un compte — {name}",
+      "reset": "Choisir un nouveau mot de passe — Yipyy"
+    },
+    "signIn": {
+      "title": "Connexion",
+      "description": "Utilisez votre compte Yipyy — nous vous emmenons au bon endroit.",
+      "brandedDescription": "Connectez-vous à {name}.",
+      "noAccount": "Vous n'avez pas de compte ?",
+      "signUpLink": "Créer un compte"
+    },
+    "signUp": {
+      "title": "Créez votre compte",
+      "description": "Un seul compte pour vos réservations, vos animaux et vos visites.",
+      "descriptionJoin": "Créez votre compte Yipyy, puis rejoignez {name}.",
+      "descriptionNoSelfSignup": "Créez votre compte Yipyy. {name} ajoute ses clients elle-même — nous retrouverons votre dossier ensuite.",
+      "haveAccount": "Vous avez déjà un compte ?",
+      "signInLink": "Se connecter"
+    },
+    "reset": {
+      "title": "Choisissez un nouveau mot de passe",
+      "description": "Nous vous connecterons ensuite.",
+      "badLinkTitle": "Ce lien n'a pas fonctionné",
+      "badLinkDescription": "Les liens de réinitialisation ne servent qu'une fois, et ils expirent.",
+      "badLinkBody": "Demandez-en un nouveau depuis la page de connexion.",
+      "backToSignIn": "Retour à la connexion",
+      "remembered": "Vous vous en souvenez ?",
+      "signInLink": "Se connecter",
+      "confirmLabel": "Confirmez le nouveau mot de passe",
+      "mismatch": "Ces deux mots de passe ne correspondent pas.",
+      "submit": "Définir le mot de passe",
+      "submitting": "Enregistrement…"
+    },
+    "fields": {
+      "firstName": "Prénom",
+      "lastName": "Nom",
+      "email": "E-mail",
+      "emailPlaceholder": "vous@exemple.com",
+      "password": "Mot de passe",
+      "newPassword": "Nouveau mot de passe",
+      "verificationCode": "Code de vérification",
+      "codePlaceholder": "Code à 6 chiffres",
+      "passwordHint": "Au moins 8 caractères, et pas un mot de passe connu pour avoir fuité."
+    },
+    "actions": {
+      "signIn": "Se connecter",
+      "signingIn": "Connexion…",
+      "createAccount": "Créer le compte",
+      "creatingAccount": "Création du compte…",
+      "verify": "Vérifier et continuer",
+      "verifying": "Vérification…",
+      "forgotPassword": "Mot de passe oublié ?",
+      "continueWith": "Continuer avec {provider}",
+      "redirecting": "Redirection…",
+      "or": "ou"
+    },
+    "notices": {
+      "codeSent": "Nous avons envoyé un code de vérification à {email}.",
+      "enterEmailFirst": "Saisissez d'abord votre e-mail, puis choisissez Mot de passe oublié.",
+      "resetSent": "Si un compte existe pour cette adresse, nous y avons envoyé un lien de réinitialisation.",
+      "resetOpenLink": "Ouvrez le lien dans cet e-mail pour choisir un nouveau mot de passe. Vous pouvez fermer cette page."
+    },
+    "callbackErrors": {
+      "state": "Cette connexion n'a pas pu être vérifiée. Réessayez depuis cette page.",
+      "missing_code": "La connexion ne s'est pas terminée. Veuillez réessayer.",
+      "exchange": "Nous n'avons pas pu terminer votre connexion. Veuillez réessayer.",
+      "provider": "Cette connexion a été annulée."
+    }
+  },
   "common": {
     "save": "Enregistrer",
     "cancel": "Annuler",
@@ -130,8 +206,7 @@
     "systemStatus": "État du système",
     "alertsNotifications": "Alertes et notifications",
     "promotionsDiscounts": "Promotions et rabais",
-    "promoCodeSystem": "Système de codes promo",
-    "performanceMetrics": "Métriques de performance"
+    "promoCodeSystem": "Système de codes promo"
   },
   "dashboard": {
     "title": "Tableau de bord",

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,4 +1,15 @@
+import createNextIntlPlugin from "next-intl/plugin";
 import type { NextConfig } from "next";
+
+// next-intl was installed, given a request config, two message catalogues and a
+// settings layer -- and never connected, so `src/i18n/request.ts` was dead code
+// and `getTranslations()` would have thrown at every call site. There were none.
+// This is the wire that was missing; without it the language switcher on the
+// auth screens is a control that changes nothing.
+//
+// Additive on purpose: a page that calls no translation function is unaffected,
+// which is what makes it safe to turn on across 266 routes to serve four.
+const withNextIntl = createNextIntlPlugin("./src/i18n/request.ts");
 
 const nextConfig: NextConfig = {
   reactCompiler: true,
@@ -55,4 +66,4 @@ const nextConfig: NextConfig = {
   },
 };
 
-export default nextConfig;
+export default withNextIntl(nextConfig);

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import { AuthKitProvider } from "@workos-inc/authkit-nextjs/components";
 import type { Metadata } from "next";
+import { getLocale } from "next-intl/server";
 import { Inter, Plus_Jakarta_Sans } from "next/font/google";
 import { Toaster } from "sonner";
 import { QueryProvider } from "@/lib/query-provider";
@@ -26,14 +27,20 @@ export const metadata: Metadata = {
   },
 };
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  // Was hardcoded "en", which was true until the auth screens could be read in
+  // French. `lang` is not decoration: it picks the voice a screen reader uses
+  // and the dictionary a browser spell-checks and offers to translate with, so
+  // a French page announced as English is read aloud with English phonetics.
+  const locale = await getLocale();
+
   return (
     <html
-      lang="en"
+      lang={locale}
       className={` ${inter.variable} ${plusJakarta.variable} `}
       suppressHydrationWarning
     >

--- a/src/app/reset-password/page.tsx
+++ b/src/app/reset-password/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import Link from "next/link";
+import { getTranslations } from "next-intl/server";
 import { headers } from "next/headers";
 
 import { AuthCard } from "@/components/auth/AuthCard";
@@ -7,7 +8,12 @@ import { FacilityAuthBrand } from "@/components/auth/FacilityAuthBrand";
 import { ResetPasswordForm } from "@/components/auth/ResetPasswordForm";
 import { getBrandingBySlug } from "@/lib/api/facility-branding";
 
-export const metadata: Metadata = { title: "Choose a new password — Yipyy" };
+// `generateMetadata` rather than a static object: the title follows the locale
+// now, and a static export is evaluated before one is resolved.
+export async function generateMetadata(): Promise<Metadata> {
+  const t = await getTranslations("auth.meta");
+  return { title: t("reset") };
+}
 
 // ============================================================================
 // Where the password-reset email lands.
@@ -33,6 +39,7 @@ export default async function ResetPasswordPage({
   const { token } = await searchParams;
   const slug = (await headers()).get("x-facility-slug");
   const branding = slug ? await getBrandingBySlug(slug) : null;
+  const t = await getTranslations("auth.reset");
 
   const brand = branding ? (
     <FacilityAuthBrand branding={branding} />
@@ -43,18 +50,17 @@ export default async function ResetPasswordPage({
   if (!token) {
     return (
       <AuthCard
-        title="That link didn't work"
-        description="Password reset links can only be used once, and they expire."
+        signedOut
+        title={t("badLinkTitle")}
+        description={t("badLinkDescription")}
         brand={brand}
       >
-        <p className="text-muted-foreground text-sm">
-          Request a new one from the sign-in page.
-        </p>
+        <p className="text-muted-foreground text-sm">{t("badLinkBody")}</p>
         <Link
           href="/sign-in"
           className="text-primary text-sm font-medium hover:underline"
         >
-          Back to sign in
+          {t("backToSignIn")}
         </Link>
       </AuthCard>
     );
@@ -62,17 +68,18 @@ export default async function ResetPasswordPage({
 
   return (
     <AuthCard
-      title="Choose a new password"
-      description="Then we'll sign you in."
+      signedOut
+      title={t("title")}
+      description={t("description")}
       brand={brand}
       footer={
         <p className="text-muted-foreground text-center text-sm">
-          Remembered it?{" "}
+          {t("remembered")}{" "}
           <Link
             href="/sign-in"
             className="text-primary font-medium hover:underline"
           >
-            Sign in
+            {t("signInLink")}
           </Link>
         </p>
       }

--- a/src/app/sign-in/[[...sign-in]]/page.tsx
+++ b/src/app/sign-in/[[...sign-in]]/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import Link from "next/link";
+import { getTranslations } from "next-intl/server";
 import { headers } from "next/headers";
 
 import { AuthCard } from "@/components/auth/AuthCard";
@@ -12,7 +13,10 @@ import { getBrandingBySlug } from "@/lib/api/facility-branding";
 export async function generateMetadata(): Promise<Metadata> {
   const slug = (await headers()).get("x-facility-slug");
   const branding = slug ? await getBrandingBySlug(slug) : null;
-  return { title: branding ? `Sign in — ${branding.name}` : "Sign in — Yipyy" };
+  const t = await getTranslations("auth.meta");
+  return {
+    title: branding ? t("signInBranded", { name: branding.name }) : t("signIn"),
+  };
 }
 
 // ============================================================================
@@ -47,24 +51,31 @@ export async function generateMetadata(): Promise<Metadata> {
 export default async function SignInPage() {
   const slug = (await headers()).get("x-facility-slug");
   const branding = slug ? await getBrandingBySlug(slug) : null;
+  const t = await getTranslations("auth");
 
   return (
     <AuthCard
-      title="Sign in"
+      signedOut
+      title={t("signIn.title")}
       description={
         branding
-          ? (branding.tagline ?? `Sign in to ${branding.name}.`)
-          : "Use your Yipyy account — we'll take you to the right place."
+          ? // A facility's own tagline is THEIR words, stored once, and stays in
+            // the language they wrote it in — translating it is not ours to do.
+            // The generic line beneath it is ours, so that one follows the
+            // locale.
+            (branding.tagline ??
+            t("signIn.brandedDescription", { name: branding.name }))
+          : t("signIn.description")
       }
       brand={branding ? <FacilityAuthBrand branding={branding} /> : undefined}
       footer={
         <p className="text-muted-foreground text-center text-sm">
-          Don&apos;t have an account?{" "}
+          {t("signIn.noAccount")}{" "}
           <Link
             href="/sign-up"
             className="text-primary font-medium hover:underline"
           >
-            Sign up
+            {t("signIn.signUpLink")}
           </Link>
         </p>
       }
@@ -73,7 +84,7 @@ export default async function SignInPage() {
 
       <div className="flex items-center gap-3">
         <span className="bg-border h-px flex-1" />
-        <span className="text-muted-foreground text-xs">or</span>
+        <span className="text-muted-foreground text-xs">{t("actions.or")}</span>
         <span className="bg-border h-px flex-1" />
       </div>
 

--- a/src/app/sign-up/[[...sign-up]]/page.tsx
+++ b/src/app/sign-up/[[...sign-up]]/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import Link from "next/link";
+import { getTranslations } from "next-intl/server";
 import { headers } from "next/headers";
 
 import { AuthCard } from "@/components/auth/AuthCard";
@@ -12,10 +13,9 @@ import { getBrandingBySlug } from "@/lib/api/facility-branding";
 export async function generateMetadata(): Promise<Metadata> {
   const slug = (await headers()).get("x-facility-slug");
   const branding = slug ? await getBrandingBySlug(slug) : null;
+  const t = await getTranslations("auth.meta");
   return {
-    title: branding
-      ? `Create an account — ${branding.name}`
-      : "Create an account — Yipyy",
+    title: branding ? t("signUpBranded", { name: branding.name }) : t("signUp"),
   };
 }
 
@@ -52,26 +52,28 @@ export async function generateMetadata(): Promise<Metadata> {
 export default async function SignUpPage() {
   const slug = (await headers()).get("x-facility-slug");
   const branding = slug ? await getBrandingBySlug(slug) : null;
+  const t = await getTranslations("auth");
 
   const description = !branding
-    ? "One account for booking, your pets and your visits."
+    ? t("signUp.description")
     : branding.allowCustomerSignup
-      ? `Create your Yipyy account, then join ${branding.name}.`
-      : `Create your Yipyy account. ${branding.name} adds customers themselves — we'll find your record afterwards.`;
+      ? t("signUp.descriptionJoin", { name: branding.name })
+      : t("signUp.descriptionNoSelfSignup", { name: branding.name });
 
   return (
     <AuthCard
-      title="Create your account"
+      signedOut
+      title={t("signUp.title")}
       description={description}
       brand={branding ? <FacilityAuthBrand branding={branding} /> : undefined}
       footer={
         <p className="text-muted-foreground text-center text-sm">
-          Already have an account?{" "}
+          {t("signUp.haveAccount")}{" "}
           <Link
             href="/sign-in"
             className="text-primary font-medium hover:underline"
           >
-            Sign in
+            {t("signUp.signInLink")}
           </Link>
         </p>
       }
@@ -80,7 +82,7 @@ export default async function SignUpPage() {
 
       <div className="flex items-center gap-3">
         <span className="bg-border h-px flex-1" />
-        <span className="text-muted-foreground text-xs">or</span>
+        <span className="text-muted-foreground text-xs">{t("actions.or")}</span>
         <span className="bg-border h-px flex-1" />
       </div>
 

--- a/src/components/auth/AuthCard.tsx
+++ b/src/components/auth/AuthCard.tsx
@@ -1,5 +1,9 @@
 import Image from "next/image";
+import { NextIntlClientProvider } from "next-intl";
+import { getLocale, getMessages, getTranslations } from "next-intl/server";
+import { cookies } from "next/headers";
 
+import { LanguageSwitcher } from "@/components/auth/LanguageSwitcher";
 import {
   Card,
   CardContent,
@@ -7,6 +11,10 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import {
+  getEnabledLocales,
+  loadLanguageSettingsFromCookies,
+} from "@/lib/language-settings";
 
 // ============================================================================
 // The shell every auth screen sits in.
@@ -22,6 +30,26 @@ import {
 //
 // No "use client": this is presentational, so a Server Component page can use
 // it directly and only the interactive widget inside pays for hydration.
+//
+// ── IT ALSO CARRIES THE LANGUAGE ──────────────────────────────────────────
+//
+// Two jobs live here rather than in each page because both are about the SHELL
+// around the credential UI, and eight copies of this markup is exactly how the
+// auth screens drifted apart the first time.
+//
+//   1. `NextIntlClientProvider`, scoped to the `auth` namespace ONLY. The
+//      default provider hands the client every message in the catalogue; the
+//      forms need about sixty strings, so passing the one namespace keeps ~19 kB
+//      of facility, billing and reporting copy out of a page whose entire job is
+//      a login box.
+//
+//   2. The language switcher, for people who have no session yet and therefore
+//      no settings screen to change it on. `signedOut` gates it: /join runs
+//      behind a session and its reader already has a language preference
+//      elsewhere, so it opts out rather than showing a second control.
+//
+// A screen that has NOT been translated must not pass `signedOut` — a switcher
+// over hardcoded English is a control that pretends to work.
 // ============================================================================
 
 export function AuthBrandLogo() {
@@ -38,12 +66,13 @@ export function AuthBrandLogo() {
   );
 }
 
-export function AuthCard({
+export async function AuthCard({
   title,
   description,
   brand,
   children,
   footer,
+  signedOut = false,
 }: {
   title: string;
   description?: React.ReactNode;
@@ -51,22 +80,59 @@ export function AuthCard({
   brand?: React.ReactNode;
   children: React.ReactNode;
   footer?: React.ReactNode;
+  /**
+   * This screen is reachable without a session, so offer the language choice
+   * here. Only pass it from a screen whose copy actually comes from `messages`.
+   */
+  signedOut?: boolean;
 }) {
+  const [locale, messages, t, cookieStore] = await Promise.all([
+    getLocale(),
+    getMessages(),
+    getTranslations("auth.language"),
+    cookies(),
+  ]);
+
+  const settings = loadLanguageSettingsFromCookies(
+    cookieStore
+      .getAll()
+      .map(({ name, value }) => `${name}=${value}`)
+      .join("; "),
+  );
+  const locales = getEnabledLocales(settings);
+
   return (
-    <div className="from-background via-muted/20 to-background flex min-h-screen items-center justify-center bg-linear-to-br p-4">
-      <Card className="w-full max-w-md">
-        <CardHeader className="space-y-1 text-center">
-          <div className="mb-4 flex justify-center">
-            {brand ?? <AuthBrandLogo />}
-          </div>
-          <CardTitle className="text-2xl font-bold">{title}</CardTitle>
-          {description && <CardDescription>{description}</CardDescription>}
-        </CardHeader>
-        <CardContent className="space-y-4">
-          {children}
-          {footer}
-        </CardContent>
-      </Card>
+    <div className="from-background via-muted/20 to-background flex min-h-screen flex-col items-center justify-center bg-linear-to-br p-4">
+      <NextIntlClientProvider
+        locale={locale}
+        // The namespace, not the catalogue — see the note above.
+        messages={{ auth: messages.auth }}
+      >
+        <Card className="w-full max-w-md">
+          <CardHeader className="space-y-1 text-center">
+            <div className="mb-4 flex justify-center">
+              {brand ?? <AuthBrandLogo />}
+            </div>
+            <CardTitle className="text-2xl font-bold">{title}</CardTitle>
+            {description && <CardDescription>{description}</CardDescription>}
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {children}
+            {footer}
+          </CardContent>
+        </Card>
+
+        {/* Below the card, not inside it: the card is one task and this is not
+            part of it. Hidden outright when the app offers a single locale —
+            a switcher with one option is decoration. */}
+        {signedOut && locales.length > 1 && (
+          <LanguageSwitcher
+            locales={locales}
+            current={locale as (typeof locales)[number]}
+            label={t("label")}
+          />
+        )}
+      </NextIntlClientProvider>
     </div>
   );
 }

--- a/src/components/auth/EmailSignInForm.tsx
+++ b/src/components/auth/EmailSignInForm.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useTranslations } from "next-intl";
 import { useSearchParams } from "next/navigation";
 import { useState, useTransition } from "react";
 
@@ -40,21 +41,46 @@ import {
 //
 // Errors come back from the server actions as values, never thrown, so every
 // failure lands in the red box below instead of a Next error overlay.
+//
+// EVERY STRING BELOW COMES FROM `messages`. The one category that does not is
+// the text `readableError` lifts out of a WorkOS exception in workos-actions.ts
+// — that is the vendor's wording, in the vendor's language, and preferring our
+// own translated fallback over it would trade "your password was found in a
+// breach" for "could not sign in". Known and deliberate; see the debt map.
 // ============================================================================
 
 type Step = "credentials" | "verify" | "reset-sent";
 
-/** The callback route bounces here with ?error=… when a social sign-in fails. */
-const CALLBACK_ERRORS: Record<string, string> = {
-  state: "That sign-in could not be verified. Please try again from this page.",
-  missing_code: "The sign-in did not complete. Please try again.",
-  exchange: "We could not finish signing you in. Please try again.",
-  provider: "That sign-in was cancelled.",
-};
+/**
+ * The callback route bounces here with ?error=… when a social sign-in fails.
+ *
+ * A list of KEYS rather than a map of sentences: the sentences live in
+ * `messages/*.json` now, and an unrecognised value from the query string must
+ * not reach `t()` — next-intl renders a missing key as the key itself, which
+ * would print "callbackErrors.haha" on screen for anyone who edits the URL.
+ */
+const CALLBACK_ERROR_KEYS = [
+  "state",
+  "missing_code",
+  "exchange",
+  "provider",
+] as const;
+
+type CallbackErrorKey = (typeof CALLBACK_ERROR_KEYS)[number];
+
+function asCallbackErrorKey(value: string | null): CallbackErrorKey | null {
+  return CALLBACK_ERROR_KEYS.includes(value as CallbackErrorKey)
+    ? (value as CallbackErrorKey)
+    : null;
+}
 
 export function EmailSignInForm() {
+  const t = useTranslations("auth");
   const searchParams = useSearchParams();
-  const callbackError = CALLBACK_ERRORS[searchParams.get("error") ?? ""];
+  const callbackErrorKey = asCallbackErrorKey(searchParams.get("error"));
+  const callbackError = callbackErrorKey
+    ? t(`callbackErrors.${callbackErrorKey}`)
+    : null;
 
   const [step, setStep] = useState<Step>("credentials");
   const [email, setEmail] = useState("");
@@ -71,7 +97,7 @@ export function EmailSignInForm() {
       const result = await signInWithPassword(email, password);
       // A successful sign-in redirects on the server and never returns.
       if (result?.needsVerification) {
-        setNotice(`We've sent a verification code to ${email.trim()}.`);
+        setNotice(t("notices.codeSent", { email: email.trim() }));
         setStep("verify");
         return;
       }
@@ -90,7 +116,7 @@ export function EmailSignInForm() {
 
   function startReset() {
     if (!email.trim()) {
-      setMessage("Enter your email first, then choose Forgot password.");
+      setMessage(t("notices.enterEmailFirst"));
       return;
     }
     setMessage(null);
@@ -99,9 +125,7 @@ export function EmailSignInForm() {
       // Always the same answer, whether or not the address exists — see the
       // action. Telling an anonymous caller which addresses are real turns this
       // button into an account-enumeration oracle.
-      setNotice(
-        "If that address has an account, we've emailed a link to reset the password.",
-      );
+      setNotice(t("notices.resetSent"));
       setStep("reset-sent");
     });
   }
@@ -120,7 +144,7 @@ export function EmailSignInForm() {
       {step === "credentials" && (
         <form onSubmit={submitCredentials} className="space-y-4">
           <div className="space-y-2">
-            <Label htmlFor="identifier">Email</Label>
+            <Label htmlFor="identifier">{t("fields.email")}</Label>
             <Input
               id="identifier"
               type="email"
@@ -128,19 +152,19 @@ export function EmailSignInForm() {
               required
               value={email}
               onChange={(e) => setEmail(e.target.value)}
-              placeholder="you@example.com"
+              placeholder={t("fields.emailPlaceholder")}
             />
           </div>
 
           <div className="space-y-2">
             <div className="flex items-center justify-between">
-              <Label htmlFor="password">Password</Label>
+              <Label htmlFor="password">{t("fields.password")}</Label>
               <button
                 type="button"
                 onClick={startReset}
                 className="text-primary text-sm font-medium hover:underline"
               >
-                Forgot password?
+                {t("actions.forgotPassword")}
               </button>
             </div>
             <PasswordInput
@@ -153,7 +177,7 @@ export function EmailSignInForm() {
           </div>
 
           <Button type="submit" className="h-11 w-full" disabled={pending}>
-            {pending ? "Signing in…" : "Sign in"}
+            {pending ? t("actions.signingIn") : t("actions.signIn")}
           </Button>
         </form>
       )}
@@ -161,7 +185,7 @@ export function EmailSignInForm() {
       {step === "verify" && (
         <form onSubmit={submitCode} className="space-y-4">
           <div className="space-y-2">
-            <Label htmlFor="verify-code">Verification code</Label>
+            <Label htmlFor="verify-code">{t("fields.verificationCode")}</Label>
             <Input
               id="verify-code"
               inputMode="numeric"
@@ -169,19 +193,18 @@ export function EmailSignInForm() {
               required
               value={code}
               onChange={(e) => setCode(e.target.value)}
-              placeholder="6-digit code"
+              placeholder={t("fields.codePlaceholder")}
             />
           </div>
           <Button type="submit" className="h-11 w-full" disabled={pending}>
-            {pending ? "Verifying…" : "Verify and continue"}
+            {pending ? t("actions.verifying") : t("actions.verify")}
           </Button>
         </form>
       )}
 
       {step === "reset-sent" && (
         <p className="text-muted-foreground text-sm">
-          Open the link in that email to choose a new password. You can close
-          this page.
+          {t("notices.resetOpenLink")}
         </p>
       )}
 

--- a/src/components/auth/EmailSignUpForm.tsx
+++ b/src/components/auth/EmailSignUpForm.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useTranslations } from "next-intl";
 import { useState, useTransition } from "react";
 
 import { Button } from "@/components/ui/button";
@@ -39,6 +40,7 @@ import { signUpWithPassword, verifyEmailCode } from "@/lib/auth/workos-actions";
 type Step = "details" | "verify";
 
 export function EmailSignUpForm() {
+  const t = useTranslations("auth");
   const [step, setStep] = useState<Step>("details");
   const [firstName, setFirstName] = useState("");
   const [lastName, setLastName] = useState("");
@@ -60,7 +62,7 @@ export function EmailSignUpForm() {
         password,
       );
       if (result?.needsVerification) {
-        setNotice(`We've sent a verification code to ${email.trim()}.`);
+        setNotice(t("notices.codeSent", { email: email.trim() }));
         setStep("verify");
         return;
       }
@@ -93,7 +95,7 @@ export function EmailSignUpForm() {
         <form onSubmit={submitDetails} className="space-y-4">
           <div className="grid grid-cols-2 gap-3">
             <div className="space-y-2">
-              <Label htmlFor="first-name">First name</Label>
+              <Label htmlFor="first-name">{t("fields.firstName")}</Label>
               <Input
                 id="first-name"
                 autoComplete="given-name"
@@ -103,7 +105,7 @@ export function EmailSignUpForm() {
               />
             </div>
             <div className="space-y-2">
-              <Label htmlFor="last-name">Last name</Label>
+              <Label htmlFor="last-name">{t("fields.lastName")}</Label>
               <Input
                 id="last-name"
                 autoComplete="family-name"
@@ -115,7 +117,7 @@ export function EmailSignUpForm() {
           </div>
 
           <div className="space-y-2">
-            <Label htmlFor="signup-email">Email</Label>
+            <Label htmlFor="signup-email">{t("fields.email")}</Label>
             <Input
               id="signup-email"
               type="email"
@@ -123,12 +125,12 @@ export function EmailSignUpForm() {
               required
               value={email}
               onChange={(e) => setEmail(e.target.value)}
-              placeholder="you@example.com"
+              placeholder={t("fields.emailPlaceholder")}
             />
           </div>
 
           <div className="space-y-2">
-            <Label htmlFor="signup-password">Password</Label>
+            <Label htmlFor="signup-password">{t("fields.password")}</Label>
             <PasswordInput
               id="signup-password"
               autoComplete="new-password"
@@ -138,13 +140,14 @@ export function EmailSignUpForm() {
               onChange={(e) => setPassword(e.target.value)}
             />
             <p className="text-muted-foreground text-xs">
-              At least 8 characters, and not a password known to have been
-              breached.
+              {t("fields.passwordHint")}
             </p>
           </div>
 
           <Button type="submit" className="h-11 w-full" disabled={pending}>
-            {pending ? "Creating account…" : "Create account"}
+            {pending
+              ? t("actions.creatingAccount")
+              : t("actions.createAccount")}
           </Button>
         </form>
       )}
@@ -152,7 +155,7 @@ export function EmailSignUpForm() {
       {step === "verify" && (
         <form onSubmit={submitCode} className="space-y-4">
           <div className="space-y-2">
-            <Label htmlFor="signup-code">Verification code</Label>
+            <Label htmlFor="signup-code">{t("fields.verificationCode")}</Label>
             <Input
               id="signup-code"
               inputMode="numeric"
@@ -160,11 +163,11 @@ export function EmailSignUpForm() {
               required
               value={code}
               onChange={(e) => setCode(e.target.value)}
-              placeholder="6-digit code"
+              placeholder={t("fields.codePlaceholder")}
             />
           </div>
           <Button type="submit" className="h-11 w-full" disabled={pending}>
-            {pending ? "Verifying…" : "Verify and continue"}
+            {pending ? t("actions.verifying") : t("actions.verify")}
           </Button>
         </form>
       )}

--- a/src/components/auth/LanguageSwitcher.tsx
+++ b/src/components/auth/LanguageSwitcher.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { Languages } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useTransition } from "react";
+
+import { setClientLocaleCookie, type AppLocale } from "@/lib/language-settings";
+import { cn } from "@/lib/utils";
+
+// ============================================================================
+// Choosing a language before you have an account.
+//
+// Every other language control in this app lives behind a session — facility
+// settings, the customer profile — which left the one screen where somebody has
+// no session yet with no way to read it in their own language. A French-speaking
+// pet owner arriving at a Quebec facility's sign-in page had to sign in in
+// English to find the setting that would have let them sign in in French.
+//
+// ── HOW THE CHOICE TRAVELS ────────────────────────────────────────────────
+//
+// `NEXT_LOCALE` is the cookie src/i18n/request.ts already reads, so this writes
+// the same one every other locale decision in the app is made from rather than
+// inventing a second channel. It survives sign-in, which is the point: the
+// language you picked here is still the language you get afterwards.
+//
+// `router.refresh()` and NOT a navigation. The cookie is read on the SERVER, so
+// something has to re-render — but a refresh refetches the RSC payload in place,
+// which keeps whatever the person had already typed into the form and never asks
+// the client router to navigate. (That last part is not incidental; a soft
+// redirect through the client router is what crashed the front door on
+// 2026-08-17 — see docs/quality/debt-map.md.)
+//
+// ── WHY THE OPTIONS ARE PASSED IN ─────────────────────────────────────────
+//
+// Which locales exist is an app setting (`APP_LANG_*` cookies, read by
+// loadLanguageSettingsFromCookies), and the server has already resolved it by
+// the time this renders. Passing the answer down avoids a client-side read that
+// would disagree with the server on the first paint and flip after hydration.
+// AuthCard renders nothing at all when only one locale is enabled, so this
+// component never has to draw a control with a single choice.
+// ============================================================================
+
+const LOCALE_LABELS: Record<AppLocale, string> = {
+  en: "English",
+  fr: "Français",
+};
+
+export function LanguageSwitcher({
+  locales,
+  current,
+  label,
+}: {
+  locales: AppLocale[];
+  current: AppLocale;
+  /** Translated, because it is the one word that has to make sense either way. */
+  label: string;
+}) {
+  const router = useRouter();
+  const [pending, startTransition] = useTransition();
+
+  function choose(locale: AppLocale) {
+    if (locale === current) return;
+    setClientLocaleCookie(locale);
+    startTransition(() => router.refresh());
+  }
+
+  return (
+    <div
+      className="text-muted-foreground mt-6 flex items-center justify-center gap-2 text-xs"
+      data-pending={pending ? "" : undefined}
+    >
+      <Languages className="size-3.5 shrink-0" aria-hidden="true" />
+      {/* A radiogroup rather than a row of buttons: a screen reader should hear
+          "English, selected, 1 of 2", not two unrelated controls. */}
+      <div role="radiogroup" aria-label={label} className="flex items-center">
+        {locales.map((locale, index) => (
+          <span key={locale} className="flex items-center">
+            {index > 0 && <span className="text-border px-1.5">|</span>}
+            <button
+              type="button"
+              role="radio"
+              aria-checked={locale === current}
+              // `lang` so a screen reader pronounces "Français" in French
+              // rather than reading it as English.
+              lang={locale}
+              disabled={pending}
+              onClick={() => choose(locale)}
+              className={cn(
+                "rounded-sm px-1 transition-colors",
+                "focus-visible:ring-ring focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none",
+                locale === current
+                  ? "text-foreground font-medium"
+                  : "hover:text-foreground",
+                pending && "cursor-wait opacity-60",
+              )}
+            >
+              {LOCALE_LABELS[locale]}
+            </button>
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/auth/OAuthButton.tsx
+++ b/src/components/auth/OAuthButton.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useTranslations } from "next-intl";
 import type { ReactNode } from "react";
 import { useState, useTransition } from "react";
 
@@ -39,10 +40,15 @@ export function OAuthButton({
   mark,
 }: {
   provider: SupportedOAuthProvider;
-  /** Shown to the user, and used in the failure message. */
+  /**
+   * Shown to the user, and used in the failure message. NOT translated, and
+   * never should be: "Google" and "Apple" are trademarks with one spelling, and
+   * both companies' sign-in branding rules require their name verbatim.
+   */
   providerName: string;
   mark: ReactNode;
 }) {
+  const t = useTranslations("auth.actions");
   const [pending, startTransition] = useTransition();
   const [message, setMessage] = useState<string | null>(null);
 
@@ -66,11 +72,11 @@ export function OAuthButton({
         disabled={pending}
       >
         {pending ? (
-          "Redirecting…"
+          t("redirecting")
         ) : (
           <>
             {mark}
-            Continue with {providerName}
+            {t("continueWith", { provider: providerName })}
           </>
         )}
       </Button>

--- a/src/components/auth/ResetPasswordForm.tsx
+++ b/src/components/auth/ResetPasswordForm.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useTranslations } from "next-intl";
 import { useState, useTransition } from "react";
 
 import { Button } from "@/components/ui/button";
@@ -23,6 +24,7 @@ import { resetPassword } from "@/lib/auth/workos-actions";
 // ============================================================================
 
 export function ResetPasswordForm({ token }: { token: string }) {
+  const t = useTranslations("auth");
   const [password, setPassword] = useState("");
   const [confirm, setConfirm] = useState("");
   const [pending, startTransition] = useTransition();
@@ -44,7 +46,7 @@ export function ResetPasswordForm({ token }: { token: string }) {
   return (
     <form onSubmit={submit} className="space-y-4">
       <div className="space-y-2">
-        <Label htmlFor="new-password">New password</Label>
+        <Label htmlFor="new-password">{t("fields.newPassword")}</Label>
         <PasswordInput
           id="new-password"
           autoComplete="new-password"
@@ -54,12 +56,12 @@ export function ResetPasswordForm({ token }: { token: string }) {
           onChange={(e) => setPassword(e.target.value)}
         />
         <p className="text-muted-foreground text-xs">
-          At least 8 characters, and not a password known to have been breached.
+          {t("fields.passwordHint")}
         </p>
       </div>
 
       <div className="space-y-2">
-        <Label htmlFor="confirm-password">Confirm new password</Label>
+        <Label htmlFor="confirm-password">{t("reset.confirmLabel")}</Label>
         <PasswordInput
           id="confirm-password"
           autoComplete="new-password"
@@ -68,9 +70,7 @@ export function ResetPasswordForm({ token }: { token: string }) {
           onChange={(e) => setConfirm(e.target.value)}
         />
         {mismatch && (
-          <p className="text-destructive text-xs">
-            Those two passwords do not match.
-          </p>
+          <p className="text-destructive text-xs">{t("reset.mismatch")}</p>
         )}
       </div>
 
@@ -79,7 +79,7 @@ export function ResetPasswordForm({ token }: { token: string }) {
         className="h-11 w-full"
         disabled={pending || mismatch}
       >
-        {pending ? "Saving…" : "Set new password"}
+        {pending ? t("reset.submitting") : t("reset.submit")}
       </Button>
 
       {message && (


### PR DESCRIPTION
Adds a language switcher to the sign-in and sign-up screens. Most of this change is what had to be true for that switcher to mean anything.

## What was actually there

`next-intl@4.5.8` was a dependency, `src/i18n/request.ts` returned a locale, `messages/en.json` + `messages/fr.json` held ~1,100 strings, and `src/lib/language-settings.ts` resolved a preference from three cookies.

There were **zero** calls to `useTranslations` or `getTranslations` in `src/`, no `NextIntlClientProvider`, and no plugin in `next.config.ts`. So `request.ts` was dead code, the auth screens were hardcoded English, and `<html lang>` was the literal string `"en"`. A switcher on top of that is a control that changes nothing.

## What this does

- **Wires the plugin.** Additive — a page that calls no translation function is unaffected, which is what makes it safe to turn on across 266 routes to serve four.
- **Adds an `auth` namespace** to both catalogues, at verified key parity (58 keys each).
- **Translates** sign-in, sign-up and reset-password — pages, forms, OAuth buttons, notices, callback errors and `<title>`.
- **`<html lang>` follows the locale.** Not decoration: it picks the voice a screen reader uses and the dictionary a browser spell-checks with.
- **The switcher** writes `NEXT_LOCALE` — the cookie `request.ts` already reads, so the choice survives sign-in — and calls `router.refresh()` rather than navigating, which keeps whatever was typed into the form and never hands the client router a navigation to perform.

## Design notes

`AuthCard` carries the scoped `NextIntlClientProvider` (the `auth` namespace only — the default ships the whole catalogue, ~19 kB of facility and billing copy on a login page) and the switcher, behind a `signedOut` prop.

`/join` opts out: it runs behind a session, its reader can already set a language elsewhere, and its copy is not translated. **A switcher over untranslated copy pretends to work.**

Two things stay English on a French screen, both deliberate and both in the debt map:

- WorkOS's own error text (`readableError`) — preferring our translated fallback would trade *"that password was found in a data breach"* for *"could not sign in"*.
- A facility's `tagline` — their words, one stored string.

## Verification

Against a production build (`next build` + `next start`):

| check | result |
|---|---|
| `/sign-in`, `/sign-up`, `/reset-password` with `NEXT_LOCALE=fr` | fully French |
| `<html lang>` | `en` / `fr` correctly |
| `<title>` under fr | `Connexion — Yipyy` |
| switcher markup | `role="radiogroup"`, `aria-label="Language"`, English / Français |
| `APP_LANG_SECONDARY_ENABLED=0` | switcher absent (one locale is not a choice) |
| `?error=haha` | renders nothing — no message key printed on screen |
| `?error=provider` under fr | *Cette connexion a été annulée.* |
| `/` | still 307 |
| `/join` | still 200 (AuthCard became async) |
| server log | no errors |

`typecheck` / `lint` / `format:check` / `check:settings-wiring` / `check:settings-fixture` green.