### PR TITLE
feat(onboarding): the wizard asks whether customers may register themselves

### DIFF
--- a/src/app/api/facilities/route.ts
+++ b/src/app/api/facilities/route.ts
@@ -78,6 +78,14 @@ const ProvisionInput = z.object({
   locations: z.array(z.object({ name: z.string().trim().min(1) })).default([]),
   /** Boarding, daycare, grooming… The list renders these as badges. */
   businessTypes: z.array(z.string().trim().min(1)).default([]),
+  /**
+   * Whether customers may register themselves at this facility's own address.
+   *
+   * Defaults FALSE, matching the column, so an older client that does not send
+   * it provisions exactly as before. `provision_facility` does not take it —
+   * see where it is applied below for why that is deliberate.
+   */
+  allowCustomerSignup: z.boolean().default(false),
 });
 
 /** "Pawradise Resort" → "pawradise-resort". */
@@ -256,6 +264,42 @@ export async function POST(request: NextRequest) {
     console.error(`Subdomain for "${slug}" not attached: ${domain.reason}`);
   }
 
+  // ── Whether customers may register themselves, also after the commit ──────
+  //
+  // NOT a parameter on provision_facility, deliberately. That function is one
+  // transaction over org + facility + location + staff + membership, and this
+  // is a policy switch the facility can flip any day afterwards from their own
+  // settings screen. Widening the provisioning signature for it would put a
+  // reversible preference inside the irreversible part.
+  //
+  // `set_customer_signup` is the same gated function that screen calls, so
+  // there is one writer and one permission check rather than two. A platform
+  // admin — which this route has already established — satisfies it.
+  //
+  // Only when TRUE: the column already defaults to false, so asking for the
+  // default would be a write that changes nothing and one more way to fail.
+  //
+  // Non-fatal, like the domain and the invitation above. The facility exists by
+  // now; refusing it because a switch did not flip would be the wrong trade,
+  // and the setting is one click away on their settings screen.
+  let customerSignup: { enabled: boolean; reason?: string } = {
+    enabled: false,
+  };
+  if (result?.facilityId && input.allowCustomerSignup) {
+    const { error: signupError } = await supabase.rpc("set_customer_signup", {
+      p_facility_id: result.facilityId,
+      p_enabled: true,
+    });
+    if (signupError) {
+      console.error(
+        `Customer sign-up for "${slug}" not enabled: ${signupError.message}`,
+      );
+      customerSignup = { enabled: false, reason: signupError.message };
+    } else {
+      customerSignup = { enabled: true };
+    }
+  }
+
   let invite: unknown = null;
   if (result?.facilityId && !result.replayed) {
     // link-origin-ok: this is not a link anyone sees — it is this server
@@ -290,7 +334,7 @@ export async function POST(request: NextRequest) {
   // honestly reported as "this already existed" instead of claiming to have
   // made a second facility.
   return NextResponse.json(
-    { ...result, invite, domain },
+    { ...result, invite, domain, customerSignup },
     { status: result?.replayed ? 200 : 201 },
   );
 }

--- a/src/components/admin/facility-onboarding-wizard.tsx
+++ b/src/components/admin/facility-onboarding-wizard.tsx
@@ -23,6 +23,7 @@ import { PrimaryAdminStep } from "./facility-onboarding/primary-admin-step";
 import { ReviewStep } from "./facility-onboarding/review-step";
 import {
   SuccessScreen,
+  type CustomerSignupOutcome,
   type DomainOutcome,
   type OwnerInviteOutcome,
 } from "./facility-onboarding/success-screen";
@@ -32,6 +33,7 @@ type Created = {
   slug?: string;
   invite?: OwnerInviteOutcome | null;
   domain?: DomainOutcome | null;
+  customerSignup?: CustomerSignupOutcome | null;
 };
 
 export function FacilityOnboardingWizard({
@@ -93,6 +95,7 @@ export function FacilityOnboardingWizard({
           website: draft.website,
           locations: draft.city ? [{ name: draft.city }] : [],
           businessTypes: draft.businessTypes,
+          allowCustomerSignup: draft.allowCustomerSignup,
         }),
       });
 
@@ -185,6 +188,7 @@ export function FacilityOnboardingWizard({
             ownerEmail={draft.adminEmail}
             invite={create.data?.invite ?? null}
             domain={create.data?.domain ?? null}
+            customerSignup={create.data?.customerSignup ?? null}
             onViewProfile={handleViewProfile}
             onClose={onClose}
           />

--- a/src/components/admin/facility-onboarding/operating-configuration-step.tsx
+++ b/src/components/admin/facility-onboarding/operating-configuration-step.tsx
@@ -39,6 +39,7 @@ export function OperatingConfigurationStep({
       bookingCutoff: draft.bookingCutoff,
       depositEnabled: draft.depositEnabled,
       depositPercent: draft.depositPercent,
+      allowCustomerSignup: draft.allowCustomerSignup,
     },
     validators: { onSubmit: operatingSchema },
     onSubmit: ({ value }) => onNext(value),
@@ -134,6 +135,36 @@ export function OperatingConfigurationStep({
               <Label>Booking cut-off</Label>
               <TimeField field={f} />
               <FormFieldError field={f} />
+            </div>
+          )}
+        </form.Field>
+      </div>
+
+      {/* ── Customers registering themselves ───────────────────────────────
+          This is the facility's OWN front door: <slug>.yipyy.com serves their
+          branded sign-in, and this switch decides whether a customer arriving
+          there can join, or is told the business adds customers itself.
+
+          Off by default, matching the column. It is asked here because the
+          default was previously invisible -- every facility got a working
+          address whose sign-up page turned customers away, and nobody was told.
+          Either answer is fine; not being asked is not. */}
+      <div className="rounded-xl border p-4">
+        <form.Field name="allowCustomerSignup">
+          {(field: AnyFieldApi) => (
+            <div className="flex items-center justify-between gap-3">
+              <div>
+                <Label>Customers can register themselves</Label>
+                <p className="text-muted-foreground text-xs">
+                  On their own web address. Leave this off if this business
+                  enters its customers itself &mdash; people it has already
+                  added can still claim their record.
+                </p>
+              </div>
+              <Switch
+                checked={!!field.state.value}
+                onCheckedChange={(c) => field.handleChange(c)}
+              />
             </div>
           )}
         </form.Field>

--- a/src/components/admin/facility-onboarding/review-step.tsx
+++ b/src/components/admin/facility-onboarding/review-step.tsx
@@ -160,6 +160,14 @@ export function ReviewStep({
                   : "Not required"
               }
             />
+            {/* On the review screen because it is the one setting here that
+                decides what STRANGERS see: it is the difference between the
+                facility's own address inviting customers in and telling them to
+                go away. Worth a last look before it is provisioned. */}
+            <Row
+              label="Customer self-registration"
+              value={draft.allowCustomerSignup ? "Open" : "Closed"}
+            />
           </Section>
 
           <Section title="Primary Admin Account" stepIndex={4} onEdit={onEdit}>

--- a/src/components/admin/facility-onboarding/success-screen.tsx
+++ b/src/components/admin/facility-onboarding/success-screen.tsx
@@ -32,6 +32,13 @@ export interface OwnerInviteOutcome {
 }
 
 /** What happened to `<slug>.yipyy.com` — see lib/vercel/domains.ts. */
+/** What the route reports about the self-registration switch. */
+export interface CustomerSignupOutcome {
+  enabled: boolean;
+  /** Present only when it was asked for and could not be set. */
+  reason?: string;
+}
+
 export interface DomainOutcome {
   attached?: boolean;
   host?: string | null;
@@ -44,6 +51,7 @@ export function SuccessScreen({
   ownerEmail,
   invite,
   domain,
+  customerSignup,
   onViewProfile,
   onClose,
 }: {
@@ -51,6 +59,7 @@ export function SuccessScreen({
   ownerEmail?: string;
   invite?: OwnerInviteOutcome | null;
   domain?: DomainOutcome | null;
+  customerSignup?: CustomerSignupOutcome | null;
   onViewProfile: () => void;
   onClose: () => void;
 }) {
@@ -111,6 +120,20 @@ export function SuccessScreen({
           {domain.verified
             ? "."
             : " — the certificate takes a few minutes to issue."}
+        </p>
+      )}
+
+      {/* Only when it was ASKED FOR and failed. A facility that was never meant
+          to take public registrations is not in a bad state, and saying so here
+          would train a superadmin to ignore this block. */}
+      {customerSignup?.reason && (
+        <p className="mx-auto flex max-w-md items-start gap-2 text-left text-sm text-amber-700 dark:text-amber-500">
+          <AlertTriangle className="mt-0.5 size-4 shrink-0" />
+          <span>
+            <strong>Customers cannot register themselves yet.</strong>{" "}
+            {customerSignup.reason} Turn it on from the facility&apos;s
+            settings.
+          </span>
         </p>
       )}
 

--- a/src/components/admin/facility-onboarding/wizard-config.ts
+++ b/src/components/admin/facility-onboarding/wizard-config.ts
@@ -172,6 +172,9 @@ export function createDefaultDraft(): FacilityDraft {
     checkOutTime: "18:00",
     bookingCutoff: "18:00",
     depositEnabled: false,
+    // Matches the column default. The wizard now ASKS, so this is the starting
+    // position of a visible switch rather than a silent policy.
+    allowCustomerSignup: false,
     depositPercent: "",
 
     adminFirstName: "",

--- a/src/components/admin/facility-onboarding/wizard-schemas.ts
+++ b/src/components/admin/facility-onboarding/wizard-schemas.ts
@@ -115,6 +115,7 @@ export const operatingSchema = z
     checkOutTime: z.string().min(1, "Required"),
     bookingCutoff: z.string().min(1, "Required"),
     depositEnabled: z.boolean(),
+    allowCustomerSignup: z.boolean(),
     depositPercent: z.string(),
   })
   .superRefine((val, ctx) => {

--- a/src/components/admin/facility-onboarding/wizard-types.ts
+++ b/src/components/admin/facility-onboarding/wizard-types.ts
@@ -66,6 +66,17 @@ export interface FacilityDraft {
   bookingCutoff: string;
   depositEnabled: boolean;
   depositPercent: string;
+  /**
+   * Whether customers may register themselves at this facility's own web
+   * address, i.e. `allow_customer_signup`.
+   *
+   * Asked HERE rather than left to the settings screen because the database
+   * default is false and nothing surfaced it: every facility was provisioned
+   * with a working subdomain whose sign-up page turned its customers away, and
+   * the business only found out when one of them complained. A default nobody
+   * is shown is not a decision.
+   */
+  allowCustomerSignup: boolean;
 
   // Step 5 — Primary Admin Account
   adminFirstName: string;


### PR DESCRIPTION
## The problem

`allow_customer_signup` defaults to `false`, the wizard never asked, and nothing surfaced it anywhere. So every facility was provisioned with a working branded subdomain whose sign-up page told its own customers *"this business adds customers themselves"* — and the business would find out when one of them complained.

**Both live facilities were in that state until today.** A default nobody is shown isn't a decision.

## The change

- **Asked** in Operating Configuration — a switch beside the deposit toggle
- **Shown on the review screen** as *Open* / *Closed*, because it's the one setting there that decides what **strangers** see
- **Defaults to false**, so the answer is unchanged for anyone who clicks straight through

## Why not a parameter on `provision_facility`

That function is one transaction over org, facility, location, staff row and membership grant — the irreversible part. This is a policy switch the facility can flip any day afterwards from their own settings screen. Widening the provisioning signature would put a reversible preference inside the irreversible part, and would need a migration to do it.

It's applied after the commit via `set_customer_signup` — the **same gated function** the facility's own settings screen calls, so there's one writer and one permission check rather than two. The route already holds the caller's session, so the platform-admin arm of that check is satisfied (verified: same `createServerClient()` that `provision_facility` is called with).

Only sent when **true** — the column already defaults to false, so writing the default would be a no-op write and one more thing that can fail.

## Failure handling

Non-fatal, like the subdomain attach and owner invitation beside it: the facility exists by then, and refusing it because a switch didn't flip is the wrong trade.

But a **failed flip is reported on the success screen**, because the alternative is a superadmin who asked for an open door, was told the facility was ready, and got a closed one. The warning only renders when it was *asked for* and failed — a facility deliberately left closed isn't in a bad state, and warning about it would train people to ignore the block.

## Compatibility

The API schema defaults `allowCustomerSignup` to `false`, so an older client that doesn't send the field provisions exactly as before.

`typecheck` / `lint` / `format:check` / `build` green.