### PR TITLE
feat(auth): you sign up at a facility, not at Yipyy

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -19,11 +19,14 @@
     },
     "signUp": {
       "title": "Create your account",
-      "description": "One account for booking, your pets and your visits.",
       "descriptionJoin": "Create your account, then join {name}.",
       "descriptionNoSelfSignup": "Create your account. {name} adds customers themselves — we'll find your record afterwards.",
       "haveAccount": "Already have an account?",
-      "signInLink": "Sign in"
+      "signInLink": "Sign in",
+      "noFacilityTitle": "Sign up at your facility",
+      "noFacilityDescription": "Each business on Yipyy has its own web address.",
+      "noFacilityBody": "Open the address your groomer, daycare or boarding kennel gave you — it looks like theirname.yipyy.com — and create your account there. It works at every Yipyy business afterwards.",
+      "noFacilitySignIn": "Already have an account? Sign in"
     },
     "reset": {
       "title": "Choose a new password",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -19,11 +19,14 @@
     },
     "signUp": {
       "title": "Créez votre compte",
-      "description": "Un seul compte pour vos réservations, vos animaux et vos visites.",
       "descriptionJoin": "Créez votre compte, puis rejoignez {name}.",
       "descriptionNoSelfSignup": "Créez votre compte. {name} ajoute ses clients elle-même — nous retrouverons votre dossier ensuite.",
       "haveAccount": "Vous avez déjà un compte ?",
-      "signInLink": "Se connecter"
+      "signInLink": "Se connecter",
+      "noFacilityTitle": "Créez votre compte chez votre établissement",
+      "noFacilityDescription": "Chaque établissement sur Yipyy a sa propre adresse web.",
+      "noFacilityBody": "Ouvrez l'adresse que votre toiletteur, garderie ou pension vous a donnée — elle ressemble à leurnom.yipyy.com — et créez-y votre compte. Il fonctionnera ensuite chez tous les établissements Yipyy.",
+      "noFacilitySignIn": "Vous avez déjà un compte ? Connectez-vous"
     },
     "reset": {
       "title": "Choisissez un nouveau mot de passe",

--- a/src/app/sign-up/[[...sign-up]]/page.tsx
+++ b/src/app/sign-up/[[...sign-up]]/page.tsx
@@ -59,18 +59,67 @@ export default async function SignUpPage() {
   const branding = slug ? await getBrandingBySlug(slug) : null;
   const t = await getTranslations("auth");
 
-  const description = !branding
-    ? t("signUp.description")
-    : branding.allowCustomerSignup
-      ? t("signUp.descriptionJoin", { name: branding.name })
-      : t("signUp.descriptionNoSelfSignup", { name: branding.name });
+  // ── NO FACILITY IN THE HOSTNAME: THERE IS NOTHING TO SIGN UP FOR ─────────
+  //
+  // A Yipyy login only means something at a business. Somebody who registers
+  // on the apex gets a credential that opens nothing: every portal gate wants a
+  // membership, RLS returns no rows without one, and they are routed
+  // / -> /customer/dashboard -> /join -> "no facility here". Two people did
+  // exactly that and both hold accounts that can see nothing.
+  //
+  // Nobody legitimate arrives here either. Checked, not assumed: the facility
+  // OWNER and STAFF invitations build their link from the facility's own host
+  // (lib/public-origin.ts, which exists specifically to stop those emails
+  // pointing at the wrong door), and a PLATFORM admin is invited to
+  // /setup/<token>, not here. So this form had no user with a reason to use it.
+  //
+  // It says where to go rather than 404ing: somebody reading this is a pet
+  // owner who guessed the address, and "not found" answers a question they did
+  // not ask.
+  //
+  // WHAT THIS DOES NOT CLOSE, said plainly: OAuth does not distinguish signing
+  // in from signing up (see OAuthButton), so "Continue with Google" on the apex
+  // SIGN-IN screen still mints an account for a new address. That screen has to
+  // keep it -- it is how the platform admins actually sign in. This removes the
+  // dead end and the obvious path, not every path, and it does not need to be a
+  // hard gate: a credential on its own grants nothing.
+  if (!branding) {
+    return (
+      <AuthCard
+        signedOut
+        title={t("signUp.noFacilityTitle")}
+        description={t("signUp.noFacilityDescription")}
+        footer={
+          <p className="text-muted-foreground text-center text-sm">
+            <Link
+              href="/sign-in"
+              className="text-primary font-medium hover:underline"
+            >
+              {t("signUp.noFacilitySignIn")}
+            </Link>
+          </p>
+        }
+      >
+        <p className="text-muted-foreground text-sm">
+          {t("signUp.noFacilityBody")}
+        </p>
+      </AuthCard>
+    );
+  }
+
+  // Past the guard above, so there IS a facility. The old third arm for "no
+  // branding" is gone rather than left unreachable -- a dead branch reads as a
+  // case somebody still has to think about.
+  const description = branding.allowCustomerSignup
+    ? t("signUp.descriptionJoin", { name: branding.name })
+    : t("signUp.descriptionNoSelfSignup", { name: branding.name });
 
   return (
     <AuthCard
       signedOut
       title={t("signUp.title")}
       description={description}
-      brand={branding ? <FacilityAuthBrand branding={branding} /> : undefined}
+      brand={<FacilityAuthBrand branding={branding} />}
       footer={
         <p className="text-muted-foreground text-center text-sm">
           {t("signUp.haveAccount")}{" "}
@@ -83,7 +132,7 @@ export default async function SignUpPage() {
         </p>
       }
     >
-      <EmailSignUpForm facilityName={branding?.name} />
+      <EmailSignUpForm facilityName={branding.name} />
 
       <div className="flex items-center gap-3">
         <span className="bg-border h-px flex-1" />


### PR DESCRIPTION
## Why

A Yipyy login only means something **at a business**. Someone who registered on the apex got a credential that opens nothing — every portal gate wants a membership, RLS returns no rows without one, and they were routed `/` → `/customer/dashboard` → `/join` → *"no facility here."*

Two people did exactly that yesterday, and both hold accounts that can see nothing:

```
chihinsaf@gmail.com                    staff at 0   customer at 0
houssem.ferrani@univ-constantine2.dz   staff at 0   customer at 0
```

## Nobody legitimate used it

Checked rather than assumed:

```
facility owner  →  <facility>.yipyy.com/sign-up    lib/public-origin.ts
facility staff  →  <facility>.yipyy.com/sign-up    same
platform admin  →  www.yipyy.com/setup/<token>     a signed token, not /sign-up
```

`public-origin.ts` exists *specifically* to stop those emails pointing at the wrong door — its header records the production bug where a superadmin with a Pawradise tab open created Doggieville, and its owner was emailed a link to Pawradise's sign-up. So the apex form had no user with a reason to use it.

## What changed

The apex now says **where to go** instead of rendering a form — not a 404, because whoever reads it is a pet owner who guessed the address, and "not found" answers a question they didn't ask.

Facility hosts are untouched. That's where the form belongs and it still works there.

## What this does NOT close — stated in the code

OAuth doesn't distinguish signing in from signing up (documented in `OAuthButton`), so **"Continue with Google" on the apex sign-in screen still mints an account** for a new address. That screen has to keep it — it's how the platform admins actually sign in today (`houssemsina123@gmail.com` has no password and signs in via Google).

So this removes the dead end and the obvious path, not every path. It doesn't need to be a hard gate: a credential on its own grants nothing.

## Also

Removed the now-unreachable "no branding" arms of the `description` and `brand` props, and the orphaned `signUp.description` string from both catalogues. A dead branch reads as a case somebody still has to think about.

## Verification

Production build:

```
APEX /sign-up        title "Sign up at your facility"
                     password field  0      Google button  0

FACILITY /sign-up    password field  1
                     "Create your account, then join Doggieville Mtl."

APEX /sign-in        password field  1      Google button  1     ← unchanged
```

en/fr at parity (63 keys each). `typecheck` / `lint` / `format:check` / `build` green.