### PR TITLE
feat(facilities): show a missing web address in the list, not one row at a time

### DIFF
--- a/src/app/api/facilities/domains/route.ts
+++ b/src/app/api/facilities/domains/route.ts
@@ -1,0 +1,47 @@
+import { NextResponse } from "next/server";
+
+import { attachedProjectHosts } from "@/lib/vercel/domains";
+import { getViewer } from "@/lib/auth/viewer";
+
+// ============================================================================
+// Which hosts are actually attached to the project — asked once, for the whole
+// facilities list.
+//
+// The per-facility answer already exists at /api/facilities/[id]/domain and is
+// what the detail screen uses. This exists because the LIST needs the same
+// answer for every row at once, and calling that route per row would be one
+// Vercel round trip per facility.
+//
+// ── IT RETURNS HOSTS, NOT A VERDICT ───────────────────────────────────────
+//
+// The comparison — is `<slug>.<appDomain>` in this list — is done by the
+// caller, which already holds every facility's slug. Doing it here would mean
+// re-reading the facility table to answer a question about somebody else's
+// system, and would make this route go stale in a different way than the
+// detail route does.
+//
+// Nothing is cached, for the reason facilityDomainStatus gives: a stored flag
+// is a claim about Vercel's state that is wrong the moment anyone edits the
+// project by hand.
+// ============================================================================
+
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  const viewer = await getViewer().catch(() => null);
+  if (!viewer || viewer.source !== "session") {
+    return NextResponse.json({ error: "Not signed in." }, { status: 401 });
+  }
+  if (!viewer.isPlatformAdmin) {
+    return NextResponse.json(
+      { error: "Only a platform administrator may list web addresses." },
+      { status: 403 },
+    );
+  }
+
+  // 200 even when Vercel is unreachable or unconfigured. "We could not check"
+  // is a real answer the list must be able to render as itself — turning it
+  // into a 500 would make the whole table look broken because an optional
+  // integration was unavailable.
+  return NextResponse.json(await attachedProjectHosts());
+}

--- a/src/app/dashboard/facilities/page.tsx
+++ b/src/app/dashboard/facilities/page.tsx
@@ -36,6 +36,7 @@ import {
   Plus,
   Download,
   Mail,
+  AlertTriangle,
   Building,
   Building2,
   CreditCard,
@@ -56,6 +57,21 @@ import {
   Search,
   Loader2,
 } from "lucide-react";
+
+/**
+ * What /api/facilities/domains answers.
+ *
+ * Declared here rather than imported: `src/lib/vercel/domains.ts` is
+ * `server-only`, and this screen is a client component -- the same reason
+ * AdminFacilityRow lives in its own file. FacilityWebAddress does likewise.
+ *
+ * `configured: false` is a normal answer, not an error: a deployment with no
+ * Vercel token cannot check, and must say so instead of accusing every
+ * facility of being broken.
+ */
+type AttachedHostState =
+  | { configured: true; hosts: string[] }
+  | { configured: false; reason: string };
 
 const exportToCSV = (facilities: AdminFacilityRow[]) => {
   const headers = [
@@ -231,6 +247,38 @@ export default function FacilitiesPage() {
       },
     },
   );
+  // ── Which of these actually has a working web address ───────────────────
+  //
+  // A failed domain attach was already reported in the wizard's success screen
+  // and on each facility's Overview tab. Both are per-facility, so spotting a
+  // broken one meant opening every facility in turn -- fine at three, useless
+  // at forty. And forty is when it matters: Vercel caps domains per project, so
+  // once that ceiling is hit EVERY new facility fails, not one of them.
+  //
+  // A SECOND query rather than a field on /api/facilities, so a slow or
+  // unreachable Vercel delays a badge instead of the table. One call for the
+  // whole list, not one per row.
+  const { data: hostState } = useQuery({
+    queryKey: ["admin", "facilities", "hosts"],
+    queryFn: async (): Promise<AttachedHostState> => {
+      const response = await fetch("/api/facilities/domains");
+      if (!response.ok) throw new Error("Could not check web addresses.");
+      return (await response.json()) as AttachedHostState;
+    },
+    retry: false,
+  });
+
+  // Absent until the answer arrives, and absent for good if Vercel could not be
+  // reached. Both mean "do not claim anything" -- an unchecked facility must
+  // not be badged as broken, which would send somebody to fix what is not wrong.
+  const unattachedHost = useMemo(() => {
+    const appDomain = process.env.NEXT_PUBLIC_APP_DOMAIN;
+    if (!hostState?.configured || !appDomain) return null;
+    const attached = new Set(hostState.hosts.map((h) => h.toLowerCase()));
+    return (slug: string) =>
+      !attached.has(`${slug}.${appDomain}`.toLowerCase());
+  }, [hostState]);
+
   const [isNotifyModalOpen, setIsNotifyModalOpen] = useState(false);
   const [wizardOpen, setWizardOpen] = useState(false);
   const [notifySubject, setNotifySubject] = useState("");
@@ -362,7 +410,18 @@ export default function FacilitiesPage() {
       defaultVisible: true,
       render: (facility) => (
         <div className="flex flex-col">
-          <span className="font-medium">{facility.name}</span>
+          <span className="flex items-center gap-1.5 font-medium">
+            {facility.name}
+            {unattachedHost?.(facility.slug) && (
+              <span
+                className="flex items-center gap-1 text-xs font-normal text-amber-600"
+                title={`${facility.slug}.${process.env.NEXT_PUBLIC_APP_DOMAIN} is not attached, so this facility's own login page does not open. Fix it from their Overview tab.`}
+              >
+                <AlertTriangle className="size-3.5 shrink-0" />
+                no web address
+              </span>
+            )}
+          </span>
           <span className="text-muted-foreground text-xs">
             {facility.locationsList[0]?.address || "No address"}
           </span>

--- a/src/lib/vercel/domains.ts
+++ b/src/lib/vercel/domains.ts
@@ -262,3 +262,114 @@ export async function facilityDomainStatus(
     };
   }
 }
+
+/**
+ * Every host attached to the project, in ONE call.
+ *
+ * `facilityDomainStatus` answers for a single facility and is right for the
+ * detail screen. The facilities LIST needs the same answer for every row, and
+ * asking per row would be one Vercel round trip per facility — forty-odd calls
+ * to render a table, against a documented rate limit of 500/minute. This asks
+ * once and lets the caller compare.
+ *
+ * ── WHY THE LIST NEEDS THIS AT ALL ────────────────────────────────────────
+ *
+ * A failed attach was already loud in the two places it happens — the wizard's
+ * success screen and the facility's Overview tab. Both are per-facility, so
+ * finding a broken one meant opening every facility in turn. That is fine at
+ * three and useless at forty, and forty is exactly when it matters: the Vercel
+ * plan caps domains per project (50 on Hobby), so the failures do not arrive
+ * one at a time — every facility created after the ceiling fails, and the first
+ * anyone hears of it is the business asking why their address is dead.
+ *
+ * Paginated deliberately. The cap is 50 on Hobby but unlimited on Pro, so a
+ * single page is an assumption with a expiry date on it.
+ */
+export type AttachedHosts =
+  | { configured: true; hosts: string[] }
+  | { configured: false; reason: string };
+
+export async function attachedProjectHosts(): Promise<AttachedHosts> {
+  const config = configure();
+  if ("reason" in config) return { configured: false, reason: config.reason };
+
+  // A Set, because a cursor that repeats a page would otherwise inflate the
+  // list with duplicates and hide that anything went wrong.
+  const hosts = new Set<string>();
+  let since: string | undefined;
+  let complete = false;
+
+  try {
+    // Bounded rather than `while (true)`: a malformed pagination cursor that
+    // never advances would otherwise spin against Vercel until the request
+    // times out. 20 pages of 100 is 2,000 hosts — far past the Pro soft limit
+    // anyone here will reach, and it fails visibly rather than hanging.
+    for (let page = 0; page < 20; page += 1) {
+      const query = `&limit=100${since ? `&until=${encodeURIComponent(since)}` : ""}`;
+      const response = await fetch(
+        url(
+          config,
+          `/v9/projects/${encodeURIComponent(config.projectId)}/domains?production=true`,
+        ) + query,
+        { headers: { Authorization: `Bearer ${config.token}` } },
+      );
+
+      const body = (await response.json().catch(() => null)) as {
+        domains?: { name?: string }[];
+        pagination?: { next?: number | null };
+        error?: { message?: string };
+      } | null;
+
+      if (!response.ok) {
+        return {
+          configured: false,
+          reason:
+            body?.error?.message ?? `Vercel answered HTTP ${response.status}.`,
+        };
+      }
+
+      // An OK response whose shape we do not recognise must NOT be read as
+      // "no domains are attached". That answer is indistinguishable from a
+      // real empty project, and the caller badges every facility it cannot
+      // find as broken -- so a change at Vercel's end would send a superadmin
+      // chasing forty problems that do not exist. Unknown shape is unknown.
+      if (!Array.isArray(body?.domains)) {
+        return {
+          configured: false,
+          reason: "Vercel returned an unrecognised response.",
+        };
+      }
+
+      for (const domain of body.domains) {
+        if (domain.name) hosts.add(domain.name.toLowerCase());
+      }
+
+      const next = body?.pagination?.next;
+      if (next === null || next === undefined) {
+        complete = true;
+        break;
+      }
+      since = String(next);
+    }
+
+    // Falling out of the loop instead of breaking means the cursor never
+    // reached the end -- too many domains, or a cursor that does not advance.
+    // Either way the list is PARTIAL, and a partial list is the one thing the
+    // caller must never treat as complete: every host missing from it gets
+    // badged as having no web address.
+    if (!complete) {
+      return {
+        configured: false,
+        reason: "Too many domains to list in one pass.",
+      };
+    }
+
+    return { configured: true, hosts: [...hosts] };
+  } catch (error) {
+    return {
+      configured: false,
+      reason:
+        error instanceof Error ? error.message : "Could not reach Vercel.",
+    };
+  }
+}


### PR DESCRIPTION
## What already existed

A failed domain attach was **already** reported in both places it happens:

- the onboarding wizard's success screen — amber warning with the reason and where to fix it
- the facility's **Overview** tab — `FacilityWebAddress` asks Vercel live and offers an **"Attach it now"** button

Neither of those is the gap, and I'm not touching them.

## The actual gap

Both are **per-facility**, so finding a broken one means opening every facility in turn. Fine at three; useless at forty — and forty is exactly when it matters.

Vercel caps domains per project (**50** on the current plan). Once that ceiling is hit, *every* new facility fails rather than one. And `attachFacilityDomain` is deliberately non-fatal — correct, since a committed facility shouldn't be rolled back because Vercel hiccuped — so the facility is created, a `console.error` is written, and **the first anyone hears of it is the business asking why their address is dead.**

So the list now badges any facility whose host isn't attached.

## Design

`attachedProjectHosts()` asks Vercel **once for the whole project** rather than once per row. Forty round trips to render a table, against a documented 500/min limit, is not a table.

It's a **second query**, not a field on `/api/facilities`, so a slow or unreachable Vercel delays a badge instead of the table.

## Every failure reports itself

This is the part that mattered most. "No domains found" is indistinguishable from a real empty project — so any unhandled failure would badge **all** forty facilities as broken and send someone chasing problems that don't exist. Each path returns `configured: false` instead:

| condition | result |
|---|---|
| unrecognised response shape | `configured: false` |
| HTTP error | `configured: false` + Vercel's message |
| pagination that never terminates | `configured: false` — "too many to list" |
| no token (local dev, previews) | `configured: false`, badge stays off |

## Verification

Exercised against a stubbed Vercel:

```
two pages                calls=2    {"configured":true,"hosts":["a.yipyy.com","b.yipyy.com"]}
unknown shape            calls=1    {"configured":false,"reason":"Vercel returned an unrecognised response."}
http error               calls=1    {"configured":false,"reason":"Forbidden"}
cursor never advances    calls=20   {"configured":false,"reason":"Too many domains to list in one pass."}
no token                 calls=0    {"configured":false,"reason":"DOMAINS_API_TOKEN is not set."}
```

Follows the cursor across pages, lowercases and de-duplicates hosts, and terminates at a bound instead of spinning. Response shape and pagination semantics checked against Vercel's published OpenAPI reference rather than assumed (`{domains, pagination:{next}}`, `next` is a timestamp for `until`, `limit` max 100).

Route returns 401 anonymous / 403 non-platform-admin. `typecheck` / `lint` / `format:check` / `build` green.