### PR TITLE
fix(auth): an invited hire reaches their checklist, and the e2e suite tells the truth

### DIFF
--- a/docs/quality/debt-map.md
+++ b/docs/quality/debt-map.md
@@ -2141,6 +2141,74 @@ happened) and letting the trigger allow the facility_id null-out specifically �
 the second is almost certainly right, but it is a change to an immutability
 guarantee and deserves its own ADR.
 
+## Snapshot (2026-08-18, walking the journey found the harness first)
+
+### 🔴 An invited hire was never routed to their checklist (fixed)
+
+`redirectIfStillOnboarding` lived ONLY in the facility layout, and it runs AFTER
+`guardPortal`. That worked by accident while any member could reach `/facility`:
+an invited hire who went looking for the dashboard was intercepted.
+
+They never took that path. Signing in has always landed staff on
+`/employee/schedule`, and the employee layout had no onboarding gate at all — so
+the checklist existed and nothing routed anybody to it. ADR 0005 then denied
+staff `/facility` outright, which removed the accidental interception as well.
+
+Caught by `tests/e2e/staff-invite-gate.spec.ts`, whose assertion was written
+against the accidental path. Fixed by running the gate in the employee layout
+too, with a `x-pathname` guard — the checklist is itself under `/employee`, so
+without one it redirects to itself forever.
+
+**Do instead:** when a gate's destination lives inside the portal it guards, the
+loop check is not optional. And an assertion that reads a redirect out of one
+hop's RSC payload breaks the moment the routing gains a hop — assert where the
+browser STOPS.
+
+### 🟡 No single e2e run can execute the whole suite
+
+The 50 spec files need identities from two different WorkOS environments:
+
+| run                                           | identities that work                    | identities that do not                               |
+| --------------------------------------------- | --------------------------------------- | ---------------------------------------------------- |
+| local (`bun run test:e2e`)                    | the seven `@yipyy.dev` staging accounts | `CLOVER_E2E_*`, `E2E_NON_FIXTURE_OWNER` — production |
+| remote (`E2E_BASE_URL=https://www.yipyy.com`) | the production accounts                 | the seven `@yipyy.dev` — staging only                |
+
+`playwright.config.ts` calls `applyWorkosTestKeys()` unconditionally and it
+**refuses anything but `sk_test_`**, on purpose. `scripts/provision-e2e-identities.ts`
+provisions the seven `@yipyy.dev` accounts and nothing else.
+
+Eight spec files were failing locally because their guards check that the
+fixture variables are SET, not that the account is reachable — so with values in
+`.env.local` they ran and every test failed at sign-in with `Invalid
+credentials`, which reads like a broken app. `client-file` alone is 15 tests,
+each burning a 30s timeout twice with retries.
+
+`tests/e2e/_fixtures.ts` now resolves those values only on a deployed run, so
+they skip honestly instead. **Do instead:** guard a fixture on whether it can be
+USED, not on whether somebody filled the variable in.
+
+### 🟡 e2e is not in CI, and a long local run is not a clean signal
+
+The four required checks are Analyze, build, format, lint and typecheck. Nothing
+runs Playwright, so the suite's red/green state is unmonitored.
+
+A full local run on 2026-08-18 did not complete cleanly. Every failure inspected
+was infrastructure: `ERR_CONNECTION_REFUSED`, or `/api/permissions -> 404` right
+after a restart — 30 of one and 4 of the other in a single subset run. The
+dev-server log also carried `Uncaught Error: Rendered more hooks than during the
+previous render` (React #310, the same error as the front-door crash above)
+followed by `script "dev" exited with code 255`; the two are adjacent in the log
+and the causal link is NOT established.
+
+`rm -rf .next` fixed it. Three consecutive subset runs afterwards were stable
+(13, 22 and 11 tests), which points at a corrupted `.next` cache —
+`turbopackFileSystemCacheForDev` is on — rather than at the app.
+
+**Do instead:** clear `.next` before trusting a red local run, and verify a
+change with the subset that covers it rather than the whole suite. The config's
+own note already says a rotating cast of failures means the environment is
+loaded, not that there are that many defects.
+
 ## How to add to this map
 
 Append under a new dated heading. For each item: a one-line description, a severity, **why it's risky**, and **what to do instead** of casually touching it. Don't delete items — strike them through with the date and PR when genuinely resolved.

--- a/src/app/employee/layout.tsx
+++ b/src/app/employee/layout.tsx
@@ -1,5 +1,6 @@
 import { canAccessStaffPortal } from "@/lib/auth/viewer";
 import { guardPortal } from "@/lib/auth/portal-gate";
+import { redirectIfStillOnboarding } from "@/lib/auth/onboarding-gate";
 
 // ============================================================================
 // Employee portal — authentication.
@@ -19,7 +20,23 @@ export default async function EmployeeLayout({
 }: {
   children: React.ReactNode;
 }) {
-  await guardPortal({ allow: canAccessStaffPortal });
+  const viewer = await guardPortal({ allow: canAccessStaffPortal });
+
+  // ── WHY THIS MOVED HERE TOO (ADR 0005) ──────────────────────────────────
+  //
+  // The onboarding gate lived ONLY in the facility layout, which worked while
+  // any member could reach /facility: an invited hire who went looking for the
+  // dashboard was intercepted and sent to their checklist.
+  //
+  // Staff are now denied that portal outright, so the interception never
+  // happened — and it never happened on the path they actually take either,
+  // because signing in has always landed them on /employee/schedule, which had
+  // no gate. So an invited hire simply started work: the checklist existed and
+  // nothing routed anybody to it.
+  //
+  // Caught by tests/e2e/staff-invite-gate.spec.ts, whose assertion was written
+  // against the accidental path rather than the real one.
+  await redirectIfStillOnboarding(viewer.email);
 
   return <>{children}</>;
 }

--- a/src/lib/auth/onboarding-gate.ts
+++ b/src/lib/auth/onboarding-gate.ts
@@ -1,5 +1,6 @@
 import "server-only";
 
+import { headers } from "next/headers";
 import { redirect } from "next/navigation";
 
 import { createServerClient } from "@/lib/supabase/server";
@@ -55,10 +56,26 @@ import { createServerClient } from "@/lib/supabase/server";
  * check stays anyway: routing a proprietor into a new hire's checklist is
  * wrong however the status got that way, and the cost is one column.
  */
+const CHECKLIST = "/employee/onboarding";
+
 export async function redirectIfStillOnboarding(
   email: string | null,
 ): Promise<void> {
   if (!email) return;
+
+  // ── THE CHECKLIST IS INSIDE THE PORTAL THIS NOW GUARDS ──────────────────
+  //
+  // This used to run only in the facility layout, where the destination was
+  // somewhere else entirely and could never be the current page. It runs in the
+  // employee layout too now, and /employee/onboarding is under /employee — so
+  // without this line the checklist would redirect to itself forever.
+  //
+  // `x-pathname` is stamped by src/proxy.ts, the same header guardPortal reads.
+  // Absent means the proxy did not run, which for a rendered layout does not
+  // happen; an empty string matches no prefix, so the gate still fires rather
+  // than failing open into a loop.
+  const pathname = (await headers()).get("x-pathname") ?? "";
+  if (pathname.startsWith(CHECKLIST)) return;
 
   const supabase = await createServerClient();
   const { data } = await supabase
@@ -68,6 +85,6 @@ export async function redirectIfStillOnboarding(
     .maybeSingle();
 
   if (data?.status === "invited" && data.primary_role !== "owner") {
-    redirect("/employee/onboarding");
+    redirect(CHECKLIST);
   }
 }

--- a/tests/e2e/_fixtures.ts
+++ b/tests/e2e/_fixtures.ts
@@ -1,0 +1,79 @@
+// ============================================================================
+// Fixtures that only exist in the DEPLOYED environment.
+//
+// ── THE TRAP THIS CLOSES ──────────────────────────────────────────────────
+//
+// Eight spec files are built on real Clover data and the staff account attached
+// to it: CLOVER_E2E_STAFF_EMAIL, CLOVER_E2E_CUSTOMER_EMAIL, the booking refs,
+// and the E2E_POSTGRES_* client. Each one already guards itself with
+// `test.skip(!VAR, "set VAR…")`, which is correct as far as it goes.
+//
+// It does not go far enough, and a local run is where that shows. Those
+// addresses are PRODUCTION WorkOS identities. The suite runs on STAGING keys —
+// `_workos-keys.ts` requires `sk_test_…` and refuses anything else, on purpose.
+// So with the variables set in `.env.local`, the guard sees non-empty values,
+// runs the tests, and every one of them fails at sign-in with
+//
+//   Invalid credentials for 'clover-staff@yipyy.com'
+//
+// which reads like a broken account or a broken app. It is neither: it is the
+// wrong environment. Measured on 2026-08-18, that was 8 of 50 spec files —
+// client-file alone is 15 tests, each burning a 30-second sign-in timeout twice
+// over with retries, and the run was still in the c's after an hour.
+//
+// ── WHY E2E_BASE_URL IS THE RIGHT DISCRIMINATOR ───────────────────────────
+//
+// The data these specs read lives in the one shared Postgres, so it IS
+// reachable from a local dev server. Only the IDENTITY is not. The suite can
+// authenticate a production identity exactly when it is pointed at the
+// deployment that owns it, and `E2E_BASE_URL` is what points it there
+// (playwright.config.ts calls the same value REMOTE and skips its webServer
+// block for it).
+//
+// So these values are readable on a remote run and empty on a local one, which
+// makes each file's own guard fire and report an honest SKIP instead of a
+// failure that means nothing.
+//
+//   bun run test:e2e                                    # local, these skip
+//   E2E_BASE_URL=https://www.yipyy.com bun run test:e2e  # these run
+//
+// Do NOT "fix" a skip by hardcoding a value here. The account has to exist in
+// the WorkOS environment the run authenticates against, and no amount of
+// configuration makes a production user resolve on staging keys.
+// ============================================================================
+
+/**
+ * True when the suite is pointed at a DEPLOYED environment.
+ *
+ * Not merely "E2E_BASE_URL is set". Pointing it at a locally built server —
+ * `next build && next start`, which is a sane way to dodge the dev server's
+ * on-demand compilation — would otherwise count as remote and hand production
+ * identities back to a run using staging keys, which is the exact trap this
+ * file exists to close. A local host is still a local run whatever the port.
+ */
+export const REMOTE_RUN = (() => {
+  const url = process.env.E2E_BASE_URL?.trim();
+  if (!url) return false;
+  try {
+    const { hostname } = new URL(url);
+    return hostname !== "localhost" && hostname !== "127.0.0.1";
+  } catch {
+    return false;
+  }
+})();
+
+/**
+ * A fixture that only resolves on a remote run.
+ *
+ * Returns "" locally so the caller's existing `test.skip(!VALUE, …)` fires,
+ * rather than handing it a value that cannot authenticate.
+ */
+export function deployedFixture(name: string): string {
+  if (!REMOTE_RUN) return "";
+  return process.env[name]?.trim() ?? "";
+}
+
+/** The numeric form. NaN locally, which every caller already treats as absent. */
+export function deployedFixtureRef(name: string): number {
+  return Number(deployedFixture(name));
+}

--- a/tests/e2e/booking-detail.spec.ts
+++ b/tests/e2e/booking-detail.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "@playwright/test";
 
 import { signIn } from "./_auth";
+import { deployedFixture, deployedFixtureRef } from "./_fixtures";
 
 // ============================================================================
 // The facility booking detail page renders a client that lives in Postgres.
@@ -18,10 +19,10 @@ import { signIn } from "./_auth";
 // may see it.
 // ============================================================================
 
-const CLIENT_REF = Number(process.env.E2E_POSTGRES_CLIENT_REF ?? "");
-const BOOKING_REF = Number(process.env.E2E_POSTGRES_BOOKING_REF ?? "");
-const CLIENT_NAME = process.env.E2E_POSTGRES_CLIENT_NAME?.trim() ?? "";
-const STAFF = process.env.CLOVER_E2E_STAFF_EMAIL?.trim() ?? "";
+const CLIENT_REF = deployedFixtureRef("E2E_POSTGRES_CLIENT_REF");
+const BOOKING_REF = deployedFixtureRef("E2E_POSTGRES_BOOKING_REF");
+const CLIENT_NAME = deployedFixture("E2E_POSTGRES_CLIENT_NAME");
+const STAFF = deployedFixture("CLOVER_E2E_STAFF_EMAIL");
 
 test.describe("a booking belonging to a Postgres client", () => {
   test.skip(

--- a/tests/e2e/client-billing.spec.ts
+++ b/tests/e2e/client-billing.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "@playwright/test";
 
 import { signIn } from "./_auth";
+import { deployedFixture, deployedFixtureRef } from "./_fixtures";
 
 // ============================================================================
 // A client's payments.
@@ -16,13 +17,13 @@ import { signIn } from "./_auth";
 // ============================================================================
 
 const PAYMENTS = "/api/payments";
-const CLIENT_REF = Number(process.env.E2E_POSTGRES_CLIENT_REF ?? "");
-const STAFF = process.env.CLOVER_E2E_STAFF_EMAIL?.trim() ?? "";
-const CUSTOMER = process.env.CLOVER_E2E_CUSTOMER_EMAIL?.trim() ?? "";
+const CLIENT_REF = deployedFixtureRef("E2E_POSTGRES_CLIENT_REF");
+const STAFF = deployedFixture("CLOVER_E2E_STAFF_EMAIL");
+const CUSTOMER = deployedFixture("CLOVER_E2E_CUSTOMER_EMAIL");
 // A real client at a DIFFERENT FACILITY, with hundreds of payments of their
 // own. An empty result for a client who has nothing would prove nothing about
 // scoping; this one has plenty to refuse.
-const OTHER_REF = Number(process.env.E2E_OTHER_CLIENT_REF ?? "");
+const OTHER_REF = deployedFixtureRef("E2E_OTHER_CLIENT_REF");
 
 test.describe("a client's payments", () => {
   test.skip(

--- a/tests/e2e/client-file.spec.ts
+++ b/tests/e2e/client-file.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "@playwright/test";
 
 import { signIn } from "./_auth";
+import { deployedFixture, deployedFixtureRef } from "./_fixtures";
 
 // ============================================================================
 // The client file, for a client who lives in Postgres.
@@ -19,9 +20,9 @@ import { signIn } from "./_auth";
 // because pointed at a fixture id it would pass against the bug.
 // ============================================================================
 
-const CLIENT_REF = Number(process.env.E2E_POSTGRES_CLIENT_REF ?? "");
-const CLIENT_NAME = process.env.E2E_POSTGRES_CLIENT_NAME?.trim() ?? "";
-const STAFF = process.env.CLOVER_E2E_STAFF_EMAIL?.trim() ?? "";
+const CLIENT_REF = deployedFixtureRef("E2E_POSTGRES_CLIENT_REF");
+const CLIENT_NAME = deployedFixture("E2E_POSTGRES_CLIENT_NAME");
+const STAFF = deployedFixture("CLOVER_E2E_STAFF_EMAIL");
 
 // Every tab in the client file that renders the client itself.
 const TABS = [

--- a/tests/e2e/clover-pay.spec.ts
+++ b/tests/e2e/clover-pay.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test, type Page } from "@playwright/test";
 
 import { signIn } from "./_auth";
+import { deployedFixture, deployedFixtureRef } from "./_fixtures";
 
 // ============================================================================
 // Paying a booking by card, through Clover's real sandbox.
@@ -32,8 +33,8 @@ import { signIn } from "./_auth";
 // `error.type` that Clover does not send.
 // ============================================================================
 
-const BOOKING_REF = Number(process.env.CLOVER_E2E_BOOKING_REF ?? "");
-const CUSTOMER = process.env.CLOVER_E2E_CUSTOMER_EMAIL?.trim() ?? "";
+const BOOKING_REF = deployedFixtureRef("CLOVER_E2E_BOOKING_REF");
+const CUSTOMER = deployedFixture("CLOVER_E2E_CUSTOMER_EMAIL");
 
 /** Clover's documented decline Visa. Approved cards are NOT used here. */
 const DECLINE_CARD = "4264281511117771";

--- a/tests/e2e/clover-platform.spec.ts
+++ b/tests/e2e/clover-platform.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "@playwright/test";
 
 import { ACCOUNTS, signIn } from "./_auth";
+import { deployedFixture } from "./_fixtures";
 
 // ============================================================================
 // The platform Clover status endpoint: who may read it, and what it discloses.
@@ -23,7 +24,7 @@ const STATUS = "/api/payments/clover/platform";
 // A facility staff account with a REAL Clover connection, which the @yipyy.dev
 // fixtures do not have — the refusal assertions want a member of a facility
 // that could plausibly be asking.
-const STAFF = process.env.CLOVER_E2E_STAFF_EMAIL?.trim() ?? "";
+const STAFF = deployedFixture("CLOVER_E2E_STAFF_EMAIL");
 
 test.describe("the platform Clover status endpoint", () => {
   test("refuses anyone who is not signed in", async ({ page }) => {

--- a/tests/e2e/clover-refund.spec.ts
+++ b/tests/e2e/clover-refund.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test, type Page } from "@playwright/test";
 
 import { signIn } from "./_auth";
+import { deployedFixture, deployedFixtureRef } from "./_fixtures";
 
 // ============================================================================
 // Refunding a card payment, through Clover's real sandbox.
@@ -23,9 +24,9 @@ import { signIn } from "./_auth";
 // was written for. Serial, and the sequence is deliberate.
 // ============================================================================
 
-const BOOKING_REF = Number(process.env.CLOVER_E2E_REFUND_BOOKING_REF ?? "");
-const CUSTOMER = process.env.CLOVER_E2E_CUSTOMER_EMAIL?.trim() ?? "";
-const STAFF = process.env.CLOVER_E2E_STAFF_EMAIL?.trim() ?? "";
+const BOOKING_REF = deployedFixtureRef("CLOVER_E2E_REFUND_BOOKING_REF");
+const CUSTOMER = deployedFixture("CLOVER_E2E_CUSTOMER_EMAIL");
+const STAFF = deployedFixture("CLOVER_E2E_STAFF_EMAIL");
 
 const refund = (page: Page, body: unknown) =>
   page.request.post("/api/payments/clover/refund", { data: body });

--- a/tests/e2e/clover-terminal.spec.ts
+++ b/tests/e2e/clover-terminal.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test, type Page } from "@playwright/test";
 
 import { signIn } from "./_auth";
+import { deployedFixture, deployedFixtureRef } from "./_fixtures";
 
 // ============================================================================
 // The terminal route: who may use it, and whether it can reach the hardware.
@@ -14,10 +15,10 @@ import { signIn } from "./_auth";
 // which is a Dev Kit somebody physically associated.
 // ============================================================================
 
-const BOOKING_REF = Number(process.env.CLOVER_E2E_TERMINAL_BOOKING_REF ?? "");
-const SERIAL = process.env.CLOVER_E2E_TERMINAL_SERIAL?.trim() ?? "";
-const STAFF = process.env.CLOVER_E2E_STAFF_EMAIL?.trim() ?? "";
-const CUSTOMER = process.env.CLOVER_E2E_CUSTOMER_EMAIL?.trim() ?? "";
+const BOOKING_REF = deployedFixtureRef("CLOVER_E2E_TERMINAL_BOOKING_REF");
+const SERIAL = deployedFixture("CLOVER_E2E_TERMINAL_SERIAL");
+const STAFF = deployedFixture("CLOVER_E2E_STAFF_EMAIL");
+const CUSTOMER = deployedFixture("CLOVER_E2E_CUSTOMER_EMAIL");
 
 const check = (page: Page, body: unknown) =>
   page.request.post("/api/payments/clover/terminal", { data: body });

--- a/tests/e2e/facility-access-level.spec.ts
+++ b/tests/e2e/facility-access-level.spec.ts
@@ -1,0 +1,166 @@
+import { test, expect } from "@playwright/test";
+import { ACCOUNTS, signIn } from "./_auth";
+
+// ============================================================================
+// A facility membership is admin or staff, and the gates finally act on it.
+//
+// ── THE BEHAVIOUR CHANGE THIS FILE EXISTS FOR ─────────────────────────────
+//
+// `canAccessFacilityPortal` and `canAccessStaffPortal` in src/lib/auth/viewer.ts
+// were BYTE-IDENTICAL: any active membership admitted you to /facility, and only
+// the LANDING PATH differed. So the admin/staff distinction was a suggestion the
+// app made on sign-in and nothing enforced afterwards — a groomer who typed the
+// URL got the whole business.
+//
+// ADR 0005 made it an access level, and the facility gate now requires `admin`.
+// These checks are the reason that is safe to enforce: the denied staff member
+// must land somewhere they DO belong, not at a login screen and not in a loop.
+//
+// The loop is not hypothetical. guardPortal's own comment records one: a fixed
+// per-portal fallback sent a customer from /facility to /dashboard, which denied
+// them and sent them back. Routing by `landingPathFor(viewer)` is what makes
+// that impossible, and test 1 is what proves it still is.
+//
+// ── ROUTING, NOT THE BOUNDARY ─────────────────────────────────────────────
+//
+// Every redirect here is SOFT — `redirect()` from a streaming layout is HTTP 200
+// with NEXT_REDIRECT in the RSC payload, executed by the client router — so
+// somebody ignoring it still reaches the route handler. What stops them there is
+// RLS, proved in supabase/tests/facility-account-rls.sql. These tests are about
+// where a browser ends up.
+// ============================================================================
+
+test.describe.configure({ mode: "serial" });
+
+test.describe("the facility portal is the admin's", () => {
+  for (const role of ["groomer", "reception", "caretaker"] as const) {
+    test(`a ${role} is sent to their own portal, not into /facility`, async ({
+      page,
+    }) => {
+      await signIn(page, ACCOUNTS[role]);
+      await page.goto("/facility/dashboard");
+
+      // Their landing path, computed from their own claims — NOT /sign-in, which
+      // would be the answer to a different question, and not back to /facility.
+      await page.waitForURL(/\/employee\/schedule/, { timeout: 30_000 });
+      expect(page.url()).not.toContain("/sign-in");
+      expect(page.url()).not.toContain("/facility");
+    });
+  }
+
+  for (const role of ["owner", "manager"] as const) {
+    test(`the ${role} still runs the business`, async ({ page }) => {
+      await signIn(page, ACCOUNTS[role]);
+      await page.goto("/facility/dashboard");
+
+      // Not bounced. Asserted as "did not leave" rather than on any particular
+      // widget, so a dashboard redesign does not fail an auth test.
+      await page.waitForLoadState("domcontentloaded");
+      await expect(page).toHaveURL(/\/facility\/dashboard/);
+    });
+  }
+
+  test("a staff member cannot reach the facility's own account", async ({
+    page,
+  }) => {
+    // The gate that was reading a client-writable cookie whose rule was
+    // `role == null || role === "owner"` — so an ABSENT cookie meant yes, and
+    // the subscription, the payment method and a full data export were open to
+    // every member of every facility.
+    await signIn(page, ACCOUNTS.groomer);
+    await page.goto("/facility/account/subscription");
+
+    await page.waitForURL(/\/employee\/schedule/, { timeout: 30_000 });
+    // And none of the page's own content arrived on the way past.
+    await expect(page.getByText(/current plan/i)).toHaveCount(0);
+  });
+
+  test("the owner can", async ({ page }) => {
+    await signIn(page, ACCOUNTS.owner);
+    await page.goto("/facility/account/subscription");
+
+    await page.waitForLoadState("domcontentloaded");
+    await expect(page).toHaveURL(/\/facility\/account\/subscription/);
+  });
+});
+
+test.describe("the retired groomer portal", () => {
+  // ADR 0005 §4. `/groomer` was one page reading the src/data/grooming fixture,
+  // for one of thirteen job titles. Retired with a next.config redirects entry
+  // rather than an in-app redirect() page, because the bookmark people hold is
+  // `/groomer/dashboard` and a page can only answer for the path it occupies.
+  for (const path of [
+    "/groomer",
+    "/groomer/dashboard",
+    "/groomer/dashboard/anything",
+  ]) {
+    test(`${path} redirects to the canonical staff shell`, async ({ page }) => {
+      const response = await page.request.get(path, { maxRedirects: 0 });
+
+      // 307, not 308: a permanent redirect is cached by the browser until it is
+      // cleared, so a wrong one would be hardest to fix for whoever hit it first.
+      expect(response.status()).toBe(307);
+      expect(response.headers()["location"]).toBe("/employee/schedule");
+    });
+  }
+});
+
+test.describe("inviting somebody onto the platform team", () => {
+  const BODY = {
+    name: "Probe Invitee",
+    email: "e2e.invite.probe@yipyy.invalid",
+    role: "system_administrator",
+  };
+
+  test("an anonymous caller cannot send Yipyy-branded mail", async ({
+    request,
+  }) => {
+    // This route had NO guard of any kind. Anyone who knew the path could make
+    // Yipyy email an address of their choosing, from the domain that also
+    // carries password resets.
+    const response = await request.post("/api/admin/invite", { data: BODY });
+    expect(response.status()).toBe(403);
+  });
+
+  test("running a facility is not running the platform", async ({ page }) => {
+    await signIn(page, ACCOUNTS.owner);
+    const response = await page.request.post("/api/admin/invite", {
+      data: BODY,
+    });
+    expect(response.status()).toBe(403);
+  });
+
+  test("a forged invitation token opens nothing", async ({ page }) => {
+    // Exactly the shape the OLD token had: base64url JSON, no signature, with a
+    // `role` field the holder could edit. The page decoded it and believed it.
+    const forged = Buffer.from(
+      JSON.stringify({
+        id: 1,
+        name: "Attacker",
+        email: "attacker@yipyy.invalid",
+        role: "system_administrator",
+        department: "x",
+        issuedAt: Date.now(),
+        expiresAt: Date.now() + 9e8,
+        nonce: "x",
+      }),
+    ).toString("base64url");
+
+    await page.goto(`/setup/${forged}`);
+    await expect(
+      page.getByText(/invitation link is invalid or has expired/i),
+    ).toBeVisible();
+    // The address from the payload is nowhere on the page.
+    await expect(page.getByText("attacker@yipyy.invalid")).toHaveCount(0);
+
+    const response = await page.request.post("/api/admin/setup", {
+      data: {
+        token: forged,
+        firstName: "A",
+        lastName: "B",
+        password: "x".repeat(12),
+      },
+    });
+    expect(response.status()).toBe(400);
+  });
+});

--- a/tests/e2e/facility-identity.spec.ts
+++ b/tests/e2e/facility-identity.spec.ts
@@ -42,28 +42,37 @@ test.describe("facility portal identity", () => {
     expect(await identityLine(page)).toContain("Dana Okafor");
 
     await page.context().clearCookies();
-    await signIn(page, "groomer@yipyy.dev");
-    const groomer = await identityLine(page);
-    expect(groomer).toContain("Jessica Alvarez");
-    expect(groomer).toContain("Groomer");
-
-    await page.context().clearCookies();
     await signIn(page, "manager@yipyy.dev");
-    expect(await identityLine(page)).toContain("Priya Raman");
+    const manager = await identityLine(page);
+    expect(manager).toContain("Priya Raman");
+    expect(manager).toContain("Manager");
   });
 
+  // THE GROOMER ARM IS GONE, AND ITS ABSENCE IS THE POINT (ADR 0005). This
+  // portal is the facility ADMIN's now, so a groomer cannot reach
+  // /facility/dashboard/staff at all — the identity line they used to be
+  // checked against is a page they are redirected away from. That a staff
+  // member is themselves is not untested: employee-identity.spec.ts asserts it
+  // on the portal they actually work in, and facility-access-level.spec.ts
+  // asserts the redirect itself.
+  //
+  // The manager took their place here because the guarantee is about the
+  // BRIDGE, not the role: an admin-tier account that is not the owner is what
+  // proves the page reads the signed-in staff member rather than defaulting to
+  // whoever owns the facility.
+
   test("the switcher is gone for a real staff member", async ({ page }) => {
-    await signIn(page, "groomer@yipyy.dev");
+    await signIn(page, "manager@yipyy.dev");
     expect(await identityLine(page)).toContain("Signed in as");
 
     // Not merely hidden — there is no combobox to click.
     await expect(
-      page.locator("button[role='combobox']").filter({ hasText: /Alvarez/ }),
+      page.locator("button[role='combobox']").filter({ hasText: /Raman/ }),
     ).toHaveCount(0);
   });
 
   test("localStorage cannot change who you are", async ({ page }) => {
-    await signIn(page, "groomer@yipyy.dev");
+    await signIn(page, "manager@yipyy.dev");
 
     // The exact attack the old provider allowed: name yourself the owner.
     await page.evaluate(
@@ -81,7 +90,7 @@ test.describe("facility portal identity", () => {
     );
 
     const after = await identityLine(page);
-    expect(after).toContain("Jessica Alvarez");
+    expect(after).toContain("Priya Raman");
     expect(after).not.toContain("Dana Okafor");
 
     // And the permissions agree — manage_roles is owner/admin only.

--- a/tests/e2e/facility-shell.spec.ts
+++ b/tests/e2e/facility-shell.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "@playwright/test";
 
 import { ACCOUNTS, signIn } from "./_auth";
+import { deployedFixture } from "./_fixtures";
 
 // ============================================================================
 // The facility shell — the sidebar and header on EVERY page of the portal.
@@ -67,7 +68,11 @@ test.describe("the facility shell", () => {
   // every real-email account — the pawradise owners, the Doggieville Mtl owner
   // — has no identity to sign in with. Reusing the Clover variable made this
   // spec fail for a reason that has nothing to do with the facility shell.
-  const OTHER_OWNER = process.env.E2E_NON_FIXTURE_OWNER?.trim() ?? "";
+  // Through deployedFixture for the reason the paragraph above describes: a
+  // real-email owner is a PRODUCTION identity, and a local run authenticates
+  // against staging. Set but unreachable is the failure mode; empty is the
+  // honest one.
+  const OTHER_OWNER = deployedFixture("E2E_NON_FIXTURE_OWNER");
 
   test("names a facility that is not in the fixtures at all", async ({
     page,

--- a/tests/e2e/server-permissions.spec.ts
+++ b/tests/e2e/server-permissions.spec.ts
@@ -34,16 +34,35 @@ async function serverHtml(page: Page, path: string): Promise<string> {
 test.describe.configure({ mode: "serial" });
 
 test.describe("server-rendered permissions", () => {
-  test("a groomer's first paint carries no manage_staff controls", async ({
+  test("a groomer never reaches the staff page to be withheld anything", async ({
     page,
   }) => {
+    // ── WHAT THIS TEST USED TO ASSERT, AND WHY IT CHANGED (ADR 0005) ──────
+    //
+    // It signed in as a groomer, fetched /facility/dashboard/staff, and checked
+    // that the owner-only control was absent from the FIRST PAINT — with
+    // "Manage departments" as a sanity anchor proving a real page came back
+    // rather than a redirect shell.
+    //
+    // The facility portal is the admin's now, so the groomer no longer gets a
+    // page to have anything withheld from: the layout gate sends them to
+    // /employee. The anchor is what caught it, exactly as designed — it exists
+    // to stop "the control is absent" being satisfied by "nothing rendered",
+    // and here nothing rendered.
+    //
+    // So the assertion moves up a layer. This is now the stronger claim: not
+    // "we withheld the button" but "we did not serve the page". The withholding
+    // itself is still proved below, by an owner who DOES get the control.
     await signIn(page, "groomer@yipyy.dev");
 
     const html = await serverHtml(page, STAFF_PAGE);
-    // Sanity: we fetched the staff page and not a redirect or a shell, so the
-    // absence below means "withheld" rather than "nothing rendered".
-    expect(html).toContain("Manage departments");
-    expect(html).not.toContain(OWNER_ONLY);
+    expect(html, "a soft redirect, not the staff page").toContain(
+      "NEXT_REDIRECT",
+    );
+    expect(html, "and none of its content came with it").not.toContain(
+      OWNER_ONLY,
+    );
+    expect(html).not.toContain("Manage departments");
   });
 
   test("an owner's first paint carries them", async ({ page }) => {

--- a/tests/e2e/staff-invite-gate.spec.ts
+++ b/tests/e2e/staff-invite-gate.spec.ts
@@ -98,18 +98,27 @@ test.describe("an invited account is not an admitted one", () => {
     }
 
     await signIn(page, ACCOUNTS.caretaker);
-    const body = await (await page.request.get("/facility/dashboard")).text();
 
-    // A soft redirect: HTTP 200 with NEXT_REDIRECT in the RSC payload, because
-    // the layout streams. The status is not the answer — the body is.
-    expect(body, "not left in the admin portal").toContain("NEXT_REDIRECT");
-    expect(body, "and sent somewhere useful, not to /sign-in").toContain(
-      "/employee/onboarding",
-    );
-    expect(
-      body,
-      "none of the admin portal's own content came back",
-    ).not.toContain("Add new staff");
+    // ── ASSERTED ON THE DESTINATION, NOT ON ONE HOP (ADR 0005) ───────────
+    //
+    // This used to fetch /facility/dashboard and read `/employee/onboarding`
+    // straight out of the RSC payload, because the facility layout ran the
+    // onboarding gate itself. That was the accidental path: it only ever fired
+    // for an invited hire who went looking for the ADMIN dashboard, and signing
+    // in has always landed staff on /employee/schedule instead — which had no
+    // gate at all. So the checklist existed and nothing routed anyone to it.
+    //
+    // The gate now runs in the employee layout too, which is the portal they
+    // actually reach. There are two hops from here (facility -> employee ->
+    // onboarding), so the payload of the first no longer names the destination.
+    // Following them and asserting where the browser STOPS is the guarantee
+    // anybody cares about, and it survives the routing changing again.
+    await page.goto("/facility/dashboard");
+    await page.waitForURL(/\/employee\/onboarding/, { timeout: 30_000 });
+
+    // Not left in the admin portal, and none of its content came with them.
+    expect(page.url()).not.toContain("/facility");
+    await expect(page.getByText("Add new staff")).toHaveCount(0);
   });
 
   test("…and once activated, the same person gets in", async ({


### PR DESCRIPTION
Phase 4 — walking the journey. It found **a regression I introduced**, an older gap underneath it, and a harness that could not have reported either.

## The regression, and the older gap under it

`redirectIfStillOnboarding` lived only in the facility layout, and it runs *after* `guardPortal`. Denying staff `/facility` ([#134](https://github.com/Yipyy-Inc/puneet/pull/134)) therefore stopped it firing for them.

The older gap is the part that matters: **they never took that path anyway.** Signing in has always landed staff on `/employee/schedule`, and the employee layout had no onboarding gate at all. So the checklist existed and nothing routed anybody to it — the facility gate only ever caught someone going looking for a portal they had no business in.

Fixed where it belongs: the gate now runs in the employee layout too. It needed loop protection first — `/employee/onboarding` is itself under `/employee`, so without an `x-pathname` check the checklist redirects to itself forever.

## Eight spec files could not have passed, and said so wrongly

They're built on **production** identities (`CLOVER_E2E_*`, `E2E_NON_FIXTURE_OWNER`). The suite runs on **staging** keys — `playwright.config.ts` calls `applyWorkosTestKeys()` unconditionally and it refuses anything but `sk_test_`.

Each file already guarded itself with `test.skip(!VAR, …)` — which checks that somebody *filled the variable in*, not that the account is reachable. With values in `.env.local` they ran, and every test failed at sign-in with `Invalid credentials`, which reads like a broken account or a broken app and is neither. `client-file` alone is 15 tests, each burning a 30s timeout twice with retries.

`tests/e2e/_fixtures.ts` resolves those values only on a deployed run, so each file's own guard fires and reports an honest **skip**. Not merely "`E2E_BASE_URL` is set": a localhost base URL is still a local run, and counting it as remote would hand production identities back to a staging-keyed suite — the exact trap.

## Three specs encoded the old access model

Updated rather than deleted, each keeping its guarantee:

- **facility-identity** — the groomer arm is gone because a groomer can't reach `/facility/dashboard/staff` at all now. The manager takes their place: an admin-tier account that *isn't* the owner is what proves the page reads the signed-in staff member rather than defaulting to whoever owns the facility. That a staff member is themselves is still covered by `employee-identity.spec.ts`, on the portal they actually work in.
- **server-permissions** — "a groomer's first paint carries no manage_staff controls" now asserts the stronger claim: not *"we withheld the button"* but *"we did not serve the page"*. Its own sanity anchor is what caught the change, exactly as designed — the anchor exists so "the control is absent" can't be satisfied by "nothing rendered", and here nothing rendered.
- **staff-invite-gate** — asserted `/employee/onboarding` by reading it out of one hop's RSC payload. There are two hops now, so it follows them and asserts where the browser **stops**.

## New: `facility-access-level.spec.ts` — 13 tests

Covers what Phases 1–3 changed and nothing did:

- groomer / reception / caretaker land on `/employee/schedule`, **not** `/sign-in` and **not** back at `/facility` (guardPortal's comment records a real redirect loop from a fixed per-portal fallback — this proves routing by `landingPathFor` still prevents it)
- owner and manager still get the dashboard
- a staff member is refused `/facility/account/subscription`; the owner is not
- `/groomer`, `/groomer/dashboard` and a deeper path all 307 to `/employee/schedule`
- `/api/admin/invite` refuses an anonymous caller **and** a facility owner
- a hand-crafted base64 token naming `role=system_administrator` — exactly what the old code believed — opens nothing

## Verification

```
facility-access-level                                    13 passed
+ facility-identity, server-permissions, staff-invite-gate  22 passed, 1 flaky
employee-identity, staff-portal-nav                       11 passed
```

`typecheck`, `lint` (0 errors, 225 warnings — unchanged), `format:check`, `build` green.

**A full local run is deliberately not part of that evidence.** Every failure I inspected was infrastructure — 30 × `ERR_CONNECTION_REFUSED` and 4 × `/api/permissions -> 404` after a restart in one subset alone. `rm -rf .next` fixed it, and three consecutive subset runs afterwards were stable. The debt map records that, the two-environment split that means **no single run can execute the whole suite**, and the fact that **e2e doesn't run in CI at all** — so nobody would have seen any of this.

## Not done

The customer walk (sign up at a facility host → join → add a pet → book) and the super-admin walk are still untested end to end. The super-admin half can't be driven from here at all: `houssemsina123@gmail.com` is Google-only, and the seven password accounts exist in staging while production identities exist only in production.
