### PR TITLE
feat(auth): the facility's own account is the admin's, and RLS says so

### DIFF
--- a/docs/quality/debt-map.md
+++ b/docs/quality/debt-map.md
@@ -2042,6 +2042,35 @@ than the guard. Fixed in `20260818120000_the_hire_guard_reads_the_right_column`.
 And branch on `tg_table_name` with `IF`, one statement per arm, never with a
 CASE over fields that do not exist on both records.
 
+### 🔴 Every member could read their employer's plan and Clover merchant (fixed)
+
+`facility_subscriptions_read` and `payment_connections_read` were both "any
+active member". Measured as a groomer, against production, before the fix:
+
+```
+groomer reads employer's facility_subscriptions rows = 1
+```
+
+That row is the facility's commercial relationship with Yipyy — plan, price,
+status, dunning state — reachable through PostgREST from a browser with a
+session and the publishable key. `payment_connections` names the facility's
+Clover merchant.
+
+Closed by `20260818140000_the_facilitys_own_account_is_the_admins`: both now go
+through `private.is_facility_admin`. No facility-facing screen read either; the
+only consumers are platform-admin surfaces, and a platform admin passes.
+
+**Do instead:** when adding a facility-scoped table, decide which of two things
+it is. What the business RUNS ON (settings, modules, hours) is readable by
+staff. What the business IS COMMERCIALLY (subscription, merchant, invoices) is
+`is_facility_admin` only. The default of "any active member" is the wrong answer
+for the second kind and it is easy to reach for.
+
+**And a trap in proving it:** an RLS-refused UPDATE affects zero rows and does
+NOT raise. Asserting "the row still exists afterwards" proves nothing — the
+first draft of `supabase/tests/facility-account-rls.sql` did exactly that and
+passed while measuring nothing. Use `GET DIAGNOSTICS ... row_count`.
+
 ### 🟡 A facility cannot be deleted at all
 
 Found while testing the cascade carve-out in

--- a/supabase/migrations/20260818140000_the_facilitys_own_account_is_the_admins.sql
+++ b/supabase/migrations/20260818140000_the_facilitys_own_account_is_the_admins.sql
@@ -1,0 +1,107 @@
+-- ============================================================================
+-- The facility's own account is the admin's, and RLS starts saying so.
+--
+-- ADR 0005 split a membership into a JOB TITLE and an ACCESS LEVEL, and
+-- 20260818100000 added the column, the guard and the gates. That change moved
+-- ROUTING only — deliberately, so it could be proved to alter nothing else.
+-- Not one row changed who may read it.
+--
+-- This is the half that makes the split real. `canAccessFacilityPortal` sends a
+-- staff member away from /facility, but a redirect is not a boundary: the
+-- database decides, from the JWT, and it was still answering "any active
+-- member".
+--
+-- ── WHAT WAS ACTUALLY READABLE ────────────────────────────────────────────
+--
+-- Measured against production before this migration, as a groomer:
+--
+--   groomer reads employer's facility_subscriptions rows = 1
+--
+-- That row is the facility's commercial relationship with Yipyy: its plan, its
+-- price, its status, its dunning state. Every member of every facility could
+-- read it — through PostgREST, from a browser, with nothing but a session and
+-- the publishable key. `payment_connections` is the same shape and worse in
+-- kind: it names the facility's Clover merchant.
+--
+-- Neither is read by any facility-facing screen. The only consumers are the
+-- platform-admin surfaces (src/lib/api/admin-facilities.ts,
+-- src/lib/api/facility-modules.ts), and private.is_facility_admin returns true
+-- for a platform admin, so they are unaffected. The Clover libraries and
+-- /pay/[ref] use the service-role client and never touched these policies —
+-- /pay/[ref] says so in its own header, because a customer paying their own
+-- booking is not a facility member either.
+--
+-- ── AND THE WRITES, WHICH WERE ONE ROLE-EDITOR CLICK FROM WRONG ───────────
+--
+-- The settings writes are gated on the PERMISSION `settings_general`. Only the
+-- owner/admin/manager presets hold it today, and all three are admin-tier — so
+-- this changes nothing for any membership that exists. But a permission is
+-- exactly what a facility can hand to any job title through its own role
+-- editor, which is the escalation shape 20260818100000 closed for memberships.
+-- A facility's own name, address, hours and rules are the admin's, not a
+-- permission it can delegate to the front desk.
+--
+-- Written as `is_facility_admin AND has_permission`, never as a replacement.
+-- has_permission ALSO excludes suspended and cancelled facilities, and
+-- is_facility_admin deliberately does not — dropping the permission arm would
+-- quietly hand a suspended facility its settings back. Both arms, so the change
+-- can only ever narrow.
+--
+-- ── WHAT IS DELIBERATELY LEFT WIDE ────────────────────────────────────────
+--
+-- `facility_settings_read` and `facility_modules_read` still admit any member.
+-- Staff need the opening hours to read a schedule and the enabled modules to
+-- render a nav; narrowing those would break the staff portal to protect
+-- nothing. The distinction is between what a business RUNS ON and what it IS
+-- COMMERCIALLY — only the second is the admin's alone.
+--
+-- `membership_grants_read` stays on `manage_staff`: seeing pending invitations
+-- is part of hiring, which a non-admin may legitimately do. What they may no
+-- longer do — mint an admin — is enforced one layer down, by trigger.
+-- ============================================================================
+
+-- ── The two commercial tables ──────────────────────────────────────────────
+
+drop policy if exists facility_subscriptions_read on public.facility_subscriptions;
+create policy facility_subscriptions_read on public.facility_subscriptions
+  for select to authenticated
+  using (private.is_facility_admin(facility_id));
+
+drop policy if exists payment_connections_read on public.payment_connections;
+create policy payment_connections_read on public.payment_connections
+  for select to authenticated
+  using (private.is_facility_admin(facility_id));
+
+-- ── The facility's own profile and settings ────────────────────────────────
+
+drop policy if exists facility_settings_insert on public.facility_settings;
+create policy facility_settings_insert on public.facility_settings
+  for insert to authenticated
+  with check (
+    private.is_facility_admin(facility_id)
+    and private.has_permission(facility_id, 'settings_general')
+  );
+
+drop policy if exists facility_settings_update on public.facility_settings;
+create policy facility_settings_update on public.facility_settings
+  for update to authenticated
+  using (
+    private.is_facility_admin(facility_id)
+    and private.has_permission(facility_id, 'settings_general')
+  )
+  with check (
+    private.is_facility_admin(facility_id)
+    and private.has_permission(facility_id, 'settings_general')
+  );
+
+drop policy if exists facilities_update_own_profile on public.facilities;
+create policy facilities_update_own_profile on public.facilities
+  for update to authenticated
+  using (
+    private.is_facility_admin(id)
+    and private.has_permission(id, 'settings_general')
+  )
+  with check (
+    private.is_facility_admin(id)
+    and private.has_permission(id, 'settings_general')
+  );

--- a/supabase/tests/facility-account-rls.sql
+++ b/supabase/tests/facility-account-rls.sql
@@ -1,0 +1,135 @@
+-- ============================================================================
+-- A facility's commercial account is readable by its admins, and nobody else.
+--
+--   psql "$(supabase status -o json | jq -r .DB_URL)" \
+--     -f supabase/tests/facility-account-rls.sql
+--
+-- One transaction, rolled back.
+--
+-- ── WHAT THIS FILE IS REALLY ABOUT ─────────────────────────────────────────
+--
+-- ADR 0005 gave a membership an access level, and 20260818100000 made the app
+-- gates read it. But `canAccessFacilityPortal` sending a groomer away from
+-- /facility is ROUTING. The boundary is here, and until 20260818140000 it still
+-- said "any active member":
+--
+--   groomer reads employer's facility_subscriptions rows = 1
+--
+-- That row is the facility's commercial relationship with Yipyy — plan, price,
+-- status, dunning state — and it was reachable through PostgREST from a browser
+-- with nothing but a session. `payment_connections` names the facility's Clover
+-- merchant and had the same policy.
+--
+-- P3 and P4 are the ones that stop this becoming a different bug: staff must
+-- STILL read facility_settings and facility_modules, because a schedule needs
+-- the opening hours and a nav needs the enabled modules. The line is between
+-- what a business RUNS ON and what it IS COMMERCIALLY.
+--
+-- P5/P6 measure the write refusal with GET DIAGNOSTICS row_count, not by
+-- checking the row afterwards. An RLS-refused UPDATE affects zero rows SILENTLY
+-- — it does not raise — so "the row still exists" proves nothing at all. The
+-- first draft of this test asserted exactly that and passed while proving
+-- nothing.
+-- ============================================================================
+
+begin;
+
+set local client_min_messages to warning;
+
+create temp table tap (n int, name text, ok boolean, detail text);
+grant all on tap to authenticated;
+
+create or replace function pg_temp.t(i int, p text, ok boolean, d text default '')
+returns void language sql as $$
+  insert into tap(n, name, ok, detail) values (i, p, ok, d);
+$$;
+
+do $$
+declare
+  v_fac uuid; v_admin_profile text; v_staff constant text := 'user_acctStaff000000000000000000';
+  n int; v_rows int; v_name text;
+begin
+  select id into v_fac from public.facilities where legacy_id = '11';
+  select profile_id into v_admin_profile
+    from public.facility_memberships
+   where facility_id = v_fac and access_level = 'admin' limit 1;
+  select name into v_name from public.facilities where id = v_fac;
+
+  insert into public.profiles (id, email, full_name)
+  values (v_staff, 'acct.staff@yipyy.invalid', 'Account Probe Staff')
+  on conflict (id) do nothing;
+  insert into public.facility_memberships (profile_id, facility_id, role, is_active)
+  values (v_staff, v_fac, 'groomer', true)
+  on conflict (profile_id, facility_id) do nothing;
+
+  -- ── as a member of staff ────────────────────────────────────────────────
+  perform set_config('request.jwt.claims',
+    json_build_object('sub', v_staff, 'role', 'authenticated')::text, true);
+  execute 'set local role authenticated';
+
+  select count(*) into n from public.facility_subscriptions where facility_id = v_fac;
+  perform pg_temp.t(1, 'staff cannot read their employer''s subscription', n = 0, n::text);
+
+  select count(*) into n from public.payment_connections where facility_id = v_fac;
+  perform pg_temp.t(2, 'staff cannot read the facility''s payment connection', n = 0, n::text);
+
+  select count(*) into n from public.facility_settings where facility_id = v_fac;
+  perform pg_temp.t(3, 'staff CAN still read facility_settings', n > 0, n || ' rows');
+
+  select count(*) into n from public.facility_modules where facility_id = v_fac;
+  perform pg_temp.t(4, 'staff CAN still read facility_modules (no error)', true, n || ' rows');
+
+  update public.facilities set name = 'HIJACKED' where id = v_fac;
+  get diagnostics v_rows = row_count;
+  perform pg_temp.t(5, 'staff cannot rename the facility', v_rows = 0, v_rows || ' rows affected');
+
+  update public.facility_settings set updated_at = now() where facility_id = v_fac;
+  get diagnostics v_rows = row_count;
+  perform pg_temp.t(6, 'staff cannot write facility settings', v_rows = 0, v_rows || ' rows affected');
+
+  execute 'reset role';
+
+  -- ── as an admin of the same facility ────────────────────────────────────
+  perform set_config('request.jwt.claims',
+    json_build_object('sub', v_admin_profile, 'role', 'authenticated')::text, true);
+  execute 'set local role authenticated';
+
+  select count(*) into n from public.facility_subscriptions where facility_id = v_fac;
+  perform pg_temp.t(7, 'an admin still reads their own subscription', n = 1, n::text);
+
+  update public.facilities set name = v_name where id = v_fac;
+  get diagnostics v_rows = row_count;
+  perform pg_temp.t(8, 'an admin still renames the facility', v_rows = 1, v_rows || ' rows affected');
+
+  update public.facility_settings set updated_at = now() where facility_id = v_fac;
+  get diagnostics v_rows = row_count;
+  perform pg_temp.t(9, 'an admin still writes facility settings', v_rows > 0, v_rows || ' rows affected');
+
+  execute 'reset role';
+
+  -- ── as a platform admin, who supports every facility ────────────────────
+  perform set_config('request.jwt.claims',
+    json_build_object('sub', (select profile_id from public.platform_memberships limit 1),
+                      'role', 'authenticated')::text, true);
+  execute 'set local role authenticated';
+
+  select count(*) into n from public.facility_subscriptions;
+  perform pg_temp.t(10, 'a platform admin reads every subscription',
+                    n = (select count(*) from public.facility_subscriptions), n::text);
+
+  execute 'reset role';
+end $$;
+
+select n, name, case when ok then 'PASS' else 'FAIL' end as result, detail
+  from tap order by n;
+
+do $$
+declare v_failed int;
+begin
+  select count(*) into v_failed from tap where not ok;
+  if v_failed > 0 then
+    raise exception '% assertion(s) failed', v_failed;
+  end if;
+end $$;
+
+rollback;


### PR DESCRIPTION
Phase 2b — the half that makes the admin/staff split a **boundary** rather than a redirect.

> ⚠️ Migration `the_facilitys_own_account_is_the_admins` is **already applied to production**. Every measurement below was taken against the live database inside transactions that abort themselves; nothing persisted.

## The leak

[#134](https://github.com/Yipyy-Inc/puneet/pull/134) gave a membership an access level and made the app gates read it — routing only, deliberately, so it could be proved to change nothing else. But `canAccessFacilityPortal` sending a groomer away from `/facility` is a *redirect*. The database decides, and it still said "any active member":

```
groomer reads employer's facility_subscriptions rows = 1
```

That row is the facility's commercial relationship with Yipyy — **plan, price, status, dunning state** — reachable through PostgREST from a browser with a session and the publishable key. `payment_connections` is the same shape and worse in kind: it names the facility's Clover merchant.

Neither is read by any facility-facing screen. The only consumers are the platform-admin surfaces, and `is_facility_admin` returns true for a platform admin. The Clover libraries and `/pay/[ref]` use the service-role client — `/pay/[ref]` already says so in its own header, because a customer paying their own booking isn't a facility member either.

## The writes, one role-editor click from wrong

Settings writes were gated on the **permission** `settings_general`. A permission is exactly what a facility can hand to any job title through its own role editor — the escalation shape #134 closed for memberships. A facility's own name, address, hours and rules are the admin's.

Written as `is_facility_admin AND has_permission`, **never as a replacement**: `has_permission` also excludes suspended and cancelled facilities and `is_facility_admin` deliberately does not, so dropping the permission arm would quietly hand a suspended facility its settings back. Both arms, so this can only narrow.

## Deliberately left wide

`facility_settings_read` and `facility_modules_read` still admit any member. Staff need the opening hours to read a schedule and the enabled modules to render a nav. **The line is between what a business RUNS ON and what it IS COMMERCIALLY** — only the second is the admin's alone.

`membership_grants_read` stays on `manage_staff`: seeing pending invitations is part of hiring, which a non-admin may legitimately do. What they may no longer do — mint an admin — is enforced by trigger one layer down.

## Verified

| | staff | admin | platform admin |
|---|---|---|---|
| subscription rows | **1 → 0** | 1 | 3 |
| Clover connection | **0** (the row exists) | 1 | 1 |
| `UPDATE facilities` | **0 rows affected** | 1 row | — |
| `UPDATE facility_settings` | **0 rows affected** | 6 rows | — |
| reads `facility_settings` | 6 rows *(unchanged, and must stay so)* | — | — |

**A trap worth naming:** an RLS-refused UPDATE affects zero rows and does **not** raise. Asserting "the row still exists afterwards" proves nothing — the first draft of `supabase/tests/facility-account-rls.sql` did exactly that and passed while measuring nothing. It now uses `GET DIAGNOSTICS ... row_count`, and the trap is in the debt map.

No new security advisors; the existing set is a pre-existing baseline.
