### PR TITLE
fix(branding): a facility can set a wordmark, and it is actually drawn

### DIFF
--- a/src/components/auth/FacilityAuthBrand.tsx
+++ b/src/components/auth/FacilityAuthBrand.tsx
@@ -14,6 +14,23 @@ import type { FacilityBranding } from "@/lib/api/facility-branding";
 // 500 from the image optimiser, not a missing picture. The optimiser buys
 // little on a single small logo above the fold.
 //
+// ── WORDMARK FIRST, THEN LOGO, THEN THE NAME ──────────────────────────────
+//
+// Three states, in the order a facility grows into them.
+//
+// The wordmark wins where there is one because this slot is WIDE AND SHORT --
+// it is the header of a 28rem card. A square logo constrained to h-12 either
+// shrinks to a thumbnail or crowds the title, while a wordmark is drawn for
+// exactly this shape. Facilities with a single mark upload it as the logo and
+// never think about this.
+//
+// `wordmark_url` was reachable by NOBODY until 2026-08-18: the column, the API
+// and facility_branding_by_slug had supported it since 20260807240000, but the
+// settings screen posted a hardcoded "" for it on every save -- so it could not
+// be set, and any unrelated save would have cleared it. Nothing rendered it
+// either. Both ends fixed together; a field that can be stored and not shown is
+// the same bug as one that can be shown and not stored.
+//
 // ── THE NAME IS THE FALLBACK, NOT A BROKEN IMAGE ──────────────────────────
 //
 // A facility that has not uploaded a logo yet is the normal state on the day it
@@ -26,13 +43,20 @@ export function FacilityAuthBrand({
 }: {
   branding: FacilityBranding;
 }) {
-  if (branding.logoUrl) {
+  const mark = branding.wordmarkUrl ?? branding.logoUrl;
+
+  if (mark) {
     return (
       // eslint-disable-next-line @next/next/no-img-element -- see the note above
       <img
-        src={branding.logoUrl}
+        src={mark}
+        // The facility's NAME, not "logo" or "wordmark". A screen reader should
+        // announce whose sign-in page this is; which asset happened to be
+        // uploaded is not information anyone needs.
         alt={branding.name}
-        className="h-12 w-auto object-contain"
+        // max-w-full so a wide wordmark scales down inside the card instead of
+        // overflowing it -- the height cap alone does not constrain width.
+        className="h-12 w-auto max-w-full object-contain"
       />
     );
   }

--- a/src/components/facility/BrandingSettings.tsx
+++ b/src/components/facility/BrandingSettings.tsx
@@ -44,6 +44,7 @@ interface Branding {
   facilityId: string;
   facilityName: string;
   logoUrl: string | null;
+  wordmarkUrl: string | null;
   primaryColor: string | null;
   accentColor: string | null;
   tagline: string | null;
@@ -57,6 +58,7 @@ export function BrandingSettings() {
   const queryClient = useQueryClient();
   const supabase = useWorkosSupabaseClient();
   const fileInput = useRef<HTMLInputElement>(null);
+  const wordmarkInput = useRef<HTMLInputElement>(null);
 
   const [draft, setDraft] = useState<Partial<Branding>>({});
   const [uploadError, setUploadError] = useState<string | null>(null);
@@ -82,7 +84,11 @@ export function BrandingSettings() {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           logoUrl: value("logoUrl") ?? "",
-          wordmarkUrl: "",
+          // Was the literal "". The API, the column and
+          // facility_branding_by_slug had all supported a wordmark since
+          // 20260807240000, and this one line meant no facility could ever set
+          // one -- and that every unrelated save silently cleared it.
+          wordmarkUrl: value("wordmarkUrl") ?? "",
           primaryColor: value("primaryColor") ?? "",
           accentColor: value("accentColor") ?? "",
           tagline: value("tagline") ?? "",
@@ -102,7 +108,13 @@ export function BrandingSettings() {
     },
   });
 
-  async function onPickLogo(file: File) {
+  /**
+   * One uploader for both marks.
+   *
+   * `kind` is the FIELD, and it also names the stored object, so a logo and a
+   * wordmark cannot overwrite one another in the bucket.
+   */
+  async function onPickImage(kind: "logoUrl" | "wordmarkUrl", file: File) {
     setUploadError(null);
     if (!data?.facilityId) return;
 
@@ -110,7 +122,7 @@ export function BrandingSettings() {
     // side, which is the enforcement — this is only so the person is not told
     // "row-level security" when they picked a 5 MB TIFF.
     if (file.size > 2 * 1024 * 1024) {
-      setUploadError("That file is over 2 MB. Try a smaller logo.");
+      setUploadError("That file is over 2 MB. Try a smaller image.");
       return;
     }
     if (!["image/png", "image/jpeg", "image/webp"].includes(file.type)) {
@@ -121,7 +133,7 @@ export function BrandingSettings() {
     // {facility_id}/... — the first segment IS the tenancy boundary the storage
     // policies key on, so this is not merely tidy.
     const extension = file.name.split(".").pop()?.toLowerCase() ?? "png";
-    const path = `${data.facilityId}/logo-${Date.now()}.${extension}`;
+    const path = `${data.facilityId}/${kind === "wordmarkUrl" ? "wordmark" : "logo"}-${Date.now()}.${extension}`;
 
     const { error } = await supabase.storage
       .from("facility-logos")
@@ -136,7 +148,7 @@ export function BrandingSettings() {
       .from("facility-logos")
       .getPublicUrl(path);
 
-    setDraft((previous) => ({ ...previous, logoUrl: published.publicUrl }));
+    setDraft((previous) => ({ ...previous, [kind]: published.publicUrl }));
   }
 
   const dirty = Object.keys(draft).length > 0;
@@ -194,7 +206,7 @@ export function BrandingSettings() {
                     className="hidden"
                     onChange={(e) => {
                       const file = e.target.files?.[0];
-                      if (file) void onPickLogo(file);
+                      if (file) void onPickImage("logoUrl", file);
                       e.target.value = "";
                     }}
                   />
@@ -207,6 +219,54 @@ export function BrandingSettings() {
                       {uploadError}
                     </p>
                   )}
+                </div>
+
+                {/* ── Wordmark ─────────────────────────────────────────────
+                    A SECOND mark, not a duplicate of the logo. The login card
+                    header is wide and short, which is the shape a wordmark is
+                    drawn for; a square logo either shrinks to nothing or eats
+                    the card. Facilities that only have one mark upload it as
+                    the logo and never come here. */}
+                <div className="space-y-2">
+                  <Label>Wordmark</Label>
+                  <div className="flex items-center gap-3">
+                    <Button
+                      type="button"
+                      variant="outline"
+                      onClick={() => wordmarkInput.current?.click()}
+                    >
+                      <Upload className="mr-2 size-4" />
+                      {value("wordmarkUrl")
+                        ? "Replace wordmark"
+                        : "Upload wordmark"}
+                    </Button>
+                    {value("wordmarkUrl") && (
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        onClick={() =>
+                          setDraft((p) => ({ ...p, wordmarkUrl: null }))
+                        }
+                      >
+                        Remove
+                      </Button>
+                    )}
+                  </div>
+                  <input
+                    ref={wordmarkInput}
+                    type="file"
+                    accept="image/png,image/jpeg,image/webp"
+                    className="hidden"
+                    onChange={(e) => {
+                      const file = e.target.files?.[0];
+                      if (file) void onPickImage("wordmarkUrl", file);
+                      e.target.value = "";
+                    }}
+                  />
+                  <p className="text-muted-foreground text-xs">
+                    Optional. Your name drawn as an image, for the top of your
+                    sign-in page. Used there in preference to the logo.
+                  </p>
                 </div>
 
                 <div className="space-y-2">
@@ -297,16 +357,23 @@ export function BrandingSettings() {
                 <div className="bg-muted/40 flex items-center justify-center rounded-xl border p-6">
                   <div className="bg-card w-full max-w-xs rounded-2xl border p-6 shadow-sm">
                     <div className="mb-4 flex justify-center">
-                      {value("logoUrl") ? (
+                      {/* Wordmark before logo, the SAME precedence
+                          FacilityAuthBrand uses. This preview exists so what
+                          is approved here is what customers get -- showing the
+                          logo while the real page shows the wordmark would make
+                          it a picture of a different screen. */}
+                      {(value("wordmarkUrl") ?? value("logoUrl")) ? (
                         // A user-supplied Storage URL. next/image would need
                         // that host in remotePatterns at BUILD time, so a
                         // facility on a different bucket or CDN would break the
                         // preview with a 500 from the optimiser.
                         // eslint-disable-next-line @next/next/no-img-element
                         <img
-                          src={value("logoUrl") as string}
+                          src={
+                            (value("wordmarkUrl") ?? value("logoUrl")) as string
+                          }
                           alt=""
-                          className="h-12 w-auto object-contain"
+                          className="h-12 w-auto max-w-full object-contain"
                         />
                       ) : (
                         <span


### PR DESCRIPTION
## The bug

`wordmark_url` has been reachable by **nobody** since migration `20260807240000`:

| layer | state |
|---|---|
| `facility_branding.wordmark_url` column | exists |
| `/api/facility/branding` validate + write | works |
| `facility_branding_by_slug()` | returns it |
| **Settings screen** | posts a hardcoded `wordmarkUrl: ""` on every save |
| **Auth screens** | never rendered it |

So it could not be set — and any *unrelated* save (changing a colour, a tagline) would have silently cleared it. A field that can be stored and never shown is the same bug as one that can be shown and never stored, so both ends are fixed together.

## Why a wordmark at all, rather than just the logo

The brand slot is the header of a 28rem card — **wide and short**. A square logo capped at `h-12` either shrinks to a thumbnail or crowds the title; a wordmark is drawn for exactly that shape.

`FacilityAuthBrand` now resolves **wordmark → logo → the name**, which is the order a facility grows into them. A facility with a single mark uploads it as the logo and never opens this.

## The preview had to match

`BrandingSettings`' own header comment says the point of the preview is that *"what they approve is what their customers get."* Showing the logo there while the login page showed the wordmark would have made it a picture of a different screen — so the preview uses the same precedence.

## Verification

Against a production build, branding set on the demo facility and its host requested directly:

```
both set        <img src=".../wordmark.png" alt="Yipyy Demo Facility" class="h-12 w-auto max-w-full …">
wordmark removed <img src=".../logo.png"     alt="Yipyy Demo Facility" …>
neither          <span class="text-2xl font-bold tracking-tight">Yipyy Demo Facility</span>
```

Tagline rendered too (*"Where good dogs go."*). **Test rows deleted afterwards** — all three facilities are back to having no branding row.

## Details worth noting

- `max-w-full` added: the `h-12` cap does not constrain width, so a wide wordmark would overflow the card.
- `alt` is the facility's **name**, not "logo" — which asset happened to be uploaded isn't something a screen reader user needs to hear.
- Upload path generalised to one handler; the stored object is named per kind so a logo and wordmark can't overwrite each other in the bucket.

`typecheck` / `lint` / `format:check` / `build` green.