### PR TITLE
feat(customer): a pet is a real row, and the portal names the right business

### DIFF
--- a/docs/quality/debt-map.md
+++ b/docs/quality/debt-map.md
@@ -2166,7 +2166,7 @@ management's two-admin restore, scheduled support messages and
 four real roles, but `mfaRequiredByRole` is still a localStorage preference that
 enforces nothing — enrolment is WorkOS's to require.
 
-### 🔴 The customer journey stops at "add a pet" — and the APIs it needs already exist
+### 🟠 The customer journey: a pet is real now, a booking still is not
 
 **Walked end to end for the first time on 2026-08-19** (CUJ-20), against a built
 server on the facility's own hostname, writing to the live database. It gets
@@ -2211,7 +2211,51 @@ whether `src/app/api/` already has the route. Here the backend was finished and
 the last hundred metres were never walked, which is exactly the failure the
 half-converted state of this repo produces.
 
-### 🟠 The customer portal is branded with a fixture, whichever facility you joined
+**FIXED 2026-08-19 — the pet.** `/customer/pets/add` calls `POST /api/pets` with
+the caller's own client ref. Verified against the live database: `pets.ref 9045`,
+Biscuit the Beagle, owner Walk Customer, facility `doggieville-mtl` — and the
+facility was derived by `pets_set_facility` from the owner, because nothing is
+sent and nothing would be honoured if it were.
+
+**NOT FIXED — the booking, and it is not one fetch away.** Two things were wrong
+about the sentence above when it came to bookings, and both were found by trying:
+
+1. **`CustomerBookingModal.tsx` is dead code** — 4,137 lines, imported nowhere,
+   and Knip has been reporting it. `/customer/bookings/new` renders the SHARED
+   `components/bookings/modals/BookingModal`, the same one the facility uses.
+   Editing the customer-named file changes nothing, which is precisely the trap
+   AGENTS.md §Ground warns about: confirm the component is wired in before
+   editing it. Grep the host page for the import.
+2. **The customer path does not create a booking at all.** It builds a
+   `BookingRequest` and hands it to `useBookingRequestsStore` — localStorage —
+   with an instabook-eligibility check deciding `scheduled` vs `pending`. There
+   is **no `booking_requests` table**. So this is not a screen that forgot to
+   call an API; it is a request-and-approval model that exists only in the
+   browser.
+
+Making it real is a design decision plus a migration, not wiring: either a
+`booking_requests` table with RLS (a customer inserts their own, the facility's
+staff read and approve, approval creates the booking) — or the decision that a
+customer books straight into `bookings` with status `request_submitted` and the
+separate queue goes. Do not pick one by editing a component.
+
+**Groundwork that IS in place**, because the booking route was wrong for a
+customer in a way worth fixing regardless of which UI calls it:
+
+- `POST /api/bookings` resolved the facility from `getFacilityContext()`, which
+  falls back to the DEMO facility for any caller with no membership — so a pet
+  owner's booking would have been written against a business they had never
+  heard of. A silent wrong-row write, not a refusal. It now resolves the client
+  FIRST and takes the facility from that client row when the caller has no
+  membership: `facilityContextForClient()`, a parent-row source, which is the
+  second of the two `check:facility-from-session` allows. The staff path is
+  byte-identical.
+- `locations_read` refused a customer, so their booking would have been the only
+  row in the table without a location. Migration `20260819100000` admits a
+  facility's own clients, mirroring what `facilities_read` has done since 20260801130000. Measured on production: the walk customer's readable
+  locations 0 -> 1, a groomer's and an owner's unchanged at 1.
+
+### 🟢 The customer portal names the facility you joined (was 🟠)
 
 `/sign-in`, `/sign-up` and `/join` are correctly branded from the hostname
 (`getBrandingBySlug`). The moment you are **inside** the portal, the sidebar, the
@@ -2231,7 +2275,21 @@ holds, not the fixture"). The customer side has no such guard.
 Two smaller things visible in the same first paint, from the same cause: the
 Getting Started checklist says **"Add your first pet: Done ✓"** directly above
 "My Pets 0 / No pets registered yet", and a brand-new account shows a
-notification badge of 3 and a chat badge of 2.
+notification badge of 3 and a chat badge of 2. Both still stand.
+
+**FIXED 2026-08-19.** The customer layout is already a Server Component and
+already reads `x-facility-slug`, so it now calls the same `getBrandingBySlug()`
+the auth screens use and passes the result down to the provider. Verified on the
+running app: the welcome line reads "Manage your pets and book services at
+Doggieville Mtl", and "Paws & Play" appears nowhere in the portal.
+
+**What deliberately did NOT change: `selectedFacility.id`.** Twenty-eight call
+sites filter fixture arrays by it — bookings, packages, report cards, the
+billing tabs — and a facility uuid matches none of them. Swapping it would turn
+every one of those screens silently empty, which is a worse failure than a wrong
+name because nothing on screen says anything is missing. So the NAME and MARK
+are real and the ID is still the fixture's, and the provider says so in as many
+words. That split goes when the screens behind it read Postgres.
 
 ### 🟡 `check:success-claims` misses "created successfully" — the commoner word order
 

--- a/src/app/api/bookings/route.ts
+++ b/src/app/api/bookings/route.ts
@@ -1,12 +1,16 @@
 import { NextResponse, type NextRequest } from "next/server";
 
+import { getViewer } from "@/lib/auth/viewer";
 import { createServerClient, getCurrentUser } from "@/lib/supabase/server";
 import {
   BOOKING_SELECT,
   bookingToRow,
   rowToBooking,
 } from "@/lib/api/mappers/booking";
-import { getFacilityContext } from "@/lib/api/facility-context";
+import {
+  facilityContextForClient,
+  getFacilityContext,
+} from "@/lib/api/facility-context";
 import type { NewBooking } from "@/types/booking";
 
 // ============================================================================
@@ -103,14 +107,13 @@ export async function POST(request: NextRequest) {
   const input = (await request.json()) as NewBooking;
   const supabase = await createServerClient();
 
-  const facility = await getFacilityContext();
-  if (!facility) {
-    return NextResponse.json({ error: "Facility not found." }, { status: 500 });
-  }
-
   // The client arrives as the app's numeric ref; the row needs the uuid.
   // Resolved through RLS, so a caller who cannot see a client cannot book for
   // them — the lookup simply returns nothing.
+  //
+  // Resolved BEFORE the facility, which is the other way round from how this
+  // read: a customer has no membership, so their client row is what says which
+  // facility the booking is at.
   const { data: client } = await supabase
     .from("clients")
     .select("id")
@@ -122,6 +125,31 @@ export async function POST(request: NextRequest) {
       { error: `No client ${input.clientId} you can book for.` },
       { status: 422 },
     );
+  }
+
+  // ── WHICH FACILITY, AND WHY IT DEPENDS ON WHO IS ASKING ─────────────────
+  //
+  // Staff: their membership, as everywhere else.
+  //
+  // A CUSTOMER: the facility of the client row above. Not a fallback and not a
+  // convenience — getFacilityContext() answers the DEMO facility for a caller
+  // with no membership (its own comment says so), so a pet owner booking
+  // through this route would have had their booking stamped against a business
+  // they have never heard of. Walking CUJ-20 on 2026-08-19 is what surfaced
+  // that; a silent wrong-facility write is worse than a refusal.
+  //
+  // The facility comes from a PARENT ROW already scoped by RLS, which is the
+  // second of the two sources check:facility-from-session allows. Nothing here
+  // reads a facility from the request — `input.facilityId` exists on the type
+  // and is ignored, as it always has been.
+  const viewer = await getViewer().catch(() => null);
+  const facility =
+    viewer && viewer.memberships.length > 0
+      ? await getFacilityContext()
+      : await facilityContextForClient(client.id);
+
+  if (!facility) {
+    return NextResponse.json({ error: "Facility not found." }, { status: 500 });
   }
 
   // Pets are resolved and checked BEFORE the booking is written.

--- a/src/app/customer/_shell.tsx
+++ b/src/app/customer/_shell.tsx
@@ -5,7 +5,10 @@ import { StrangerGate } from "@/components/customer/StrangerGate";
 import Link from "next/link";
 import { MessageCircle } from "lucide-react";
 
-import { CustomerFacilityProvider } from "@/hooks/use-customer-facility";
+import {
+  CustomerFacilityProvider,
+  type RealFacilityBranding,
+} from "@/hooks/use-customer-facility";
 import { SettingsProviderWrapper } from "@/components/providers/ModulesConfigProviderWrapper";
 import { BookingModalProviderWrapper } from "@/components/providers/BookingModalProviderWrapper";
 import { CustomerHeader } from "@/components/customer/CustomerHeader";
@@ -19,13 +22,20 @@ import { CustomerSidebar } from "@/components/customer/CustomerSidebar";
  * run the auth gate. Everything here needs the pathname — which shell to draw,
  * and whether to show the chat bubble — so it stays on the client.
  */
-export function CustomerShell({ children }: { children: React.ReactNode }) {
+export function CustomerShell({
+  children,
+  branding,
+}: {
+  children: React.ReactNode;
+  /** The hostname's facility, resolved by the server layout. */
+  branding?: RealFacilityBranding | null;
+}) {
   const pathname = usePathname();
   const isAuthRoute = pathname?.startsWith("/customer/auth");
 
   return (
     <SettingsProviderWrapper>
-      <CustomerFacilityProvider>
+      <CustomerFacilityProvider branding={branding}>
         <BookingModalProviderWrapper>
           {isAuthRoute ? (
             <div className="flex min-h-screen flex-col">

--- a/src/app/customer/layout.tsx
+++ b/src/app/customer/layout.tsx
@@ -1,6 +1,7 @@
 import { headers } from "next/headers";
 import { redirect } from "next/navigation";
 
+import { getBrandingBySlug } from "@/lib/api/facility-branding";
 import { canAccessCustomerPortal } from "@/lib/auth/viewer";
 import { guardPortal } from "@/lib/auth/portal-gate";
 import { createServerClient } from "@/lib/supabase/server";
@@ -57,5 +58,31 @@ export default async function CustomerLayout({
     if (!clientId) redirect("/join");
   }
 
-  return <CustomerShell>{children}</CustomerShell>;
+  // ── THE PORTAL NAMES THE BUSINESS WHOSE DOOR THEY CAME THROUGH ──────────
+  //
+  // The same read /sign-in, /sign-up and /join have always done. Those three
+  // were correctly branded while everything INSIDE the portal said "Paws &
+  // Play Daycare" to everybody — the shell's provider defaulted to the first
+  // entry in src/data/facilities.ts. Found by walking CUJ-20 on 2026-08-19.
+  //
+  // Resolved here rather than in the shell because the answer is a function of
+  // the hostname, which the server has and the client would have to be told.
+  // `null` on the apex is the honest answer, not a failure.
+  const branding = slug ? await getBrandingBySlug(slug) : null;
+
+  return (
+    <CustomerShell
+      branding={
+        branding && {
+          name: branding.name,
+          slug: branding.slug,
+          logoUrl: branding.logoUrl,
+          primaryColor: branding.primaryColor,
+          accentColor: branding.accentColor,
+        }
+      }
+    >
+      {children}
+    </CustomerShell>
+  );
 }

--- a/src/app/customer/pets/add/page.tsx
+++ b/src/app/customer/pets/add/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
 import { useCurrentCustomer } from "@/lib/api/current-customer";
 import { useRouter } from "next/navigation";
 import Image from "next/image";
@@ -26,6 +27,7 @@ import {
 import { ArrowLeft, Save, Loader2, Dog, Cat, Upload } from "lucide-react";
 import { toast } from "sonner";
 import { FormWizard } from "@/components/forms/FormWizard";
+import type { Pet } from "@/types/pet";
 
 interface PetFormData {
   name: string;
@@ -45,6 +47,7 @@ export default function AddPetPage() {
   const customerId = customer?.id;
 
   const router = useRouter();
+  const queryClient = useQueryClient();
   const { selectedFacility } = useCustomerFacility();
   const [isSaving, setIsSaving] = useState(false);
   const [errors, setErrors] = useState<Record<string, string>>({});
@@ -99,25 +102,27 @@ export default function AddPetPage() {
       return;
     }
 
+    if (customerId === undefined) {
+      // No client record means there is nothing to own the pet. This is
+      // reachable — a signed-in stranger — and saying so beats a write that
+      // cannot succeed.
+      toast.error("Join this facility before adding a pet.");
+      return;
+    }
+
     setIsSaving(true);
 
     try {
-      // TODO: Replace with actual API call
-      const petData = {
+      const createdPet = await createPet({
         ...formData,
         age: Number(formData.age),
         weight: Number(formData.weight),
-      };
-
-      const createdPet = await createPet(petData);
-      if (createdPet?.id) {
-        setNewPetId(createdPet.id);
-        toast.success("Pet added! Let's complete any required forms.");
-        setShowWizard(true);
-      } else {
-        toast.success("Pet added successfully!");
-        router.push("/customer/pets");
-      }
+      });
+      setNewPetId(createdPet.id);
+      toast.success(`${createdPet.name} added. Now any required forms.`);
+      setShowWizard(true);
+      // The list is stale the moment this succeeds.
+      void queryClient.invalidateQueries({ queryKey: ["pets"] });
     } catch (error: unknown) {
       toast.error(error instanceof Error ? error.message : "Failed to add pet");
     } finally {
@@ -125,16 +130,57 @@ export default function AddPetPage() {
     }
   };
 
-  // Placeholder function - replace with actual API call. Return { id } to redirect to pet Forms tab.
+  // ── THIS USED TO WRITE NOTHING ──────────────────────────────────────────
+  //
+  // It was a placeholder that slept a second and returned
+  // `{ id: Date.now() % 100000 }` — an invented number — after which the screen
+  // said "Pet added!" and pushed the owner into a required-forms wizard for a
+  // pet that did not exist. The parameter was named `_petData`; the underscore
+  // was the file admitting the form's contents went nowhere. Found by walking
+  // CUJ-20 on 2026-08-19: a customer could join a facility and then never own
+  // an animal.
+  //
+  // `POST /api/pets` existed the whole time. It is the right route for an owner
+  // and not only for staff: it resolves the owner through an RLS read the
+  // CALLER has to be able to make, so a customer can name their own client
+  // record and nobody else's, and `pets_set_facility` derives the facility from
+  // that owner — which is why no facility is sent from here and none would be
+  // honoured if it were.
+  //
+  // The returned id is `pets.ref`, the app's numeric handle, which is what the
+  // forms wizard and /customer/pets/[petId] both address a pet by.
   const createPet = async (
-    _petData: Omit<PetFormData, "age" | "weight"> & {
+    petData: Omit<PetFormData, "age" | "weight"> & {
       age: number;
       weight: number;
     },
-  ): Promise<{ id: number } | void> => {
-    await new Promise((resolve) => setTimeout(resolve, 1000));
-    // When API returns new pet: return { id: newPet.id };
-    return { id: Date.now() % 100000 }; // temporary: simulate new pet id for Forms redirect
+  ): Promise<Pet> => {
+    const response = await fetch("/api/pets", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        clientId: customerId,
+        name: petData.name.trim(),
+        type: petData.type,
+        breed: petData.breed.trim(),
+        age: petData.age,
+        weight: petData.weight,
+        color: petData.color.trim(),
+        microchip: petData.microchip.trim() || undefined,
+        allergies: petData.allergies.trim() || undefined,
+        specialNeeds: petData.specialNeeds.trim() || undefined,
+        imageUrl: petData.imageUrl || undefined,
+      }),
+    });
+
+    if (!response.ok) {
+      const body = (await response.json().catch(() => ({}))) as {
+        error?: string;
+      };
+      throw new Error(body.error ?? "Could not add that pet.");
+    }
+
+    return (await response.json()) as Pet;
   };
 
   const PetIcon = formData.type === "Cat" ? Cat : Dog;

--- a/src/hooks/use-customer-facility.tsx
+++ b/src/hooks/use-customer-facility.tsx
@@ -36,13 +36,48 @@ const CustomerFacilityContext = createContext<
   CustomerFacilityContextValue | undefined
 >(undefined);
 
+/**
+ * The facility this portal is FOR, resolved from the hostname by the server
+ * layout. `null` on the apex, where there is no facility.
+ */
+export interface RealFacilityBranding {
+  name: string;
+  slug: string;
+  logoUrl: string | null;
+  primaryColor: string | null;
+  accentColor: string | null;
+}
+
 export function CustomerFacilityProvider({
   children,
+  branding,
 }: {
   children: ReactNode;
+  /** From `getBrandingBySlug()` in the customer layout. */
+  branding?: RealFacilityBranding | null;
 }) {
-  // Get available facilities for the customer
-  // TODO: Replace with actual API call to get customer's facilities
+  // ── WHY THE FIXTURE IS STILL HERE, AND WHAT IT IS STILL FOR ─────────────
+  //
+  // Walking CUJ-20 on 2026-08-19 found this provider naming the WRONG BUSINESS
+  // to every customer: it mapped src/data/facilities.ts, filtered to active,
+  // and defaulted to `availableFacilities[0]` — so somebody who joined
+  // Doggieville Mtl saw "Paws & Play Daycare" in the sidebar, the header, the
+  // switcher and the welcome line. /sign-in, /sign-up and /join were correct
+  // the whole time, because those read the hostname.
+  //
+  // So the NAME and the MARK now come from the hostname too, via
+  // getBrandingBySlug() in the server layout.
+  //
+  // The `id` deliberately does NOT. Twenty-eight call sites filter fixture
+  // arrays by `selectedFacility.id` — bookings, packages, report cards, the
+  // billing tabs — and a facility uuid matches none of them. Changing it would
+  // turn every one of those screens silently empty, which is a worse failure
+  // than a wrong name because nothing on screen says anything is missing. The
+  // id stays the fixture's until the screens behind it read Postgres; see
+  // docs/quality/debt-map.md.
+  //
+  // Stated plainly because the halves disagree: what you SEE is real, what the
+  // fixture screens FILTER BY is not.
   const availableFacilities: FacilityBranding[] = useMemo(
     () =>
       facilities
@@ -50,9 +85,9 @@ export function CustomerFacilityProvider({
         .map((f) => ({
           id: f.id,
           name: f.name,
-          logo: undefined, // TODO: Get from facility settings/API - defaults to Yipyy logo in header
-          primaryColor: undefined, // TODO: Get from facility settings
-          secondaryColor: undefined, // TODO: Get from facility settings
+          logo: undefined,
+          primaryColor: undefined,
+          secondaryColor: undefined,
           contact: f.contact,
         })),
     [],
@@ -96,10 +131,26 @@ export function CustomerFacilityProvider({
     }
   };
 
-  const selectedFacility =
+  const fixtureFacility =
     selectedFacilityId !== null
       ? (availableFacilities.find((f) => f.id === selectedFacilityId) ?? null)
       : null;
+
+  // The real facility's identity over the fixture's id. On the apex there is no
+  // hostname facility, so the fixture stands alone and this is a no-op — which
+  // is every customer who signed up before facilities had their own addresses.
+  const selectedFacility = useMemo(() => {
+    if (!branding) return fixtureFacility;
+    return {
+      id: fixtureFacility?.id ?? availableFacilities[0]?.id ?? 0,
+      name: branding.name,
+      logo: branding.logoUrl ?? undefined,
+      primaryColor: branding.primaryColor ?? undefined,
+      secondaryColor: branding.accentColor ?? undefined,
+      contact: fixtureFacility?.contact ??
+        availableFacilities[0]?.contact ?? { email: "", phone: "" },
+    };
+  }, [branding, fixtureFacility, availableFacilities]);
 
   return (
     <CustomerFacilityContext.Provider

--- a/src/lib/api/facility-context.ts
+++ b/src/lib/api/facility-context.ts
@@ -35,9 +35,14 @@ import { DEFAULT_TIMEZONE } from "@/lib/time/facility-time";
 //
 // A CUSTOMER has no membership by design (viewer.ts), and a platform admin may
 // have none either. Both fall back to the demo facility, which is exactly
-// today's behaviour — so this change cannot regress a single-facility project,
-// and the fallback is what to delete when the customer portal learns to name
-// the facility it is booking at.
+// today's behaviour — so this change cannot regress a single-facility project.
+//
+// That fallback was the reason a customer could not be allowed to book: walking
+// CUJ-20 on 2026-08-19 showed a pet owner's booking would have been stamped
+// with the DEMO facility rather than the one they joined — a silent wrong-row
+// write, which is worse than a refusal. `facilityContextForClient()` below is
+// the answer for that caller, and it is the function a customer route should
+// use instead of this one.
 //
 // ── NOT A SECURITY BOUNDARY, AND THAT MATTERS HERE ────────────────────────
 //
@@ -120,6 +125,74 @@ export async function getFacilityContext(
     .eq("facility_id", facility.id)
     .eq("is_primary", true)
     .maybeSingle();
+
+  return {
+    facilityId: facility.id,
+    locationId: location?.id ?? null,
+    timeZone: facility.timezone ?? DEFAULT_TIMEZONE,
+    name: facility.name,
+    legacyRef: Number.isFinite(legacyRef) ? legacyRef : null,
+  };
+}
+
+/**
+ * The facility a CLIENT belongs to, for a caller who has no membership.
+ *
+ * ── WHY A SECOND FUNCTION AND NOT A FLAG ──────────────────────────────────
+ *
+ * `getFacilityContext()` answers "which facility is this MEMBER working in".
+ * A pet owner is not a member of anything, so the honest answer for them comes
+ * from a different place: the client row they own. Folding that into the same
+ * function would mean one call site could silently get either answer depending
+ * on who called it, and the wrong one is a booking written against the demo
+ * facility.
+ *
+ * ── THE FACILITY COMES FROM THE PARENT ROW, WHICH IS THE SANCTIONED PATH ──
+ *
+ * `check:facility-from-session` allows exactly two sources: the session, or a
+ * parent row already scoped by RLS. This is the second. The caller must have
+ * been able to READ the client — `clients_read` admits a customer only their
+ * own record — so a person naming somebody else's client id gets nothing back
+ * and no context at all, rather than a facility they have no business in.
+ *
+ * @param clientRowId the client's uuid, already resolved through RLS by the caller
+ */
+export async function facilityContextForClient(
+  clientRowId: string,
+): Promise<FacilityContext | null> {
+  const supabase = await createServerClient();
+
+  // Through the client, not around it. `facilities_read` admits a client of the
+  // facility (private.client_facility_ids, 20260801130000), so this read
+  // succeeds for the owner and for nobody else.
+  const { data: client } = await supabase
+    .from("clients")
+    .select("facility_id, facilities(id, timezone, name, legacy_id)")
+    .eq("id", clientRowId)
+    .maybeSingle();
+
+  const facility = client?.facilities as
+    | {
+        id: string;
+        timezone: string | null;
+        name: string;
+        legacy_id: string | null;
+      }
+    | null
+    | undefined;
+  if (!facility) return null;
+
+  // `locations_read` admits the facility's own clients as of 20260819100000.
+  // Before that this was always null for a customer, which is why their
+  // bookings would have been the only ones in the table without a location.
+  const { data: location } = await supabase
+    .from("locations")
+    .select("id")
+    .eq("facility_id", facility.id)
+    .eq("is_primary", true)
+    .maybeSingle();
+
+  const legacyRef = Number(facility.legacy_id);
 
   return {
     facilityId: facility.id,

--- a/supabase/migrations/20260819100000_a_customer_can_see_where_they_are_dropping_their_dog.sql
+++ b/supabase/migrations/20260819100000_a_customer_can_see_where_they_are_dropping_their_dog.sql
@@ -1,0 +1,43 @@
+-- ============================================================================
+-- A customer may read the locations of the facility they are a client of.
+--
+-- ── WHY ───────────────────────────────────────────────────────────────────
+--
+-- Walking CUJ-20 on 2026-08-19 found the customer booking path writing nothing,
+-- and wiring it to POST /api/bookings exposed this: `bookings.location_id` is
+-- resolved from the facility's primary location through a read the CALLER has
+-- to be able to make, and `locations_read` admitted only members and platform
+-- admins. A customer therefore books with no location at all — 245 of the 250
+-- bookings in this database carry one, so the customer's would have been the
+-- odd row out, and the ops board filters by it.
+--
+-- `facilities_read` has admitted a client of the facility since
+-- 20260801130000, through `private.client_facility_ids()`. This is the same
+-- sentence applied to the table one level down; the helper already exists and
+-- is already granted to `authenticated`.
+--
+-- ── WHAT THIS DISCLOSES ───────────────────────────────────────────────────
+--
+-- `locations` holds id, facility_id, name, is_primary, timezone and legacy_id.
+-- No address, no phone, no staffing. So a customer of Doggieville Mtl learns
+-- that Doggieville Mtl has a location called "Main" in America/Toronto — which
+-- is on their booking confirmation anyway, and which they cannot learn about
+-- any facility they are not a client of.
+--
+-- Deliberately SELECT only. Insert, update and delete keep requiring
+-- `manage_services`: a customer may see where they are dropping their dog off,
+-- and may not rename it.
+-- ============================================================================
+
+drop policy if exists locations_read on public.locations;
+
+create policy locations_read on public.locations
+  for select to authenticated
+  using (
+    private.is_platform_admin()
+    or facility_id in (select private.member_facility_ids())
+    or facility_id in (select private.client_facility_ids())
+  );
+
+comment on policy locations_read on public.locations is
+  'Platform admins, members of the facility, and its own clients. A customer needs the location their booking is at; see 20260819100000.';


### PR DESCRIPTION
Two of the three things the [CUJ-20 walk](https://github.com/Yipyy-Inc/puneet/commit/c3541de2) found. The third turned out not to be what I said it was — that's below and in the debt map.

## Adding a pet writes

`/customer/pets/add` defined its own `createPet` a hundred lines below the form:

```ts
const createPet = async (_petData) => {
  await new Promise((resolve) => setTimeout(resolve, 1000));
  return { id: Date.now() % 100000 };      // an invented id
};
```

It now calls `POST /api/pets` — which existed the whole time, is RLS-scoped, and resolves the owner through a read the **caller** has to be able to make, so a customer can name their own client record and nobody else's.

**Verified against the live database:**

```
pets.ref 9045 · Biscuit · Beagle · owner Walk Customer · facility doggieville-mtl
```

The facility was derived by `pets_set_facility` from the owner — nothing sends one, and nothing would be honoured if it did.

## The portal names the facility you joined

Sign-in, sign-up and join were correctly branded from the hostname. **Inside** the portal, the sidebar, header, switcher and welcome line all said **"Paws & Play Daycare"** — `src/data/facilities.ts`, entry zero — to somebody who had joined Doggieville Mtl.

The customer layout is already a Server Component and already reads `x-facility-slug`, so it now calls the same `getBrandingBySlug()` the auth screens use. Verified on the running app: *"Manage your pets and book services at Doggieville Mtl"*, and "Paws & Play" appears nowhere.

**`selectedFacility.id` deliberately does not change.** Twenty-eight call sites filter fixture arrays by it, and a facility uuid matches none of them — swapping it would turn those screens silently empty, which is worse than a wrong name because nothing on screen would say anything was missing. Name and mark are real, the id is still the fixture's, and the provider says so in as many words.

## Groundwork, because the booking route was wrong for a customer

`POST /api/bookings` took its facility from `getFacilityContext()`, which falls back to the **demo facility** for a caller with no membership. A pet owner's booking would have been written against a business they had never heard of — a silent wrong-row write, not a refusal.

It now resolves the client first and takes the facility from that client row when the caller has no membership. That's a **parent row already scoped by RLS** — the second of the two sources `check:facility-from-session` allows. The staff path is byte-identical.

`locations_read` refused a customer, so their booking would have been the only row in the table without a location. Migration `20260819100000` admits a facility's own clients, mirroring what `facilities_read` has done since `20260801130000`. `locations` holds no address or contact — only a name, a timezone and flags. Measured on production:

```
walk customer   locations 0 → 1
a groomer       locations 1 → 1     (unchanged)
an owner        locations 1 → 1     (unchanged)
```

## ⚠️ What I got wrong, and what booking actually needs

I said the customer booking screen was one fetch from working. **It isn't**, for two reasons I found by trying:

- **`CustomerBookingModal.tsx` is dead code** — 4,137 lines, imported nowhere, and Knip has been reporting it. `/customer/bookings/new` renders the *shared* `components/bookings/modals/BookingModal`. I edited the customer-named file first; that edit is reverted. This is exactly the trap AGENTS.md §Ground warns about — confirm the component is wired in before editing it.
- **The live path doesn't create a booking at all.** It builds a `BookingRequest` and hands it to `useBookingRequestsStore` — localStorage — with an instabook check choosing `scheduled` vs `pending`. There is **no `booking_requests` table**.

So it's a request-and-approval model that exists only in the browser. Making it real is a design decision plus a migration — either `booking_requests` with RLS (customer inserts their own, the facility's staff approve, approval creates the booking), or customers book straight into `bookings` with status `request_submitted` and the queue goes. Not something to settle by editing a component.

## Verified

- `typecheck` / `lint` / `format:check` / `build` green; all seven project gates pass, including `check:facility-from-session`.
- **62 e2e passed / 1 skipped / 0 failed** against a built server — identical to before the shared-route change, which is the check that matters given `/api/bookings` is shared with the facility side.
- Walked the journey again end to end on the built server: sign-in → portal branded correctly → add a pet → the pet appears in the booking wizard's pet picker, read from Postgres.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
