### PR TITLE
feat(auth): a facility's door is theirs, and a returning customer is told why

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -20,8 +20,8 @@
     "signUp": {
       "title": "Create your account",
       "description": "One account for booking, your pets and your visits.",
-      "descriptionJoin": "Create your Yipyy account, then join {name}.",
-      "descriptionNoSelfSignup": "Create your Yipyy account. {name} adds customers themselves — we'll find your record afterwards.",
+      "descriptionJoin": "Create your account, then join {name}.",
+      "descriptionNoSelfSignup": "Create your account. {name} adds customers themselves — we'll find your record afterwards.",
       "haveAccount": "Already have an account?",
       "signInLink": "Sign in"
     },
@@ -60,13 +60,17 @@
       "forgotPassword": "Forgot password?",
       "continueWith": "Continue with {provider}",
       "redirecting": "Redirecting…",
-      "or": "or"
+      "or": "or",
+      "goToSignIn": "Sign in instead"
     },
     "notices": {
       "codeSent": "We've sent a verification code to {email}.",
       "enterEmailFirst": "Enter your email first, then choose Forgot password.",
       "resetSent": "If that address has an account, we've emailed a link to reset the password.",
-      "resetOpenLink": "Open the link in that email to choose a new password. You can close this page."
+      "resetOpenLink": "Open the link in that email to choose a new password. You can close this page.",
+      "alreadyHaveAccount": "You already have an account",
+      "alreadyHaveAccountAt": "That email already has an account, and the same password works here. Sign in and you can join {name}.",
+      "alreadyHaveAccountPlain": "That email already has an account. Sign in with it and you're straight in."
     },
     "callbackErrors": {
       "state": "That sign-in could not be verified. Please try again from this page.",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -20,8 +20,8 @@
     "signUp": {
       "title": "Créez votre compte",
       "description": "Un seul compte pour vos réservations, vos animaux et vos visites.",
-      "descriptionJoin": "Créez votre compte Yipyy, puis rejoignez {name}.",
-      "descriptionNoSelfSignup": "Créez votre compte Yipyy. {name} ajoute ses clients elle-même — nous retrouverons votre dossier ensuite.",
+      "descriptionJoin": "Créez votre compte, puis rejoignez {name}.",
+      "descriptionNoSelfSignup": "Créez votre compte. {name} ajoute ses clients elle-même — nous retrouverons votre dossier ensuite.",
       "haveAccount": "Vous avez déjà un compte ?",
       "signInLink": "Se connecter"
     },
@@ -60,13 +60,17 @@
       "forgotPassword": "Mot de passe oublié ?",
       "continueWith": "Continuer avec {provider}",
       "redirecting": "Redirection…",
-      "or": "ou"
+      "or": "ou",
+      "goToSignIn": "Se connecter"
     },
     "notices": {
       "codeSent": "Nous avons envoyé un code de vérification à {email}.",
       "enterEmailFirst": "Saisissez d'abord votre e-mail, puis choisissez Mot de passe oublié.",
       "resetSent": "Si un compte existe pour cette adresse, nous y avons envoyé un lien de réinitialisation.",
-      "resetOpenLink": "Ouvrez le lien dans cet e-mail pour choisir un nouveau mot de passe. Vous pouvez fermer cette page."
+      "resetOpenLink": "Ouvrez le lien dans cet e-mail pour choisir un nouveau mot de passe. Vous pouvez fermer cette page.",
+      "alreadyHaveAccount": "Vous avez déjà un compte",
+      "alreadyHaveAccountAt": "Cette adresse a déjà un compte, et le même mot de passe fonctionne ici. Connectez-vous et vous pourrez rejoindre {name}.",
+      "alreadyHaveAccountPlain": "Cette adresse a déjà un compte. Connectez-vous et vous y êtes."
     },
     "callbackErrors": {
       "state": "Cette connexion n'a pas pu être vérifiée. Réessayez depuis cette page.",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import { AuthKitProvider } from "@workos-inc/authkit-nextjs/components";
 import type { Metadata } from "next";
 import { getLocale } from "next-intl/server";
+import { headers } from "next/headers";
 import { Inter, Plus_Jakarta_Sans } from "next/font/google";
 import { Toaster } from "sonner";
 import { QueryProvider } from "@/lib/query-provider";
@@ -37,6 +38,21 @@ export default async function RootLayout({
   // and the dictionary a browser spell-checks and offers to translate with, so
   // a French page announced as English is read aloud with English phonetics.
   const locale = await getLocale();
+
+  // ── WHOSE SITE THIS IS ──────────────────────────────────────────────────
+  //
+  // `x-facility-slug` is stamped by proxy.ts from the Host header, so on
+  // pawradise.yipyy.com this footer is standing at the bottom of a business's
+  // OWN page. Claiming "© Yipyy. All rights reserved." there reads as the wrong
+  // company's site; "Powered by Yipyy" is what the page actually is.
+  //
+  // The SLUG only, never a database read. This layout wraps all 266 routes, and
+  // a query here would put one on every request to serve a line of footer text.
+  // The facility's real name is already the largest thing on the auth card.
+  //
+  // Free, as it happens: reading cookies for the locale above already opted
+  // every route out of static rendering, so this header read costs nothing.
+  const onFacilityHost = Boolean((await headers()).get("x-facility-slug"));
 
   return (
     <html
@@ -140,7 +156,9 @@ export default async function RootLayout({
                 page. Extra bottom padding on phones clears the facility mobile
                 bottom-nav (fixed, md:hidden); removed at md where no nav exists. */}
             <footer className="bg-background text-muted-foreground flex items-center justify-center border-t px-4 py-4 pb-20 text-xs md:pb-4">
-              © 2026 Yipyy. All rights reserved.
+              {onFacilityHost
+                ? "Powered by Yipyy"
+                : "© 2026 Yipyy. All rights reserved."}
             </footer>
           </div>
           <Toaster />

--- a/src/app/sign-in/[[...sign-in]]/page.tsx
+++ b/src/app/sign-in/[[...sign-in]]/page.tsx
@@ -16,6 +16,11 @@ export async function generateMetadata(): Promise<Metadata> {
   const t = await getTranslations("auth.meta");
   return {
     title: branding ? t("signInBranded", { name: branding.name }) : t("signIn"),
+    // The browser tab is part of the branding too. A facility whose page says
+    // their name under Yipyy's paw icon is still half somebody else's site.
+    // Only when they HAVE a mark -- the root layout's icon stays the fallback,
+    // because a missing favicon is worse than a generic one.
+    ...(branding?.logoUrl ? { icons: { icon: branding.logoUrl } } : {}),
   };
 }
 

--- a/src/app/sign-up/[[...sign-up]]/page.tsx
+++ b/src/app/sign-up/[[...sign-up]]/page.tsx
@@ -16,6 +16,11 @@ export async function generateMetadata(): Promise<Metadata> {
   const t = await getTranslations("auth.meta");
   return {
     title: branding ? t("signUpBranded", { name: branding.name }) : t("signUp"),
+    // The browser tab is part of the branding too. A facility whose page says
+    // their name under Yipyy's paw icon is still half somebody else's site.
+    // Only when they HAVE a mark -- the root layout's icon stays the fallback,
+    // because a missing favicon is worse than a generic one.
+    ...(branding?.logoUrl ? { icons: { icon: branding.logoUrl } } : {}),
   };
 }
 
@@ -78,7 +83,7 @@ export default async function SignUpPage() {
         </p>
       }
     >
-      <EmailSignUpForm />
+      <EmailSignUpForm facilityName={branding?.name} />
 
       <div className="flex items-center gap-3">
         <span className="bg-border h-px flex-1" />

--- a/src/components/auth/EmailSignInForm.tsx
+++ b/src/components/auth/EmailSignInForm.tsx
@@ -83,7 +83,10 @@ export function EmailSignInForm() {
     : null;
 
   const [step, setStep] = useState<Step>("credentials");
-  const [email, setEmail] = useState("");
+  // Prefilled when the sign-up form sent them here for already having an
+  // account. Retyping the address they just typed would make "sign in instead"
+  // feel like starting over rather than continuing.
+  const [email, setEmail] = useState(searchParams.get("email") ?? "");
   const [password, setPassword] = useState("");
   const [code, setCode] = useState("");
   const [pending, startTransition] = useTransition();

--- a/src/components/auth/EmailSignUpForm.tsx
+++ b/src/components/auth/EmailSignUpForm.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useTranslations } from "next-intl";
+import Link from "next/link";
 import { useState, useTransition } from "react";
 
 import { Button } from "@/components/ui/button";
@@ -37,9 +38,18 @@ import { signUpWithPassword, verifyEmailCode } from "@/lib/auth/workos-actions";
 // cannot drift apart — both arrive at the same verify step below.
 // ============================================================================
 
-type Step = "details" | "verify";
+type Step = "details" | "verify" | "already-exists";
 
-export function EmailSignUpForm() {
+export function EmailSignUpForm({
+  facilityName,
+}: {
+  /**
+   * The facility whose door this is, when there is one. It only changes the
+   * WORDING of the "you already have an account" answer -- the account itself
+   * is the same one everywhere, which is the whole point being explained.
+   */
+  facilityName?: string;
+}) {
   const t = useTranslations("auth");
   const [step, setStep] = useState<Step>("details");
   const [firstName, setFirstName] = useState("");
@@ -61,6 +71,12 @@ export function EmailSignUpForm() {
         email,
         password,
       );
+      if (result?.alreadyExists) {
+        // Not an error box. This is good news badly timed -- their password
+        // already works here -- and a red alert would read as a rejection.
+        setStep("already-exists");
+        return;
+      }
       if (result?.needsVerification) {
         setNotice(t("notices.codeSent", { email: email.trim() }));
         setStep("verify");
@@ -170,6 +186,26 @@ export function EmailSignUpForm() {
             {pending ? t("actions.verifying") : t("actions.verify")}
           </Button>
         </form>
+      )}
+
+      {step === "already-exists" && (
+        <div
+          role="status"
+          className="space-y-3 rounded-md border border-sky-600/40 bg-sky-600/10 px-3 py-3 text-sm"
+        >
+          <p className="font-medium">{t("notices.alreadyHaveAccount")}</p>
+          <p className="text-muted-foreground">
+            {facilityName
+              ? t("notices.alreadyHaveAccountAt", { name: facilityName })
+              : t("notices.alreadyHaveAccountPlain")}
+          </p>
+          <Link
+            href={`/sign-in?email=${encodeURIComponent(email.trim())}`}
+            className="text-primary inline-block font-medium hover:underline"
+          >
+            {t("actions.goToSignIn")}
+          </Link>
+        </div>
       )}
 
       {message && (

--- a/src/lib/auth/workos-actions.ts
+++ b/src/lib/auth/workos-actions.ts
@@ -106,7 +106,11 @@ export async function signUpWithPassword(
   lastName: string,
   email: string,
   password: string,
-): Promise<{ error?: string; needsVerification?: boolean }> {
+): Promise<{
+  error?: string;
+  needsVerification?: boolean;
+  alreadyExists?: boolean;
+}> {
   try {
     await getWorkOS().userManagement.createUser({
       email: email.trim(),
@@ -115,6 +119,40 @@ export async function signUpWithPassword(
       lastName: lastName.trim(),
     });
   } catch (error) {
+    // ── ALREADY HAS AN ACCOUNT IS NOT A FAILURE ──────────────────────────
+    //
+    // One credential serves every facility (see the note on the sign-up
+    // screen), so the SECOND facility a person deals with is a normal, expected
+    // arrival at this form -- and the only signal they got was WorkOS's own
+    // "user already exists", with nothing to explain that their existing
+    // password already works here.
+    //
+    // That is the failure mode a facility-branded page creates: the page looks
+    // like a business they have never used, so "email already in use" reads as
+    // a mistake rather than as good news.
+    //
+    // Asked of WorkOS rather than pattern-matched on the message text, which is
+    // the vendor's wording and can change without notice.
+    //
+    // ── ON ENUMERATION, SAID PLAINLY ─────────────────────────────────────
+    //
+    // This does tell an anonymous caller whether an address has an account. It
+    // is NOT a new leak: createUser already refused a duplicate and its message
+    // was shown verbatim on this screen, so the same fact was already
+    // obtainable -- only uselessly, to the person it was actually about. Every
+    // sign-up form has this property; you cannot both create an account and
+    // hide whether one exists.
+    //
+    // sendPasswordReset is the one that must NOT do this and does not: it
+    // answers identically either way, because there the caller supplies only an
+    // address and gains nothing legitimate from the difference.
+    const existing = await getWorkOS()
+      .userManagement.listUsers({ email: email.trim() })
+      .then((page) => page.data[0])
+      .catch(() => undefined);
+
+    if (existing) return { alreadyExists: true };
+
     return { error: readableError(error, "Could not create that account.") };
   }
   // Sign in immediately, which is what triggers the verification email and


### PR DESCRIPTION
Completes #3 of the facility-portal work. A customer arriving at `doggieville-mtl.yipyy.com` now sees a business's page rather than half of Yipyy's — and when they turn out to already have an account, they're told what that means.

## The returning customer — the part that was actually broken

One credential serves every facility, so the **second** facility a person deals with is a completely normal arrival at the sign-up form. All they got was WorkOS's own *"user already exists"*, verbatim, with nothing to say their existing password already works here.

A facility-branded page makes that **worse**: the page looks like a business they've never used, so "email already in use" reads as a mistake rather than as good news. This is the trap white-labelling buys you, and it's why I wanted it solved before making the page more facility-forward.

```
BEFORE   ⛔  "User already exists"          ← red, terminal, unexplained
AFTER    ℹ️  "You already have an account"
             "That email already has an account, and the same password works
              here. Sign in and you can join Doggieville Mtl."
             → Sign in instead                ← address prefilled
```

Blue, not red — this is good news badly timed. The link carries the address so "sign in instead" *continues* rather than restarts.

Detection asks WorkOS whether the address resolves, rather than pattern-matching the error text (vendor wording, can change without notice).

**On enumeration, said plainly:** this does reveal whether an address has an account — but it's not a new leak. `createUser` already refused duplicates and its message was shown verbatim, so the same fact was already obtainable, only uselessly to the person it was about. Documented in the action, along with why `sendPasswordReset` must *not* do this and doesn't.

## Facility-forward

| | before | after (facility host only) |
|---|---|---|
| sign-up copy | "Create your **Yipyy** account, then join X" | "Create your account, then join X" |
| footer | "© 2026 Yipyy. All rights reserved." | "Powered by Yipyy" |
| tab icon | Yipyy's paw | the facility's logo, when they have one |

The two-step meaning the copy exists to carry — *create a credential, then join this business* — is intact; the vendor's name just isn't on somebody else's door. **The apex is untouched.**

The footer reads `x-facility-slug` only, no database call, because the root layout wraps all 266 routes.

## Verification

Production build, both hosts:

```
FACILITY (doggieville-mtl)
  copy:   "Create your account, then join Doggieville Mtl."
  footer: "Powered by Yipyy"

YIPYY (apex)
  copy:   "One account for booking, your pets and your visits."
  footer: "© 2026 Yipyy. All rights reserved."
```

Duplicate detection against staging WorkOS:

```
listUsers({email}) finds an existing address     YES
unknown address returns                          nothing (no false positives)
duplicate createUser                             throws, as the action expects
```

en/fr at key parity (60/60). `typecheck` / `lint` / `format:check` / `build` green.

## Noted separately

Every route in this app is now dynamic — the `○ (Static)` legend is gone from the build output. That's a side effect of my earlier i18n change (`getLocale()` in the root layout reads cookies), not this PR. It made the footer's header read free, but it wasn't a deliberate trade and it deserves its own look.