### PR TITLE
feat(auth): a facility membership is admin or staff

### DIFF
--- a/docs/quality/debt-map.md
+++ b/docs/quality/debt-map.md
@@ -1991,6 +1991,80 @@ catalogues in the same change and check key parity — nothing enforces it, and
 next-intl renders a missing key as the key itself, so a gap ships as
 `auth.fields.email` printed on the page rather than as an error.
 
+## Snapshot (2026-08-18, a job title was doing an access tier's job)
+
+### 🔴 `manage_staff` was enough to mint an owner
+
+`facility_memberships` had one `role` column doing two unrelated jobs: choosing a
+permission template (13 answers) and deciding which portal you get (2 answers).
+The insert/update policies on it are gated on the **permission** `manage_staff` —
+and a facility can grant a permission to any job title through its own role
+editor (`facility_role_permissions`), or to one person
+(`staff_permissions`, `membership_permissions`).
+
+So a receptionist given `manage_staff` — a plausible thing for a front desk that
+books and hires — could set their own `primary_role` to `owner` and resolve all
+168 permission keys. Proved against production inside an aborted transaction
+before the fix, and refused after it:
+
+```
+reception raising itself to admin   => REFUSED: Only a facility admin may grant
+                                       admin access. manage_staff is not enough.
+reception making itself an owner    => REFUSED: (same)
+reception hiring a manager          => REFUSED: Only a facility admin may hire an
+                                       admin. manage_staff is not enough.
+reception hiring a groomer          => ALLOWED, level=staff
+```
+
+**Why it mattered:** the escalation is available to anyone the facility trusts
+with hiring, and it is invisible — the promoted row looks like an ordinary
+membership.
+
+**Do instead:** `private.is_facility_admin(facility_id)` is deliberately **not**
+routed through `private.has_permission`. If admin-ness were a permission key, a
+facility could grant itself admin from its own settings screen. Gate admin-only
+things on that function, never on a permission.
+
+### 🟡 A trigger that refuses for the wrong reason still looks like it works
+
+`private.enforce_hire_access_level` fires on two tables whose job-title column is
+named differently (`staff.primary_role`, `facility_membership_grants.role`). The
+first cut chose between them with a CASE **in the DECLARE initialiser**. plpgsql
+compiles that into one SQL expression, so both field references resolve
+regardless of the branch — and every insert and update of either table raised
+`record "new" has no field "role"`.
+
+The escalation probe's "reception cannot hire a manager" assertion **passed**
+anyway, because the write did fail. It just failed with a schema error rather
+than the guard. Fixed in `20260818120000_the_hire_guard_reads_the_right_column`.
+
+**Do instead:** assert on the refusal MESSAGE, not merely that something raised.
+And branch on `tg_table_name` with `IF`, one statement per arm, never with a
+CASE over fields that do not exist on both records.
+
+### 🟡 A facility cannot be deleted at all
+
+Found while testing the cascade carve-out in
+`private.protect_last_facility_admin`. `audit_log.facility_id` is
+`ON DELETE SET NULL`, and that SET NULL is an UPDATE — which the append-only
+trigger on `audit_log` refuses:
+
+```
+delete from public.facilities where id = ...
+  => audit_log is append-only: UPDATE is not permitted on an audit entry
+```
+
+Pre-dates the access-level work and is unrelated to it, but it means
+`facilities_delete` (superadmin-only, ADR-backed) cannot succeed, and the
+"the whole facility is going away" branch of the last-admin guard is currently
+unreachable.
+
+**Do instead:** don't assume facility deletion works. Fixing it is a choice
+between `ON DELETE CASCADE` on the audit rows (destroys the record of what
+happened) and letting the trigger allow the facility_id null-out specifically —
+the second is almost certainly right, but it is a change to an immutability
+guarantee and deserves its own ADR.
+
 ## How to add to this map
 
 Append under a new dated heading. For each item: a one-line description, a severity, **why it's risky**, and **what to do instead** of casually touching it. Don't delete items — strike them through with the date and PR when genuinely resolved.

--- a/src/lib/auth/onboarding-gate.ts
+++ b/src/lib/auth/onboarding-gate.ts
@@ -9,21 +9,22 @@ import { createServerClient } from "@/lib/supabase/server";
 //
 // This exists because making the invite REAL opened a hole that did not exist
 // while it was a mock. /api/staff/[id]/invite creates a facility_memberships
-// row so the new account has a facility at all — and canAccessFacilityPortal
-// admits ANY active membership:
+// row so the new account has a facility at all — and a membership then means
+// "someone we emailed yesterday who has set a password and nothing else", not
+// "someone who works here and has finished joining". That person could open
+// /facility/dashboard.
 //
-//     viewer.source === "session" && (isPlatformAdmin || memberships.length > 0)
+// STILL TRUE AFTER ADR 0005, and worth being precise about. canAccessFacilityPortal
+// now requires ADMIN access rather than any membership, which narrows this to
+// invited admins — but that is exactly the case that reached production: the
+// owner of a newly provisioned facility, invited and not yet finished. An
+// invited groomer is now sent to /employee instead, and lands here for the same
+// reason.
 //
-// which was correct when a membership meant "someone who works here and has
-// finished joining". After this change a membership also means "someone we
-// emailed yesterday who has set a password and nothing else", and that person
-// could open /facility/dashboard.
-//
-// Not a hole in canAccessFacilityPortal — the rule there is right for what it
-// answers, and widening or narrowing it would change the answer for every
-// existing member. The missing question is a different one: has this person
-// finished joining? That is what `staff.status = 'invited'` records, and this
-// is where it gets asked.
+// Not a hole in canAccessFacilityPortal — the rule there answers "may you run
+// this business", and it answers it correctly. The missing question is a
+// different one: has this person finished joining? That is what
+// `staff.status = 'invited'` records, and this is where it gets asked.
 //
 // RLS still decides what they could actually READ if they got in — an invited
 // groomer sees a groomer's rows. This is routing, not the boundary. But routing

--- a/src/lib/auth/viewer.ts
+++ b/src/lib/auth/viewer.ts
@@ -2,7 +2,10 @@ import "server-only";
 
 import { withAuth } from "@workos-inc/authkit-nextjs";
 
-import type { FacilityStaffRole } from "@/types/facility-staff";
+import type {
+  FacilityAccessLevel,
+  FacilityStaffRole,
+} from "@/types/facility-staff";
 import { createWorkosServerClient } from "@/lib/supabase/workos-server";
 
 // ============================================================================
@@ -51,7 +54,13 @@ import { createWorkosServerClient } from "@/lib/supabase/workos-server";
 export type ViewerMembership = {
   membershipId: string;
   facilityId: string;
+  /**
+   * The JOB TITLE. Selects the permission template private.resolve_permission
+   * reads — it does NOT decide which portal you get. See ADR 0005.
+   */
   role: FacilityStaffRole;
+  /** Which portal you get. The only thing the gates below read. */
+  accessLevel: FacilityAccessLevel;
 };
 
 export type Viewer = {
@@ -109,7 +118,7 @@ async function viewerFromSession(): Promise<Viewer | null> {
       .maybeSingle(),
     supabase
       .from("facility_memberships")
-      .select("id, facility_id, role")
+      .select("id, facility_id, role, access_level")
       .eq("profile_id", userId)
       .eq("is_active", true),
   ]);
@@ -133,6 +142,9 @@ async function viewerFromSession(): Promise<Viewer | null> {
       membershipId: m.id,
       facilityId: m.facility_id,
       role: m.role as FacilityStaffRole,
+      // Absent only if this build is ahead of the migration. Defaulting to
+      // "staff" is the fail-closed answer — the same default the column has.
+      accessLevel: (m.access_level ?? "staff") as FacilityAccessLevel,
     })),
   };
 }
@@ -154,13 +166,22 @@ export function belongsToFacility(viewer: Viewer, facilityId: string): boolean {
 // portal a person lands in. That decision is here rather than in the sign-in
 // action so the gates and the action cannot disagree about it.
 
-/** Roles that run the business and get the full facility admin portal. */
-const FACILITY_ADMIN_ROLES = new Set<string>([
-  "owner",
-  "admin",
-  "manager",
-  "supervisor",
-]);
+/**
+ * Does this person run the business at any facility?
+ *
+ * Reads `accessLevel`, never the job title. The hardcoded role set that used to
+ * live here — owner/admin/manager/supervisor — is now the BACKFILL of
+ * `facility_memberships.access_level`, so this answers identically for every
+ * membership that exists today while letting a facility promote, say, its
+ * receptionist without also handing them an owner's 168 permissions.
+ *
+ * The database enforces the same split from the other side:
+ * private.is_facility_admin reads the same column, and a trigger stops anyone
+ * but an existing admin from raising it.
+ */
+function isFacilityAdmin(memberships: ViewerMembership[]): boolean {
+  return memberships.some((m) => m.accessLevel === "admin");
+}
 
 export function landingPathForClaims(
   isPlatformAdmin: boolean,
@@ -172,7 +193,7 @@ export function landingPathForClaims(
   const primary = memberships[0];
   if (!primary) return "/customer/dashboard";
 
-  if (memberships.some((m) => FACILITY_ADMIN_ROLES.has(m.role))) {
+  if (isFacilityAdmin(memberships)) {
     return "/facility/dashboard";
   }
 
@@ -210,15 +231,23 @@ export function landingPathFor(viewer: Viewer): string {
 // of defence; it is the first.
 
 /**
- * Facility portal. Any active membership admits you; platform admins are let
- * through so they can review facility and HQ features without swapping
- * identity — which is what the old cookie rule allowed too.
+ * Facility portal — the admin surface. ADR 0005 made this an ADMIN gate.
+ *
+ * It used to be byte-identical to canAccessStaffPortal: any active membership
+ * admitted you, so a groomer who typed /facility got the whole business. Only
+ * the LANDING PATH differed, which meant the admin/staff distinction was a
+ * suggestion the app made and nothing enforced.
+ *
+ * Platform admins still pass — a super admin has to be able to see a facility
+ * to support it (ADR 0005 §5).
+ *
+ * Still routing, not the boundary: RLS is what returns zero rows to a staff
+ * member who ignores the redirect. The step that makes THIS gate load-bearing
+ * is moving the admin-only tables onto private.is_facility_admin.
  */
 export function canAccessFacilityPortal(viewer: Viewer): boolean {
-  return (
-    viewer.source === "session" &&
-    (viewer.isPlatformAdmin || viewer.memberships.length > 0)
-  );
+  if (viewer.source !== "session") return false;
+  return viewer.isPlatformAdmin || isFacilityAdmin(viewer.memberships);
 }
 
 /**
@@ -283,14 +312,18 @@ export function canAccessStaffPortal(viewer: Viewer): boolean {
  * Cancelling the subscription is not a permission a facility should be able to
  * hand out through its own role editor — that would let a facility grant itself
  * authority over its own billing relationship. It is an access level, which is
- * exactly the distinction ADR 0005 draws. When `access_level` lands this body
- * becomes `m.accessLevel === "admin"` and the role set goes away.
+ * exactly the distinction ADR 0005 draws.
+ *
+ * That access level has now landed, so this reads the column rather than the
+ * role set it was written against. Same answer for every membership alive
+ * today; a different, correct one the moment a facility promotes somebody whose
+ * job title is not an admin-tier one.
  */
 export function canManageFacilityAccount(viewer: Viewer): boolean {
   if (viewer.source !== "session") return false;
   // A platform admin has to be able to see a facility's billing to support it.
   if (viewer.isPlatformAdmin) return true;
-  return viewer.memberships.some((m) => FACILITY_ADMIN_ROLES.has(m.role));
+  return isFacilityAdmin(viewer.memberships);
 }
 
 /**

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -1276,6 +1276,7 @@ export type Database = {
           facility_id: string;
           granted_by: string | null;
           id: string;
+          access_level: Database["public"]["Enums"]["facility_access_level"];
           role: Database["public"]["Enums"]["facility_staff_role"];
           staff_id: string;
         };
@@ -1288,6 +1289,7 @@ export type Database = {
           facility_id: string;
           granted_by?: string | null;
           id?: string;
+          access_level?: Database["public"]["Enums"]["facility_access_level"];
           role: Database["public"]["Enums"]["facility_staff_role"];
           staff_id: string;
         };
@@ -1300,6 +1302,7 @@ export type Database = {
           facility_id?: string;
           granted_by?: string | null;
           id?: string;
+          access_level?: Database["public"]["Enums"]["facility_access_level"];
           role?: Database["public"]["Enums"]["facility_staff_role"];
           staff_id?: string;
         };
@@ -1330,6 +1333,7 @@ export type Database = {
           is_active: boolean;
           legacy_id: string | null;
           profile_id: string;
+          access_level: Database["public"]["Enums"]["facility_access_level"];
           role: Database["public"]["Enums"]["facility_staff_role"];
           updated_at: string;
         };
@@ -1342,6 +1346,7 @@ export type Database = {
           is_active?: boolean;
           legacy_id?: string | null;
           profile_id: string;
+          access_level?: Database["public"]["Enums"]["facility_access_level"];
           role: Database["public"]["Enums"]["facility_staff_role"];
           updated_at?: string;
         };
@@ -1354,6 +1359,7 @@ export type Database = {
           is_active?: boolean;
           legacy_id?: string | null;
           profile_id?: string;
+          access_level?: Database["public"]["Enums"]["facility_access_level"];
           role?: Database["public"]["Enums"]["facility_staff_role"];
           updated_at?: string;
         };
@@ -3900,6 +3906,7 @@ export type Database = {
           legacy_id: string | null;
           membership_id: string | null;
           phone: string | null;
+          access_level: Database["public"]["Enums"]["facility_access_level"];
           primary_role: Database["public"]["Enums"]["facility_staff_role"];
           service_assignments: Database["public"]["Enums"]["service_module"][];
           show_on_calendar: boolean;
@@ -3925,6 +3932,7 @@ export type Database = {
           legacy_id?: string | null;
           membership_id?: string | null;
           phone?: string | null;
+          access_level?: Database["public"]["Enums"]["facility_access_level"];
           primary_role: Database["public"]["Enums"]["facility_staff_role"];
           service_assignments?: Database["public"]["Enums"]["service_module"][];
           show_on_calendar?: boolean;
@@ -3950,6 +3958,7 @@ export type Database = {
           legacy_id?: string | null;
           membership_id?: string | null;
           phone?: string | null;
+          access_level?: Database["public"]["Enums"]["facility_access_level"];
           primary_role?: Database["public"]["Enums"]["facility_staff_role"];
           service_assignments?: Database["public"]["Enums"]["service_module"][];
           show_on_calendar?: boolean;
@@ -4853,6 +4862,7 @@ export type Database = {
         | "no_show"
         | "cancelled"
         | "declined";
+      facility_access_level: "admin" | "staff";
       facility_staff_role:
         | "owner"
         | "admin"
@@ -5021,6 +5031,7 @@ export const Constants = {
         "cancelled",
         "declined",
       ],
+      facility_access_level: ["admin", "staff"],
       facility_staff_role: [
         "owner",
         "admin",

--- a/src/types/facility-staff.ts
+++ b/src/types/facility-staff.ts
@@ -17,6 +17,26 @@ export type FacilityStaffRole =
   | "accountant"
   | "sanitation";
 
+/**
+ * Which portal a membership gets — the ACCESS model (ADR 0005).
+ *
+ * Deliberately two values while `FacilityStaffRole` has thirteen: those thirteen
+ * are JOB TITLES that select a permission template, not access tiers. A groomer
+ * and a receptionist are both `staff` and still do not see the same screens.
+ *
+ * Mirrors the `public.facility_access_level` Postgres enum. `admin` is never
+ * the default anywhere — every path that omits it must fail closed.
+ */
+export type FacilityAccessLevel = "admin" | "staff";
+
+/** The job titles that carry admin access no matter what the column says. */
+export const ADMIN_TIER_ROLES: readonly FacilityStaffRole[] = [
+  "owner",
+  "admin",
+  "manager",
+  "supervisor",
+];
+
 export type ServiceModule =
   | "grooming"
   | "training"

--- a/supabase/migrations/20260818100000_a_membership_is_admin_or_staff.sql
+++ b/supabase/migrations/20260818100000_a_membership_is_admin_or_staff.sql
@@ -1,0 +1,503 @@
+-- ============================================================================
+-- A facility membership is admin or staff, and a job title is not an access
+-- tier.
+--
+-- ADR 0005. The product owner's model is three facility roles — Facility
+-- admin, Staff, Customer. The database had thirteen, and they were doing two
+-- unrelated jobs at once:
+--
+--   1. deciding which PORTAL you land in   (an access question, 2 answers)
+--   2. selecting a PERMISSION TEMPLATE     (a job question, 13 answers)
+--
+-- Collapsing the thirteen would have destroyed (2): the presets genuinely
+-- differ — owner 168 keys, manager 141, supervisor 82, reception 65, caretaker
+-- 45, accountant 44, groomer 36, sanitation 24 — so one Staff role with one
+-- permission set gives a sanitation worker an accountant's access, or everyone
+-- the smallest set.
+--
+-- So (1) becomes its own column and (2) keeps `role` unchanged.
+--
+-- ── WHY `role` IS NOT RENAMED ─────────────────────────────────────────────
+--
+-- private.resolve_permission joins `facility_memberships.role` by name against
+-- role_preset_permissions.role and facility_role_permissions.role. The three
+-- must stay symmetric. Its MEANING changes — job title, not access tier — and a
+-- comment says so; a rename would be a 930-row, three-table refactor to say the
+-- same thing.
+--
+-- ── THE COLUMN IS NEVER LESS THAN THE ROLE IMPLIES ────────────────────────
+--
+-- Two columns that can disagree is how you get a membership with role='owner'
+-- and access_level='staff': 168 permissions, and no admin portal to exercise
+-- them in. RLS reads permissions, the gates read access — so that row is a
+-- person who can drain the data through the API while the UI calls them staff.
+--
+-- The trigger below makes that state unrepresentable: an admin-tier job title
+-- FORCES admin access. The column may only ever be MORE permissive than the
+-- role implies (a receptionist promoted to run the business), never less. An
+-- explicit attempt to demote an owner raises rather than being silently undone,
+-- because "change their job title first" is the real answer.
+--
+-- ── THE ESCALATION THIS CLOSES, WHICH PRE-DATES IT ────────────────────────
+--
+-- memberships_insert/update are gated on `manage_staff`. That is a PERMISSION,
+-- and a facility can grant a permission to any job title through its own role
+-- editor (facility_role_permissions) or to one person (staff_permissions,
+-- membership_permissions). So today a receptionist who has been given
+-- manage_staff — a plausible thing for a front desk that books and hires — can
+-- set anybody's primary_role to 'owner' and mint 168 permissions.
+--
+-- private.is_facility_admin is deliberately NOT routed through
+-- private.has_permission for exactly this reason. If admin-ness were a
+-- permission key, a facility could grant itself admin from its own settings
+-- screen. It reads the membership column directly, which nothing but this
+-- trigger and a platform admin can raise.
+--
+-- ── AND IT DOES NOT ASK ABOUT THE SUBSCRIPTION ────────────────────────────
+--
+-- private.has_permission excludes suspended and cancelled facilities. This
+-- function must NOT, and the difference is load-bearing: the admin-only screen
+-- a suspended facility needs most is the one showing them they are suspended
+-- and letting them pay. Identity ("are you an admin here") and entitlement
+-- ("is this business current") are separate questions, and gating the first on
+-- the second locks the only person who can fix it out of the fix.
+--
+-- ── WHAT THIS MIGRATION DOES NOT DO ───────────────────────────────────────
+--
+-- It does not move any RLS policy onto is_facility_admin. Not one row changes
+-- who may read it. facility_subscriptions_read and payment_connections_read are
+-- still "any active member", which is too wide — that is the next change, kept
+-- separate so this one can be proved to alter nothing but routing.
+--
+-- Proof that the permission cascade is untouched (per membership, before):
+--   owner      9f0011c366274d2ca2ba9560926f1b05  168 granted
+--   manager    d27ca77bfdb58b85a961c4ed527f65e1  141
+--   reception  2cec40d076a5855b7c150d11cf8bb4a1   65
+--   caretaker  ed3106456f6728173186f47da784d670   45
+--   groomer    e7064586bccf0b3949cc9d30cc8342dc   36
+-- ============================================================================
+
+do $mig$
+begin
+  if not exists (select 1 from pg_type where typname = 'facility_access_level') then
+    create type public.facility_access_level as enum (
+      'admin',  -- runs the business: /facility, billing, staff, settings
+      'staff'   -- works there: /employee, scoped by permissions
+    );
+  end if;
+end $mig$;
+
+-- ── The column, on all three tables in the grant chain ─────────────────────
+--
+-- Not just memberships. "Hire this person as an admin" has to survive the trip
+-- staff -> facility_membership_grants -> facility_memberships, because the
+-- membership does not exist until they accept. A level recorded only on the
+-- membership could not be expressed at the moment somebody is hired.
+--
+-- DEFAULT 'staff', never 'admin'. Several code paths insert memberships without
+-- naming a level, and every one of them must fail closed.
+
+alter table public.facility_memberships
+  add column if not exists access_level public.facility_access_level
+    not null default 'staff';
+
+alter table public.staff
+  add column if not exists access_level public.facility_access_level
+    not null default 'staff';
+
+alter table public.facility_membership_grants
+  add column if not exists access_level public.facility_access_level
+    not null default 'staff';
+
+comment on column public.facility_memberships.access_level is
+  'Which portal this person gets: admin -> /facility, staff -> /employee. '
+  'The access model (ADR 0005). Raised only by an existing facility admin, and '
+  'forced to admin when role is an admin-tier job title.';
+
+comment on column public.facility_memberships.role is
+  'JOB TITLE, not an access tier (ADR 0005). Selects the permission template '
+  'private.resolve_permission reads. Which portal you land in is access_level. '
+  'Joined by name against role_preset_permissions and facility_role_permissions '
+  '— do not rename.';
+
+comment on column public.staff.access_level is
+  'The access level this hire will hold once they accept. Travels to the grant '
+  'and then to the membership.';
+
+comment on column public.facility_membership_grants.access_level is
+  'The access level being granted. Read from the staff row, never from a '
+  'request — the same reason the grant carries the role rather than an '
+  'invitation naming one.';
+
+-- ── Backfill ───────────────────────────────────────────────────────────────
+--
+-- Exactly the set src/lib/auth/viewer.ts already routed to /facility, so the
+-- landing path for all 9 live memberships is unchanged by this migration. That
+-- is the point: the column starts out describing what is already true.
+--
+-- supervisor is included because ADR 0005 §3 says so and because it is what the
+-- code did. Worth knowing that its preset holds neither manage_staff nor
+-- settings_general (82 of 168 keys), so a supervisor reaches the admin portal
+-- and finds much of it refuses them. No production membership is a supervisor.
+-- Recorded rather than silently corrected — narrowing it is a product decision.
+
+update public.facility_memberships
+   set access_level = 'admin'
+ where role in ('owner','admin','manager','supervisor')
+   and access_level <> 'admin';
+
+update public.staff
+   set access_level = 'admin'
+ where primary_role in ('owner','admin','manager','supervisor')
+   and access_level <> 'admin';
+
+update public.facility_membership_grants
+   set access_level = 'admin'
+ where role in ('owner','admin','manager','supervisor')
+   and access_level <> 'admin';
+
+-- ── The question every admin-only gate should ask ──────────────────────────
+
+create or replace function private.is_facility_admin(p_facility_id uuid)
+returns boolean
+language sql
+stable
+security definer
+set search_path to ''
+as $fn$
+  select private.is_platform_admin() or exists (
+    select 1
+      from public.facility_memberships m
+     where m.profile_id   = (select auth.jwt()->>'sub')
+       and m.facility_id  = p_facility_id
+       and m.is_active
+       and m.access_level = 'admin'::public.facility_access_level
+  );
+$fn$;
+
+-- Callable by `authenticated` for the same reason has_platform_role is: an RLS
+-- policy expression runs as the CURRENT user, so a policy calling a function
+-- the caller may not execute FAILS rather than returning false. It leaks
+-- nothing — it reads the caller's own sub, so it can only answer about them.
+revoke execute on function private.is_facility_admin(uuid) from public, anon;
+grant  execute on function private.is_facility_admin(uuid) to authenticated;
+
+-- ── Normalisation + the escalation guard, in one BEFORE trigger ────────────
+--
+-- One trigger and not two, because the order matters: a role change to 'owner'
+-- IS a request for admin access, so normalisation has to run first and the
+-- escalation check has to see its result. Two triggers would let the raise
+-- depend on alphabetical firing order.
+
+create or replace function private.enforce_membership_access_level()
+returns trigger
+language plpgsql
+security definer
+set search_path to ''
+as $fn$
+declare
+  v_sub      text := (select auth.jwt()->>'sub');
+  v_becoming boolean;
+begin
+  -- Step 1 — an admin-tier job title forces admin access.
+  if new.role in ('owner','admin','manager','supervisor') then
+    if tg_op = 'UPDATE'
+       and old.access_level = 'admin'::public.facility_access_level
+       and new.access_level <> 'admin'::public.facility_access_level then
+      raise exception
+        'A % keeps admin access. Change their job title first, then their access.',
+        new.role
+        using errcode = '42501';
+    end if;
+    new.access_level := 'admin'::public.facility_access_level;
+  end if;
+
+  v_becoming := new.access_level = 'admin'::public.facility_access_level
+                and (tg_op = 'INSERT'
+                     or old.access_level is distinct from
+                        'admin'::public.facility_access_level);
+
+  if not v_becoming then
+    return new;
+  end if;
+
+  -- Step 2 — only an admin makes an admin.
+  --
+  -- No JWT subject means the service role or a migration, which is the same
+  -- carve-out private.enforce_staff_integrity already makes. The webhook that
+  -- writes profiles — and therefore private.claim_grants_for, which runs off
+  -- its trigger — has no session to check.
+  if v_sub is null then
+    return new;
+  end if;
+
+  if private.is_platform_admin() then
+    return new;
+  end if;
+
+  if private.is_facility_admin(new.facility_id) then
+    return new;
+  end if;
+
+  -- Claiming an admin grant made FOR you. Without this the founding owner
+  -- cannot accept their own invitation: at that moment the facility has no
+  -- admin, so there is nobody who could approve it.
+  if exists (
+    select 1
+      from public.facility_membership_grants g
+      join public.profiles p on lower(p.email) = g.email
+     where g.facility_id  = new.facility_id
+       and p.id           = new.profile_id
+       and g.access_level = 'admin'::public.facility_access_level
+  ) then
+    return new;
+  end if;
+
+  raise exception
+    'Only a facility admin may grant admin access. manage_staff is not enough.'
+    using errcode = '42501';
+end;
+$fn$;
+
+drop trigger if exists facility_memberships_access_level on public.facility_memberships;
+create trigger facility_memberships_access_level
+  before insert or update on public.facility_memberships
+  for each row execute function private.enforce_membership_access_level();
+
+-- The same rule where the level is FIRST written. A staff row and a grant are
+-- how "hire this person as an admin" is expressed, so leaving them ungated
+-- would let a manage_staff holder create the admin one table upstream and let
+-- the claim carry it in.
+
+create or replace function private.enforce_hire_access_level()
+returns trigger
+language plpgsql
+security definer
+set search_path to ''
+as $fn$
+declare
+  v_sub  text := (select auth.jwt()->>'sub');
+  v_role public.facility_staff_role :=
+    case tg_table_name when 'staff' then new.primary_role else new.role end;
+begin
+  if v_role in ('owner','admin','manager','supervisor') then
+    new.access_level := 'admin'::public.facility_access_level;
+  end if;
+
+  if new.access_level <> 'admin'::public.facility_access_level then
+    return new;
+  end if;
+
+  if tg_op = 'UPDATE'
+     and old.access_level = 'admin'::public.facility_access_level then
+    return new;
+  end if;
+
+  if v_sub is null
+     or private.is_platform_admin()
+     or private.is_facility_admin(new.facility_id) then
+    return new;
+  end if;
+
+  raise exception
+    'Only a facility admin may hire an admin. manage_staff is not enough.'
+    using errcode = '42501';
+end;
+$fn$;
+
+drop trigger if exists staff_access_level on public.staff;
+create trigger staff_access_level
+  before insert or update on public.staff
+  for each row execute function private.enforce_hire_access_level();
+
+drop trigger if exists membership_grants_access_level on public.facility_membership_grants;
+create trigger membership_grants_access_level
+  before insert or update on public.facility_membership_grants
+  for each row execute function private.enforce_hire_access_level();
+
+-- ── A facility never runs out of admins ────────────────────────────────────
+--
+-- Nothing else in the schema can restore one: memberships_insert requires
+-- manage_staff, which only the admin-tier presets hold, and raising
+-- access_level now requires an existing admin. A facility that demotes its last
+-- one is unrecoverable without a platform admin.
+
+create or replace function private.protect_last_facility_admin()
+returns trigger
+language plpgsql
+security definer
+set search_path to ''
+as $fn$
+begin
+  if old.access_level <> 'admin'::public.facility_access_level
+     or not old.is_active then
+    return coalesce(new, old);
+  end if;
+
+  if tg_op = 'UPDATE'
+     and new.access_level = 'admin'::public.facility_access_level
+     and new.is_active then
+    return new;
+  end if;
+
+  -- The whole facility is being deleted, and memberships cascade from it. There
+  -- is no business left to lock anybody out of.
+  if tg_op = 'DELETE'
+     and not exists (select 1 from public.facilities where id = old.facility_id) then
+    return old;
+  end if;
+
+  if not exists (
+    select 1 from public.facility_memberships m
+     where m.facility_id   = old.facility_id
+       and m.id           <> old.id
+       and m.is_active
+       and m.access_level  = 'admin'::public.facility_access_level
+  ) then
+    raise exception
+      'That is the last admin of this facility. Promote somebody else first.'
+      using errcode = '42501';
+  end if;
+
+  return coalesce(new, old);
+end;
+$fn$;
+
+drop trigger if exists facility_memberships_last_admin on public.facility_memberships;
+create trigger facility_memberships_last_admin
+  before update or delete on public.facility_memberships
+  for each row execute function private.protect_last_facility_admin();
+
+-- ── The two functions that move a level along the chain ────────────────────
+--
+-- Both are reproduced from their LIVE bodies (pg_get_functiondef), not from the
+-- migration that first created them — private.has_permission gained its
+-- suspended-subscription check in a later migration, and rebuilding a function
+-- from the older text is how work like that gets quietly undone.
+
+create or replace function private.claim_grants_for(p_profile_id text, p_email text)
+returns integer
+language plpgsql
+security definer
+set search_path to ''
+as $fn$
+declare
+  v_grant      record;
+  v_membership uuid;
+  v_claimed    integer := 0;
+begin
+  if p_profile_id is null or p_profile_id !~ '^user_' or p_email is null then
+    return 0;
+  end if;
+
+  for v_grant in
+    select * from public.facility_membership_grants
+     where claimed_at is null
+       and email = lower(p_email)
+       and (expires_at is null or expires_at > now())
+  loop
+    insert into public.facility_memberships
+      (facility_id, profile_id, role, access_level, is_active)
+    values (v_grant.facility_id, p_profile_id, v_grant.role,
+            v_grant.access_level, true)
+    on conflict (profile_id, facility_id) do update
+      set role         = excluded.role,
+          access_level = excluded.access_level,
+          is_active    = true
+    returning id into v_membership;
+
+    update public.facility_membership_grants
+       set claimed_at         = now(),
+           claimed_profile_id = p_profile_id
+     where id = v_grant.id;
+
+    update public.staff
+       set membership_id = v_membership
+     where id = v_grant.staff_id;
+
+    v_claimed := v_claimed + 1;
+  end loop;
+
+  return v_claimed;
+end;
+$fn$;
+
+create or replace function private.record_grant_for_staff(
+  p_staff      public.staff,
+  p_expires_at timestamptz default null
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path to ''
+as $fn$
+declare
+  v_id         uuid;
+  v_profile_id text;
+  v_claimed    integer := 0;
+begin
+  if (select auth.jwt()->>'sub') is null then
+    raise exception 'You must be signed in to invite staff.'
+      using errcode = '42501';
+  end if;
+
+  if p_staff.id is null then
+    raise exception 'No staff record to grant a membership to.'
+      using errcode = '22023';
+  end if;
+
+  if not private.has_permission(p_staff.facility_id, 'manage_staff')
+     and not private.is_platform_admin() then
+    raise exception 'You may not invite staff at this facility.'
+      using errcode = '42501';
+  end if;
+
+  if coalesce(trim(p_staff.email), '') = '' then
+    raise exception 'That staff member has no email address to invite.'
+      using errcode = '22023';
+  end if;
+
+  insert into public.facility_membership_grants
+    (facility_id, staff_id, email, role, access_level, granted_by, expires_at)
+  values (p_staff.facility_id, p_staff.id, lower(trim(p_staff.email)),
+          p_staff.primary_role, p_staff.access_level,
+          (select auth.jwt()->>'sub'), p_expires_at)
+  on conflict (staff_id) do update
+    set email        = excluded.email,
+        role         = excluded.role,
+        access_level = excluded.access_level,
+        granted_by   = excluded.granted_by,
+        expires_at   = excluded.expires_at,
+        created_at   = now(),
+        claimed_at         = null,
+        claimed_profile_id = null
+  returning id into v_id;
+
+  update public.staff
+     set status = case
+                    when p_staff.primary_role = 'owner'::public.facility_staff_role
+                      then 'active'
+                    else 'invited'
+                  end,
+         status_changed_at = now()
+   where id = p_staff.id;
+
+  select p.id into v_profile_id
+    from public.profiles p
+   where lower(p.email) = lower(trim(p_staff.email))
+   limit 1;
+
+  if v_profile_id is not null then
+    v_claimed := private.claim_grants_for(v_profile_id, p_staff.email);
+  end if;
+
+  return jsonb_build_object(
+    'grantId',     v_id,
+    'staffId',     p_staff.legacy_id,
+    'facilityId',  p_staff.facility_id,
+    'email',       lower(trim(p_staff.email)),
+    'role',        p_staff.primary_role,
+    'accessLevel', p_staff.access_level,
+    'claimed',     v_claimed > 0);
+end;
+$fn$;

--- a/supabase/migrations/20260818120000_the_hire_guard_reads_the_right_column.sql
+++ b/supabase/migrations/20260818120000_the_hire_guard_reads_the_right_column.sql
@@ -1,0 +1,66 @@
+-- ============================================================================
+-- The hire guard reads the right column.
+--
+-- private.enforce_hire_access_level fires on two tables whose job-title column
+-- is named differently: `staff.primary_role` and
+-- `facility_membership_grants.role`. The first cut chose between them with a
+-- CASE in the DECLARE initialiser:
+--
+--   v_role public.facility_staff_role :=
+--     case tg_table_name when 'staff' then new.primary_role else new.role end;
+--
+-- plpgsql compiles that into ONE SQL expression, so BOTH field references are
+-- resolved against the record no matter which branch would be taken. On a staff
+-- row `new.role` does not exist, so every insert and update of either table
+-- raised
+--
+--   record "new" has no field "role"
+--
+-- Caught by the escalation probe rather than by review: the assertion that a
+-- receptionist with manage_staff cannot hire a manager PASSED — but for the
+-- wrong reason. The write failed with a schema error, not with the guard. A
+-- refusal is not evidence unless you read why it refused.
+--
+-- Branching with IF evaluates only the arm it takes, one statement at a time.
+-- ============================================================================
+
+create or replace function private.enforce_hire_access_level()
+returns trigger
+language plpgsql
+security definer
+set search_path to ''
+as $fn$
+declare
+  v_sub  text := (select auth.jwt()->>'sub');
+  v_role public.facility_staff_role;
+begin
+  if tg_table_name = 'staff' then
+    v_role := new.primary_role;
+  else
+    v_role := new.role;
+  end if;
+
+  if v_role in ('owner','admin','manager','supervisor') then
+    new.access_level := 'admin'::public.facility_access_level;
+  end if;
+
+  if new.access_level <> 'admin'::public.facility_access_level then
+    return new;
+  end if;
+
+  if tg_op = 'UPDATE'
+     and old.access_level = 'admin'::public.facility_access_level then
+    return new;
+  end if;
+
+  if v_sub is null
+     or private.is_platform_admin()
+     or private.is_facility_admin(new.facility_id) then
+    return new;
+  end if;
+
+  raise exception
+    'Only a facility admin may hire an admin. manage_staff is not enough.'
+    using errcode = '42501';
+end;
+$fn$;

--- a/supabase/tests/facility-access-level.sql
+++ b/supabase/tests/facility-access-level.sql
@@ -1,0 +1,267 @@
+-- ============================================================================
+-- Admin access is granted by an admin, and a facility never runs out of them.
+--
+--   psql "$(supabase status -o json | jq -r .DB_URL)" \
+--     -f supabase/tests/facility-access-level.sql
+--
+-- One transaction, rolled back.
+--
+-- ── WHAT THIS FILE IS REALLY ABOUT ─────────────────────────────────────────
+--
+-- ADR 0005 splits a membership's JOB TITLE (13 values, selects a permission
+-- template) from its ACCESS LEVEL (2 values, decides which portal). The whole
+-- split is worth nothing if the level can be raised by the people it is meant
+-- to hold back, so the interesting assertions here are the refusals.
+--
+-- P3 is the one that matters most, and it names a hole that PRE-DATES the
+-- split: memberships_insert/update are gated on `manage_staff`, which is a
+-- PERMISSION — and a facility can grant a permission to any job title through
+-- its own role editor. So a receptionist given manage_staff (a plausible thing
+-- for a front desk that books and hires) could set their own primary_role to
+-- 'owner' and mint themselves 168 permissions. That is why
+-- private.is_facility_admin is deliberately NOT routed through
+-- private.has_permission: if admin-ness were a permission key, a facility could
+-- grant itself admin from its own settings screen.
+--
+-- P6 exists because the guard could otherwise be too strict to be usable: at
+-- the moment a founding owner accepts their invitation the facility has NO
+-- admin, so there is nobody who could approve them. The carve-out is an admin
+-- GRANT recorded for their address — which only an admin (or a platform admin
+-- provisioning the facility) could have created.
+--
+-- P8 is the invariant that makes the rest safe to enforce: nothing in the
+-- schema can restore an admin once the last one is gone.
+--
+-- ── A NOTE ON A REFUSAL THAT IS NOT THIS FILE'S ────────────────────────────
+--
+-- Deleting a facility outright currently fails with "audit_log is append-only:
+-- UPDATE is not permitted", because audit_log.facility_id is ON DELETE SET
+-- NULL and that SET NULL is an UPDATE the append-only trigger refuses. That is
+-- unrelated to access levels and pre-dates them; it is why the cascade carve-out
+-- in private.protect_last_facility_admin cannot be exercised here.
+-- ============================================================================
+
+begin;
+
+set local client_min_messages to warning;
+
+create temp table tap (n int, name text, ok boolean, detail text);
+grant all on tap to authenticated;
+
+create or replace function pg_temp.t(i int, p text, ok boolean, d text default '')
+returns void language sql as $$
+  insert into tap(n, name, ok, detail) values (i, p, ok, d);
+$$;
+
+-- ── The cast ───────────────────────────────────────────────────────────────
+--
+-- An owner (admin), and a receptionist (staff) whose facility has handed the
+-- front desk `manage_staff`.
+
+insert into public.profiles (id, email, full_name) values
+  ('user_aclOwner00000000000000000000', 'acl.owner@yipyy.invalid', 'ACL Owner'),
+  ('user_aclRecep00000000000000000000', 'acl.recep@yipyy.invalid', 'ACL Reception'),
+  ('user_aclInvite0000000000000000000', 'acl.invited@yipyy.invalid', 'ACL Invited')
+on conflict (id) do nothing;
+
+insert into public.facility_memberships (profile_id, facility_id, role, is_active)
+select 'user_aclOwner00000000000000000000', f.id, 'owner', true
+  from public.facilities f where f.legacy_id = '11'
+on conflict (profile_id, facility_id) do nothing;
+
+insert into public.facility_memberships (profile_id, facility_id, role, is_active)
+select 'user_aclRecep00000000000000000000', f.id, 'reception', true
+  from public.facilities f where f.legacy_id = '11'
+on conflict (profile_id, facility_id) do nothing;
+
+insert into public.facility_role_permissions (facility_id, role, permission_key, scope)
+select f.id, 'reception', 'manage_staff', 'anytime'
+  from public.facilities f where f.legacy_id = '11'
+on conflict (facility_id, role, permission_key) do update set scope = 'anytime';
+
+-- ── P0: the backfill describes what was already true ───────────────────────
+
+select pg_temp.t(0, 'an owner membership is admin, a reception one is staff',
+  (select access_level = 'admin' from public.facility_memberships
+    where profile_id = 'user_aclOwner00000000000000000000')
+  and
+  (select access_level = 'staff' from public.facility_memberships
+    where profile_id = 'user_aclRecep00000000000000000000'));
+
+-- ── As the receptionist, who holds manage_staff ────────────────────────────
+
+select set_config('request.jwt.claims',
+  json_build_object('sub','user_aclRecep00000000000000000000','role','authenticated')::text, true);
+set local role authenticated;
+
+select pg_temp.t(1, 'is_facility_admin is false for staff',
+  not private.is_facility_admin((select id from public.facilities where legacy_id='11')));
+
+do $$
+declare v_ok boolean := false; v_msg text := '';
+begin
+  begin
+    update public.facility_memberships set access_level = 'admin'
+     where profile_id = 'user_aclRecep00000000000000000000';
+  exception when others then v_ok := true; v_msg := sqlerrm;
+  end;
+  perform pg_temp.t(2, 'manage_staff cannot raise its own access level', v_ok, v_msg);
+end $$;
+
+do $$
+declare v_ok boolean := false; v_msg text := '';
+begin
+  begin
+    update public.facility_memberships set role = 'owner'
+     where profile_id = 'user_aclRecep00000000000000000000';
+  exception when others then v_ok := true; v_msg := sqlerrm;
+  end;
+  perform pg_temp.t(3, 'manage_staff cannot make itself an owner', v_ok, v_msg);
+end $$;
+
+do $$
+declare v_ok boolean := false; v_msg text := '';
+begin
+  begin
+    insert into public.staff (facility_id, first_name, last_name, email, primary_role)
+    select f.id, 'Minted', 'Admin', 'acl.minted@yipyy.invalid', 'manager'
+      from public.facilities f where f.legacy_id = '11';
+  exception when others then v_ok := true; v_msg := sqlerrm;
+  end;
+  perform pg_temp.t(4, 'manage_staff cannot HIRE an admin', v_ok, v_msg);
+end $$;
+
+-- The guard must not become a wall. An ordinary hire still works, and lands as
+-- staff without anybody naming a level.
+do $$
+declare v_lvl text;
+begin
+  insert into public.staff (facility_id, first_name, last_name, email, primary_role)
+  select f.id, 'Ordinary', 'Groomer', 'acl.groomer@yipyy.invalid', 'groomer'
+    from public.facilities f where f.legacy_id = '11';
+  select access_level into v_lvl from public.staff where email = 'acl.groomer@yipyy.invalid';
+  perform pg_temp.t(5, 'an ordinary hire still works, and defaults to staff',
+                    v_lvl = 'staff', coalesce(v_lvl, 'no row'));
+exception when others then
+  perform pg_temp.t(5, 'an ordinary hire still works, and defaults to staff', false, sqlerrm);
+end $$;
+
+reset role;
+select set_config('request.jwt.claims', '', true);
+
+-- ── P6: a founding owner accepts an invitation to an empty facility ────────
+
+do $$
+declare v_org uuid; v_fac uuid; v_staff uuid; v_lvl text;
+begin
+  select org_id into v_org from public.facilities where legacy_id = '11';
+
+  insert into public.facilities (org_id, name, slug, timezone)
+  values (v_org, 'ACL Probe', 'acl-probe-facility', 'America/Toronto')
+  returning id into v_fac;
+
+  insert into public.staff (facility_id, first_name, last_name, email, primary_role)
+  values (v_fac, 'Founding', 'Owner', 'acl.invited@yipyy.invalid', 'owner')
+  returning id into v_staff;
+
+  insert into public.facility_membership_grants (facility_id, staff_id, email, role)
+  values (v_fac, v_staff, 'acl.invited@yipyy.invalid', 'owner');
+
+  perform pg_temp.t(6, 'an owner grant carries admin without being asked',
+    (select access_level = 'admin' from public.facility_membership_grants
+      where staff_id = v_staff));
+
+  -- The real claim path: the webhook writes profiles, the trigger claims. The
+  -- profile already exists here, so re-record the grant to force a claim.
+  perform private.claim_grants_for('user_aclInvite0000000000000000000', 'acl.invited@yipyy.invalid');
+
+  select access_level into v_lvl from public.facility_memberships
+   where profile_id = 'user_aclInvite0000000000000000000' and facility_id = v_fac;
+
+  perform pg_temp.t(7, 'the founding owner claims their own admin grant',
+                    v_lvl = 'admin', coalesce(v_lvl, 'no membership'));
+
+  -- ── P8: they are now the only admin of that facility ────────────────────
+  declare v_ok boolean := false; v_msg text := '';
+  begin
+    begin
+      update public.facility_memberships set is_active = false
+       where profile_id = 'user_aclInvite0000000000000000000' and facility_id = v_fac;
+    exception when others then v_ok := true; v_msg := sqlerrm;
+    end;
+    perform pg_temp.t(8, 'the last admin cannot be deactivated', v_ok, v_msg);
+
+    v_ok := false;
+    begin
+      delete from public.facility_memberships
+       where profile_id = 'user_aclInvite0000000000000000000' and facility_id = v_fac;
+    exception when others then v_ok := true; v_msg := sqlerrm;
+    end;
+    perform pg_temp.t(9, 'the last admin cannot be deleted', v_ok, v_msg);
+  end;
+
+  -- ── P10: with a second admin, demotion is legitimate again ──────────────
+  insert into public.profiles (id, email, full_name)
+  values ('user_aclSecond0000000000000000000', 'acl.second@yipyy.invalid', 'ACL Second')
+  on conflict (id) do nothing;
+
+  insert into public.facility_memberships (profile_id, facility_id, role, is_active)
+  values ('user_aclSecond0000000000000000000', v_fac, 'manager', true);
+
+  perform pg_temp.t(10, 'a manager inserted with no level is normalised to admin',
+    (select access_level = 'admin' from public.facility_memberships
+      where profile_id = 'user_aclSecond0000000000000000000' and facility_id = v_fac));
+
+  update public.facility_memberships set is_active = false
+   where profile_id = 'user_aclInvite0000000000000000000' and facility_id = v_fac;
+  perform pg_temp.t(11, 'an admin CAN be demoted once a second one exists', true);
+exception when others then
+  perform pg_temp.t(11, 'an admin CAN be demoted once a second one exists', false, sqlerrm);
+end $$;
+
+-- ── P12: an admin-tier job title cannot be stripped of admin access ────────
+--
+-- The state this forbids is role='owner' with access_level='staff': 168
+-- permissions, and no admin portal to exercise them in. RLS reads permissions
+-- and the gates read access, so that row is somebody who can drain the data
+-- through the API while the UI calls them staff.
+
+do $$
+declare v_ok boolean := false; v_msg text := '';
+begin
+  begin
+    update public.facility_memberships set access_level = 'staff'
+     where profile_id = 'user_aclOwner00000000000000000000';
+  exception when others then v_ok := true; v_msg := sqlerrm;
+  end;
+  perform pg_temp.t(12, 'an owner cannot be demoted to staff access', v_ok, v_msg);
+end $$;
+
+-- ── P13: the permission cascade is untouched ───────────────────────────────
+--
+-- The whole point of keeping `role`: a receptionist still resolves to exactly
+-- the receptionist preset. If this fails, the split ate the RBAC.
+
+select pg_temp.t(13, 'a reception membership still resolves 66 permissions',
+  (select count(*) from public.permissions p
+    where coalesce(private.resolve_permission(
+      (select id from public.facility_memberships
+        where profile_id = 'user_aclRecep00000000000000000000'), p.key),
+      'none') <> 'none') = 66,
+  'manage_staff was added to the preset above, so 65 + 1');
+
+-- ── Results ────────────────────────────────────────────────────────────────
+
+select n, name, case when ok then 'PASS' else 'FAIL' end as result, detail
+  from tap order by n;
+
+do $$
+declare v_failed int;
+begin
+  select count(*) into v_failed from tap where not ok;
+  if v_failed > 0 then
+    raise exception '% assertion(s) failed', v_failed;
+  end if;
+end $$;
+
+rollback;


### PR DESCRIPTION
Phase 2a of the onboarding-workflow plan, and the change [ADR 0005](docs/architecture/decisions/0005-three-facility-roles-one-staff-portal.md) exists to make: **three facility roles becomes true, without eating the RBAC.**

> ⚠️ **The migration is already applied to production** (`a_membership_is_admin_or_staff`, `hire_access_level_reads_the_right_column`). Every proof below was run against the live database inside transactions that abort themselves; nothing persisted — 9 memberships, 18 profiles, unchanged.

## The problem

`facility_memberships.role` was doing two unrelated jobs:

| | question | answers |
|---|---|---|
| 1 | which **portal** do you land in? | 2 |
| 2 | which **permission template**? | 13 |

Collapsing the thirteen would have destroyed (2) — owner 168 keys, manager 141, supervisor 82, reception 65, caretaker 45, accountant 44, groomer 36, sanitation 24. One Staff role with one permission set hands a sanitation worker an accountant's access.

So (1) becomes `public.facility_access_level` (`admin | staff`) and **`role` keeps its job unchanged**.

It lands on **three** tables — memberships, staff, grants — because "hire this person as an admin" has to survive `staff → grant → membership`; the membership doesn't exist until they accept. `default 'staff'` everywhere, so the several paths that insert without naming a level fail closed.

`role` is **not renamed**: `private.resolve_permission` joins it by name against `role_preset_permissions` and `facility_role_permissions`, and the three must stay symmetric. Its *meaning* changes, and a `comment on column` says so.

## The escalation this closes — which pre-dates it

`memberships_insert/update` are gated on `manage_staff`. That's a **permission**, and a facility can grant a permission to any job title through its own role editor. So a receptionist trusted with hiring could set their own `primary_role` to `owner` and resolve all 168 keys.

Proved against production before the fix, refused after:

```
reception raising itself to admin  => REFUSED: Only a facility admin may grant admin
                                      access. manage_staff is not enough.
reception making itself an owner   => REFUSED: (same)
reception hiring a manager         => REFUSED: Only a facility admin may hire an admin.
reception hiring a groomer         => ALLOWED, level=staff        ← not a wall
```

`private.is_facility_admin` is **deliberately not routed through `has_permission`** for exactly this reason: if admin-ness were a permission key, a facility could grant itself admin from its own settings screen.

It also **doesn't ask about the subscription**, unlike `has_permission`. The admin-only screen a suspended facility needs most is the one showing them they're suspended and letting them pay.

## Two states made unrepresentable

- **`role='owner'` + `access_level='staff'`** — 168 permissions and no admin portal to exercise them in. RLS reads permissions, the gates read access, so that row is somebody who can drain the data through the API while the UI calls them staff. An admin-tier job title now *forces* admin access, and an explicit demotion raises rather than being silently undone.
- **a facility with no admins.** Nothing in the schema could restore one.

## App side

`ViewerMembership` gains `accessLevel`; `landingPathForClaims`, `canAccessFacilityPortal` and `canManageFacilityAccount` read it, and the hardcoded `FACILITY_ADMIN_ROLES` set is gone.

`canAccessFacilityPortal` was **byte-identical** to `canAccessStaffPortal` — any member reached `/facility`, and the admin/staff split was a suggestion the app made and nothing enforced. It now requires admin. Platform admins still pass (ADR 0005 §5).

## A bug the probe caught, and review didn't

The second migration fixes the first. The staff/grant guard picked its job-title column with a `CASE` in a `DECLARE` initialiser — plpgsql compiles that into **one** expression where both field references must resolve, so every staff and grant write raised `record "new" has no field "role"`.

The "a receptionist cannot hire a manager" assertion **passed anyway** — the write did fail, just with a schema error instead of the guard. A refusal isn't evidence unless you read *why* it refused.

## Verification

**The permission cascade is byte-identical.** md5 over all 168 resolved keys for all 9 live memberships, before and after:

| role | md5 | granted |
|---|---|---|
| owner | `9f0011c366274d2ca2ba9560926f1b05` | 168 |
| manager | `d27ca77bfdb58b85a961c4ed527f65e1` | 141 |
| reception | `2cec40d076a5855b7c150d11cf8bb4a1` | 65 |
| caretaker | `ed3106456f6728173186f47da784d670` | 45 |
| groomer | `e7064586bccf0b3949cc9d30cc8342dc` | 36 |

Also proved live: the founding owner claims their own admin grant at a facility with **no** admin (otherwise nobody could ever approve them); the last admin can't be deactivated or deleted, and a second admin makes it legal again; `provision_facility` and `invite_facility_owner` carry `admin` end to end.

Ten gate cases in the app — `reception`/`groomer`/`caretaker` now refused `/facility`, a **promoted receptionist** admitted without an owner's job title.

`supabase/tests/facility-access-level.sql` captures all of it in the house psql style.

Green: `typecheck`, `lint` (0 errors), `format:check`, `build`, `check:rls-writes`, `check:facility-from-session`, `check:settings-wiring`.

## Not in this change, deliberately

- **No RLS policy moves onto `is_facility_admin`.** `facility_subscriptions_read` and `payment_connections_read` are still "any active member", which is too wide — that's Phase 2b, kept separate so this one can be proved to change nothing but routing.
- **No UI to promote somebody whose job title isn't admin-tier.** The model supports it; the screen doesn't exist yet.

## One unrelated finding, recorded in the debt map

**A facility cannot be deleted at all.** `audit_log.facility_id` is `ON DELETE SET NULL`, and that SET NULL is an UPDATE the append-only trigger refuses. Pre-dates this work; found because it's what makes the cascade carve-out in the last-admin guard unreachable. Fixing it is a change to an immutability guarantee and deserves its own ADR.
