### PR TITLE
docs(domains): name the eleven records, and stop citing Clerk

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -280,3 +280,24 @@ E2E_OTHER_CLIENT_REF=
 
 # The apex this deployment answers on. Facility subdomains are <slug>.<this>.
 NEXT_PUBLIC_APP_DOMAIN=
+
+# ── Facility subdomains (spec 002 D2) ──────────────────────────────────────
+#
+# Every facility gets its own host — <slug>.yipyy.com — and provisioning
+# attaches it to the Vercel project so a certificate is issued. DNS is already
+# handled by a single wildcard CNAME at the registrar; these only control
+# CERTIFICATE issuance. See src/lib/vercel/domains.ts for why there is no
+# `*.yipyy.com` wildcard domain.
+#
+# UNSET IS A SUPPORTED STATE, not a broken one: a local dev server, a preview or
+# a self-hosted instance creates facilities normally and reports that the
+# subdomain was not attached. Only production needs these.
+#
+# A Vercel API token with access to the project (vercel.com/account/tokens).
+# DOMAINS_* rather than VERCEL_* because Vercel injects its own VERCEL_PROJECT_ID
+# and VERCEL_TEAM_ID and may refuse a custom variable under that prefix.
+DOMAINS_API_TOKEN=
+DOMAINS_PROJECT_ID=
+# Omit on a personal-account project — Vercel rejects an empty teamId rather
+# than ignoring it.
+DOMAINS_TEAM_ID=

--- a/src/lib/vercel/domains.ts
+++ b/src/lib/vercel/domains.ts
@@ -15,11 +15,31 @@ import "server-only";
 // DNS-01 challenge — Let's Encrypt requires an `_acme-challenge` TXT record
 // that Vercel has to write and rotate itself.
 //
-// Moving the nameservers to Vercel would mean recreating twelve records, four
-// of them load-bearing: the MX pair (all company email), `clerk` and
-// `accounts` (every sign-in on the platform), and the DKIM pair (Clerk's mail
-// stops authenticating). A typo in any of them is an outage in something
-// unrelated to facilities.
+// Confirmed again on 2026-08-18 by adding `*.yipyy.com` to the project: it
+// reports "Invalid Configuration -- update your domain's nameservers", and
+// offers no DNS-01 record to add. Nameserver delegation is the ONLY route, so
+// there is nothing to retry here.
+//
+// Moving the nameservers would mean recreating ELEVEN records, and most of them
+// have nothing to do with facilities. Enumerated from the live zone rather than
+// remembered (the earlier version of this note counted twelve and named Clerk's
+// `clerk`/`accounts` hosts, which ADR 0004 removed):
+//
+//   A      yipyy.com                   -> Vercel          the site
+//   CNAME  www                         -> yipyy.com       the site
+//   CNAME  *                           -> Vercel          EVERY facility host
+//   MX     yipyy.com                   -> mx1/mx2.hostinger.com   ALL COMPANY EMAIL
+//   TXT    yipyy.com                   -> v=spf1 ...hostinger...  company email SPF
+//   TXT    yipyy.com                   -> google-site-verification=...
+//   CNAME  autodiscover                -> ...hostinger.com        mail auto-setup
+//   TXT    _dmarc                      -> v=DMARC1; p=none
+//   MX     send                        -> feedback-smtp...amazonses.com   Resend bounces
+//   TXT    send                        -> v=spf1 include:amazonses.com    Resend SPF
+//   TXT    resend._domainkey           -> p=MIGfMA0G...                   Resend DKIM
+//
+// The last three carry every password-reset and verification email WorkOS
+// sends. A typo there does not break facilities -- it locks people out of the
+// platform, silently, because the mail still sends and just lands in spam.
 //
 // So DNS keeps a single wildcard CNAME at the registrar — every subdomain
 // RESOLVES to Vercel — and each facility host is added to the project on its


### PR DESCRIPTION
Investigated whether facility subdomain provisioning works. **It does** — this PR fixes the two things that were actually wrong, both documentation.

## What I verified

| facility | created | subdomain |
|---|---|---|
| `yipyy-demo-facility` | Aug 1 — before the feature | ❌ → attached by hand |
| `pawradise` | Aug 7 13:32 | ✅ automatic |
| `doggieville-mtl` | Aug 7 16:58 | ✅ automatic |

Both facilities created after `DOMAINS_API_TOKEN` was configured got their host attached automatically. All three now serve their own branded login page:

```
yipyy-demo-facility.yipyy.com  200  <title>Sign in — Yipyy Demo Facility</title>
doggieville-mtl.yipyy.com      200  <title>Sign in — Doggieville Mtl</title>
pawradise.yipyy.com            200  <title>Sign in — pawradise</title>
```

## What was wrong

**1. The wildcard note in `domains.ts` described the Clerk-era zone.** It counted twelve records and named `clerk` and `accounts` as load-bearing — both removed by ADR 0004. Replaced with the eleven records actually present, enumerated from live DNS rather than memory.

The three that matter most now are Resend's — `MX send`, `TXT send`, `TXT resend._domainkey` — because they carry every password-reset and verification email WorkOS sends. A typo there doesn't break facilities; it locks people out of the platform *silently*, since the mail still sends and just lands in spam. Worth more than the outdated warning it replaces.

Also re-confirmed the reason there's no `*.yipyy.com`: adding it to the project reports *"Invalid Configuration — update your domain's nameservers"* and offers no DNS-01 record to add, so nameserver delegation is the only route. Nothing to retry.

**2. `DOMAINS_*` was undocumented in `.env.example`.** Unset fails silently by design (correct — a local dev server shouldn't need a Vercel token), but silent-failure plus undocumented is the worst combination: nobody setting up an environment would know facility subdomains need it.

## No code changed

`src/lib/vercel/domains.ts` logic, the creation call site, and the retry route are all untouched and all working.

`typecheck` / `lint` / `format:check` green.