### PR TITLE
ci: run the auth & access specs on every PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,9 +212,13 @@ jobs:
           NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY }}
         run: bun run test:e2e:ci
 
+      # `|| echo` because the commonest failure is the preflight, which runs
+      # before any server exists — and `tail` on a missing file adds a second
+      # red ##[error] under the one that actually explains what to do.
       - name: Server log (on failure)
         if: failure()
-        run: tail -200 /tmp/server.log
+        run: |
+          tail -200 /tmp/server.log 2>/dev/null             || echo "(no server log — the run failed before the server started)"
 
       - name: Upload the Playwright report
         if: failure()
@@ -225,3 +229,6 @@ jobs:
             playwright-report/
             test-results/
           retention-days: 7
+          # Same reason: a preflight failure produces no report, and the default
+          # is to warn about that on top of the real error.
+          if-no-files-found: ignore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,3 +65,163 @@ jobs:
             nextjs-${{ runner.os }}-
 
       - run: bun run build
+
+  # ── THE BROWSER TESTS ──────────────────────────────────────────────────────
+  #
+  # Everything above proves the code COMPILES, is formatted and has no type
+  # errors. None of it proves the app behaves. Every authorisation guard in this
+  # repo — a groomer refused /facility, `manage_staff` unable to mint an owner,
+  # an invited hire routed to their checklist, the header naming the person
+  # actually signed in — was verified by somebody running Playwright by hand.
+  #
+  # Which means the realistic regression looks like this: a change loosens
+  # `canAccessFacilityPortal`, typecheck/lint/format/build all go green, the PR
+  # merges, and every staff member can reach the facility admin portal again
+  # with nothing anywhere saying so.
+  #
+  # ── WHY A SUBSET ──────────────────────────────────────────────────────────
+  #
+  # 51 spec files exist. This runs the 10 that cover AUTHORISATION AND IDENTITY
+  # — the guards that fail silently and are expensive to be wrong about. The
+  # rest (bookings, boarding, Clover, grooming) fail loudly the moment somebody
+  # opens the screen, and adding them would trade minutes on every PR for
+  # coverage of things a human notices anyway.
+  #
+  # The list lives in `bun run test:e2e:ci` rather than here, so the command CI
+  # runs is the command anybody can run locally, unchanged.
+  #
+  # ── WHY A BUILT SERVER AND NOT `bun run dev` ─────────────────────────────
+  #
+  # playwright.config.ts starts `bun run dev`, which compiles routes on first
+  # hit; the same 59 tests take minutes longer that way and the first navigation
+  # to each route is a coin flip against the 120s timeout. Measured on a built
+  # server: 59 tests, 4m09s, one skip, zero failures.
+  #
+  # `E2E_BASE_URL=http://localhost:3000` suppresses the config's webServer block
+  # so this job owns the server. It does NOT make the run "remote":
+  # tests/e2e/_fixtures.ts treats a localhost base as local on purpose, so the
+  # eight production-identity specs keep skipping honestly instead of failing at
+  # sign-in against staging keys.
+  #
+  # ── THESE TESTS TOUCH THE REAL DATABASE ──────────────────────────────────
+  #
+  # There is one Postgres. A localhost server still talks to it, so this subset
+  # was checked for write-cleanliness before being put on every PR: counts for
+  # facilities, memberships, clients, pets, bookings, profiles, platform team
+  # and role overrides were identical before and after a full run. Anything
+  # added to `test:e2e:ci` must clean up after itself the way
+  # role-editor-writes.spec.ts does.
+  e2e:
+    name: e2e (auth & access)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+
+      # Fail here, with the list, rather than 59 identical sign-in timeouts.
+      # Absent keys failing loudly is the same rule tests/e2e/_workos-keys.ts
+      # applies — a suite that cannot authenticate should say so in one line.
+      - name: Check the required secrets are configured
+        env:
+          WORKOS_API_KEY: ${{ secrets.WORKOS_API_KEY }}
+          WORKOS_CLIENT_ID: ${{ secrets.WORKOS_CLIENT_ID }}
+          WORKOS_COOKIE_PASSWORD: ${{ secrets.WORKOS_COOKIE_PASSWORD }}
+          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
+          NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+          E2E_PASSWORD: ${{ secrets.E2E_PASSWORD }}
+        run: |
+          missing=""
+          for name in WORKOS_API_KEY WORKOS_CLIENT_ID WORKOS_COOKIE_PASSWORD \
+                      NEXT_PUBLIC_SUPABASE_URL NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY \
+                      SUPABASE_SERVICE_ROLE_KEY E2E_PASSWORD; do
+            if [ -z "${!name}" ]; then missing="$missing $name"; fi
+          done
+          if [ -n "$missing" ]; then
+            echo "::error::Missing repository secrets:$missing"
+            echo "Add them under Settings → Secrets and variables → Actions."
+            echo "WORKOS_API_KEY must be the STAGING key (sk_test_…) — the suite"
+            echo "refuses anything else, so a production key fails here too."
+            exit 1
+          fi
+          case "$WORKOS_API_KEY" in
+            sk_test_*) ;;
+            *) echo "::error::WORKOS_API_KEY is not a staging key (sk_test_…)."
+               echo "The e2e accounts live in the WorkOS Staging environment;"
+               echo "a production key would try to create them on the live one."
+               exit 1 ;;
+          esac
+          echo "All seven secrets present."
+
+      - run: bun install --frozen-lockfile
+
+      - name: Restore Next.js cache
+        uses: actions/cache@v4
+        with:
+          path: .next/cache
+          key: nextjs-e2e-${{ runner.os }}-${{ github.sha }}
+          restore-keys: |
+            nextjs-e2e-${{ runner.os }}-
+            nextjs-${{ runner.os }}-
+
+      - name: Install Chromium
+        run: bunx playwright install --with-deps chromium
+
+      - name: Build
+        env:
+          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
+          NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY }}
+          NEXT_PUBLIC_WORKOS_REDIRECT_URI: http://localhost:3000/auth/callback
+          NEXT_PUBLIC_APP_DOMAIN: yipyy.test
+        run: bun run build
+
+      # Backgrounded with a readiness poll rather than a fixed sleep: the first
+      # request is what decides whether the run is testing an app or an empty
+      # port, and `next start` is ready in seconds or not at all.
+      - name: Start the built server
+        env:
+          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
+          NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+          WORKOS_API_KEY: ${{ secrets.WORKOS_API_KEY }}
+          WORKOS_CLIENT_ID: ${{ secrets.WORKOS_CLIENT_ID }}
+          WORKOS_COOKIE_PASSWORD: ${{ secrets.WORKOS_COOKIE_PASSWORD }}
+          NEXT_PUBLIC_WORKOS_REDIRECT_URI: http://localhost:3000/auth/callback
+          NEXT_PUBLIC_APP_DOMAIN: yipyy.test
+        run: |
+          bun run start --port 3000 > /tmp/server.log 2>&1 &
+          for i in $(seq 1 60); do
+            if [ "$(curl -s -o /dev/null -w '%{http_code}' http://localhost:3000/sign-in)" = "200" ]; then
+              echo "Server up after ${i}s."
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "::error::The server never became ready. Last 50 lines:"
+          tail -50 /tmp/server.log
+          exit 1
+
+      - name: Run the auth & access specs
+        env:
+          E2E_BASE_URL: http://localhost:3000
+          E2E_PASSWORD: ${{ secrets.E2E_PASSWORD }}
+          WORKOS_API_KEY: ${{ secrets.WORKOS_API_KEY }}
+          WORKOS_CLIENT_ID: ${{ secrets.WORKOS_CLIENT_ID }}
+          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
+          NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY }}
+        run: bun run test:e2e:ci
+
+      - name: Server log (on failure)
+        if: failure()
+        run: tail -200 /tmp/server.log
+
+      - name: Upload the Playwright report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: |
+            playwright-report/
+            test-results/
+          retention-days: 7

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,25 +26,36 @@ Every task follows: **Ground → Plan → Implement → Verify → Encode.**
 
 ## Commands
 
-There is **no test runner** in this project. "Green" = the CI gates plus a manual look at the UI.
+There **is** a test runner: Playwright, 51 spec files under [tests/e2e/](tests/e2e/), driving a real browser against a real server. It was described here as absent long after it existed. "Green" = the CI gates, the auth & access specs, and a look at the touched journey.
 
-| Command                               | Purpose                                                                                            |
-| ------------------------------------- | -------------------------------------------------------------------------------------------------- |
-| `bun run dev`                         | Dev server (webpack); `bun run dev:turbo` for turbo                                                |
-| `bun run typecheck`                   | `tsc --noEmit` — the primary gate (also runs on pre-commit & pre-push)                             |
-| `bun run lint`                        | ESLint (cached); `bun run lint:fix` to autofix                                                     |
-| `bun run format:check`                | Prettier check; `bun run format` to write                                                          |
-| `bun run build`                       | `next build` — full production build (CI runs this)                                                |
-| `bun run prune`                       | Knip — dead-code / unused-export report                                                            |
-| `bun run check:pricing`               | Project-specific pricing-consistency script                                                        |
-| `bun run check:settings-wiring`       | Fails if a `*Settings.tsx` component is imported nowhere (dead-code guard)                         |
-| `bun run check:rls-writes`            | Fails if an API update/delete cannot tell an RLS refusal from a no-op                              |
-| `bun run check:grooming-menu`         | Fails if a screen reads the grooming menu from the fixture, not Postgres                           |
-| `bun run check:facility-from-session` | Fails if an API route takes the facility from the request rather than the session or a parent row  |
-| `bun run check:success-claims`        | Fails if a screen claims an action succeeded with nothing that could perform it                    |
-| `bun run check:settings-fixture`      | Fails if a screen reads a facility-owned value (name, hours, rules, tips) from `src/data/settings` |
+| Command                               | Purpose                                                                                             |
+| ------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| `bun run dev`                         | Dev server (webpack); `bun run dev:turbo` for turbo                                                 |
+| `bun run typecheck`                   | `tsc --noEmit` — the primary gate (also runs on pre-commit & pre-push)                              |
+| `bun run lint`                        | ESLint (cached); `bun run lint:fix` to autofix                                                      |
+| `bun run format:check`                | Prettier check; `bun run format` to write                                                           |
+| `bun run build`                       | `next build` — full production build (CI runs this)                                                 |
+| `bun run prune`                       | Knip — dead-code / unused-export report                                                             |
+| `bun run test:e2e`                    | The whole Playwright suite (51 files, ~45 min, one worker — see the debt map before trusting a run) |
+| `bun run test:e2e:ci`                 | The 10 auth & access specs CI runs on every PR — 59 tests, ~4 min against a built server            |
+| `bun run check:pricing`               | Project-specific pricing-consistency script                                                         |
+| `bun run check:settings-wiring`       | Fails if a `*Settings.tsx` component is imported nowhere (dead-code guard)                          |
+| `bun run check:rls-writes`            | Fails if an API update/delete cannot tell an RLS refusal from a no-op                               |
+| `bun run check:grooming-menu`         | Fails if a screen reads the grooming menu from the fixture, not Postgres                            |
+| `bun run check:facility-from-session` | Fails if an API route takes the facility from the request rather than the session or a parent row   |
+| `bun run check:success-claims`        | Fails if a screen claims an action succeeded with nothing that could perform it                     |
+| `bun run check:settings-fixture`      | Fails if a screen reads a facility-owned value (name, hours, rules, tips) from `src/data/settings`  |
 
 **The green sequence (run before claiming done):** `bun run typecheck && bun run lint && bun run format:check`, then for UI changes `bun run dev` and visually confirm the touched [critical user journey](docs/product/critical-user-journeys.md). Run `bun run build` for anything structural (routing, layouts, server/client boundaries). Use **bun** only — never npm/yarn/pnpm.
+
+**Touching auth, a portal gate, a permission or an identity?** Run `bun run test:e2e:ci` too — CI runs exactly that command on every PR. Fastest locally against a built server rather than the dev one:
+
+```
+bun run build && bun run start --port 3000 &
+E2E_BASE_URL=http://localhost:3000 bun run test:e2e:ci
+```
+
+`E2E_BASE_URL` pointed at localhost is still a LOCAL run — [tests/e2e/\_fixtures.ts](tests/e2e/_fixtures.ts) treats it that way on purpose, so the production-identity specs skip rather than fail against staging keys.
 
 ## Docs map
 
@@ -73,7 +84,8 @@ App Router with RSC enabled and the React Compiler on (babel plugin). Three+ por
 - Follow the CLAUDE.md build-performance rules for all new code: Server Components by default for pages, types separated from mock data, components under ~500 lines, dynamic imports for heavy/conditional components, consume data via `src/lib/api/` factories (not direct `src/data/` imports).
 - **Conventional Commits** for every commit (`feat:`, `fix:`, `chore:`, `refactor:`, `docs:` …).
 - **Never weaken a gate** (a lint rule, the tsconfig `strict` flag, a CI step, a husky hook) to make work pass. Propose gate changes explicitly and separately.
-- There is no test harness; until one exists, **manual verification against the touched journey is mandatory** and substitutes for "tests pass." If you add a test runner, that is its own change with its own ADR.
+- **Manual verification against the touched journey is still mandatory** — the suite covers authorisation and identity, not every screen. What it does cover, CI now enforces: `bun run test:e2e:ci` runs on every PR, so a loosened gate fails the build instead of shipping.
+- A spec added to `test:e2e:ci` **must clean up after itself**. There is one Postgres and CI writes to it; see the `afterAll` in [role-editor-writes.spec.ts](tests/e2e/role-editor-writes.spec.ts).
 - Boy-scout cleanup is **opt-in** — only refactor adjacent legacy code when explicitly asked.
 
 ## Legacy / risk zones — handle with care

--- a/docs/quality/debt-map.md
+++ b/docs/quality/debt-map.md
@@ -2232,10 +2232,33 @@ each burning a 30s timeout twice with retries.
 they skip honestly instead. **Do instead:** guard a fixture on whether it can be
 USED, not on whether somebody filled the variable in.
 
-### 🟡 e2e is not in CI, and a long local run is not a clean signal
+### 🟢 The auth & access specs run in CI (was 🟡) — the rest still do not
 
-The four required checks are Analyze, build, format, lint and typecheck. Nothing
-runs Playwright, so the suite's red/green state is unmonitored.
+~~Nothing runs Playwright, so the suite's red/green state is unmonitored.~~ A
+fifth job, `e2e (auth & access)`, runs `bun run test:e2e:ci` on every PR: the ten
+spec files covering authorisation and identity, 59 tests, measured at **4m00s**
+against a built server (`next start`, not `bun run dev` — on-demand compilation
+was most of the old runtime).
+
+**Why a subset.** The other 41 files cover bookings, boarding, Clover and
+grooming: things that fail loudly the moment somebody opens the screen. The ten
+chosen cover the guards that fail SILENTLY — a groomer refused `/facility`,
+`manage_staff` unable to mint an owner, an invited hire routed to their
+checklist, the header naming the person signed in. Those are the ones where
+typecheck, lint, format and build all go green while the app is wrong.
+
+**CI writes to the real database.** There is one Postgres, and a localhost
+server still talks to it. The subset was checked for write-cleanliness before
+being put on every PR — facilities, memberships, clients, pets, bookings,
+profiles, platform team and role-override counts were identical before and
+after a full run. **Anything added to `test:e2e:ci` must clean up after itself**
+the way `role-editor-writes.spec.ts` does, or every PR will leave residue in
+production data.
+
+**Still open:** the remaining 41 files, and the two-environment problem above
+that stops any single run covering everything.
+
+### 🟡 A long local run is still not a clean signal
 
 A full local run on 2026-08-18 did not complete cleanly. Every failure inspected
 was infrastructure: `ERR_CONNECTION_REFUSED`, or `/api/permissions -> 404` right

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "check:nav-parity": "bun scripts/check-nav-parity.ts",
     "db:seed:generate": "bun scripts/generate-supabase-seed.ts",
     "test:e2e": "playwright test",
+    "test:e2e:ci": "playwright test admin-portal-enforced facility-access-level facility-identity employee-identity staff-invite-gate server-permissions staff-field-exposure role-editor-writes facility-shell staff-portal-nav",
     "test:e2e:ui": "playwright test --ui",
     "prepare": "husky",
     "db:seed:apply": "bun scripts/apply-operational-seed.ts",


### PR DESCRIPTION
The five checks on a PR — Analyze, build, format, lint, typecheck — prove the code **compiles**, is **formatted** and has **no type errors**. None of them prove the app *behaves*.

Every authorisation guard in this repo was verified by somebody running Playwright by hand. So the realistic regression looks like this: a change loosens `canAccessFacilityPortal`, all five go green, the PR merges, and every staff member can reach the facility admin portal again — with nothing anywhere saying so.

Not hypothetical: the invited-hire routing bug (a new staff member never sent to their onboarding checklist) was found by a browser test. `typecheck` was perfectly happy with it.

## A subset, and why

51 spec files exist. This runs the **ten covering authorisation and identity**:

`admin-portal-enforced` · `facility-access-level` · `facility-identity` · `employee-identity` · `staff-invite-gate` · `server-permissions` · `staff-field-exposure` · `role-editor-writes` · `facility-shell` · `staff-portal-nav`

The other 41 cover bookings, boarding, Clover, grooming — things that fail **loudly** the moment somebody opens the screen. The ten chosen are the ones that fail **silently**, which is what makes them worth minutes on every PR.

The list lives in `bun run test:e2e:ci`, not in the workflow, so **the command CI runs is the command anybody can run locally**, unchanged.

## A built server, not `bun run dev`

`playwright.config.ts` starts `bun run dev`, which compiles routes on first hit. Against `next start` the same ten files are **59 tests in 4m00s** — measured twice, zero failures, one honest skip.

`E2E_BASE_URL=http://localhost:3000` suppresses the config's `webServer` block so the job owns the server lifecycle. It does **not** make the run "remote": `tests/e2e/_fixtures.ts` treats a localhost base as local *on purpose*, so the eight production-identity specs keep skipping instead of failing at sign-in against staging keys. That file anticipated this exact setup in its header.

## CI writes to the real database — and that was checked

There is one Postgres, and a localhost server still talks to it. Before putting this on every PR I ran the subset and compared counts either side:

```
facilities 3 · memberships 9 · admins 6 · clients 16 · pets 21
bookings 250 · profiles 18 · platform team 3 · pending invites 0
role overrides 0
```

**Identical.** `role-editor-writes` restores its overrides in `afterAll`, and anything added to `test:e2e:ci` must do the same or every PR leaves residue in production data. That's written into AGENTS.md as a rule rather than left as folklore.

## Secrets fail loudly

> ⚠️ **This job will be RED until you add seven repository secrets.** That's deliberate — a check that goes green without running anything is the exact failure mode this change is about.

Settings → Secrets and variables → Actions:

| secret | note |
|---|---|
| `WORKOS_API_KEY` | **Staging** (`sk_test_…`). The job refuses anything else. |
| `WORKOS_CLIENT_ID` | Staging |
| `WORKOS_COOKIE_PASSWORD` | any 32+ char string |
| `NEXT_PUBLIC_SUPABASE_URL` | |
| `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY` | |
| `SUPABASE_SERVICE_ROLE_KEY` | |
| `E2E_PASSWORD` | the shared password for the seven `@yipyy.dev` accounts |

The first step checks all seven and exits with the list of missing names, rather than letting the run reach 59 identical sign-in timeouts. It also refuses a non-`sk_test_` key for the same reason `tests/e2e/_workos-keys.ts` does: the e2e accounts live in Staging, and a production key would try to create them on the live environment.

Once it's green, mark **`e2e (auth & access)`** required in branch protection alongside the other five.

## And a doc that had stopped being true

AGENTS.md said *"There is no test runner in this project"* and *"there is no test harness; until one exists, manual verification substitutes for tests pass."* That had been wrong for a while — 51 spec files exist. Corrected, with both commands added to the table and to the green sequence, and manual verification kept mandatory, because the suite covers authorisation and identity rather than every screen.
