### PR TITLE
fix(bookings): the care panels read the fields the wizard writes

### DIFF
--- a/docs/quality/debt-map.md
+++ b/docs/quality/debt-map.md
@@ -2166,6 +2166,71 @@ management's two-admin restore, scheduled support messages and
 four real roles, but `mfaRequiredByRole` is still a localStorage preference that
 enforces nothing — enrolment is WorkOS's to require.
 
+### 🟢 The booking page's care panels read what the wizard writes (was 🔴)
+
+Reported from the running app on 2026-08-19: "there were things missing in the
+facility side booking history — we designed the page to have a lot of details as
+it was with demo data." Three separate causes, and only one of them was a bug.
+
+**1. They opened a test row.** Special Requests read `[e2e boarding-occupancy]`
+and its `details` was `{}`. See the entry below.
+
+**2. Mock cleanup, exactly as suspected.** `src/data/bookings.ts` has 26
+bookings and **two** carry hand-written `feedingInstructions` /
+`medicationInstructions` arrays. Those two were what made the page look full.
+Measured against Postgres: 0 of 250 bookings had `feedingSchedule`,
+`medications`, `extraServices` or `groomingAddOns`; 174 had empty `details`.
+Nothing is dropped on write — `bookingToRow` routes anything outside
+`COLUMN_FIELDS` into `details` — so it is "nobody has entered one", not a lost
+write.
+
+**3. A real wiring gap, and this one is fixed.** The panels rendered
+`booking.feedingInstructions` and `booking.medicationInstructions`; the wizard
+collects and stores `booking.feedingSchedule` and `booking.medications`.
+Different names **and different types** — so the panels could never fill from a
+booking made in this app, whatever anybody typed.
+
+The two shapes are different on purpose and both are worth keeping:
+`FeedingScheduleItem` is what the OWNER asked for (occasions, prep, allergies,
+what to do if the dog refuses); `FeedingEntry` is what STAFF DID (a meal, a
+status, who completed it). So `src/lib/bookings/care-instructions.ts` projects
+the first into the second for display, with `status: "pending"` — asked for, not
+yet done — rather than renaming either.
+
+**And the panels stopped offering actions that persist nothing.** `handleLog`,
+`handleAdd`, `handleAdminister` and `handleAddNote` set component state and
+toast; a reload loses all of it. That was invisible while the panels were empty
+and became reachable the moment they started rendering real instructions, so
+`canLog={false}` hides Add Meal, Add Medication, Log meal and Give. **Logging a
+feeding and administering a dose are not built** — the highest-value thing to
+build next on this page, because staff will expect to tick these off.
+
+Still fixture-backed on the same page, and visibly wrong next to real data: the
+**Guest Journal** panel renders a different pet's stay (dates, kennel and owner
+from `src/data/boarding.ts`), and `boardingGuestForPrint` falls back to a
+synthesised guest for every real booking.
+
+### 🟢 Four e2e bookings were sitting in the live bookings list (was invisible)
+
+The suite is better behaved than it looked: **211 of 215** `[e2e …]` bookings
+were already cancelled. `bookings` has no DELETE policy by design — a booking is
+cancelled, not erased — so cancelled rows accumulate, and that is intended.
+
+**Four were still `confirmed`**, from runs that died before `afterAll` could
+execute. Those four showed on the facility's bookings screen as real work and
+held their kennels, and one of them is the booking that prompted the report
+above.
+
+**Do instead: sweep at BOTH ends.** `tests/e2e/_sweep.ts` cancels every booking
+carrying a spec's marker, and `boarding-occupancy.spec.ts` now calls it from
+`beforeAll` as well as `afterAll`. `role-editor-writes.spec.ts` concluded that
+cleaning up at the start is not _enough_ — it is not, but it is the only thing
+that heals a run which never reached its end. Together they are
+self-correcting; alone, neither is. Adopt the same pair in the other seventeen
+specs that create marked bookings.
+
+Cleared by hand at the same time: live bookings 38 -> 34, all real.
+
 ### 🟢 The customer journey reaches Postgres (was 🔴, then 🟠)
 
 **Walked end to end for the first time on 2026-08-19** (CUJ-20), against a built

--- a/src/app/facility/dashboard/clients/[id]/bookings/[bookingId]/page.tsx
+++ b/src/app/facility/dashboard/clients/[id]/bookings/[bookingId]/page.tsx
@@ -50,6 +50,10 @@ import { boardingGuests, type BoardingGuest } from "@/data/boarding";
 import { PrintKennelCardsModal } from "@/components/facility/boarding/kennel-card-print";
 import { StatusBadge } from "@/components/ui/StatusBadge";
 import { InvoicePanel } from "@/components/bookings/InvoicePanel";
+import {
+  feedingEntriesFromSchedule,
+  medicationEntriesFromItems,
+} from "@/lib/bookings/care-instructions";
 import { BookingNotes } from "@/components/bookings/BookingNotes";
 import { BookingModal } from "@/components/bookings/modals/BookingModal";
 import { ProcessPaymentModal } from "@/components/bookings/modals/ProcessPaymentModal";
@@ -1219,9 +1223,27 @@ export default function ClientBookingDetailPage({
                       id={careSectionDomIds.feeding}
                       className="rounded-xl transition-shadow"
                     >
+                      {/* ── WHAT THE OWNER ASKED FOR ─────────────────────
+                          `feedingInstructions` is the care CHECKLIST, and no
+                          booking made in this app has ever carried one — the
+                          wizard stores `feedingSchedule`, which is a different
+                          field of a different type. So these panels were empty
+                          for every real booking, and looked right only against
+                          the two hand-written entries in src/data/bookings.ts.
+
+                          The fixture field stays first so those demo bookings
+                          still render; everything else falls through to the
+                          owner's schedule, projected into the same shape. */}
                       <FeedingSection
-                        entries={booking.feedingInstructions ?? []}
+                        entries={
+                          booking.feedingInstructions?.length
+                            ? booking.feedingInstructions
+                            : feedingEntriesFromSchedule(
+                                booking.feedingSchedule,
+                              )
+                        }
                         required={feedingMode === "required"}
+                        canLog={false}
                       />
                     </div>
                   )}
@@ -1231,9 +1253,14 @@ export default function ClientBookingDetailPage({
                       className="rounded-xl transition-shadow"
                     >
                       <MedicationSection
-                        entries={booking.medicationInstructions ?? []}
+                        entries={
+                          booking.medicationInstructions?.length
+                            ? booking.medicationInstructions
+                            : medicationEntriesFromItems(booking.medications)
+                        }
                         required={medicationMode === "required"}
                         bookingId={booking.id}
+                        canLog={false}
                       />
                     </div>
                   )}

--- a/src/components/bookings/FeedingSection.tsx
+++ b/src/components/bookings/FeedingSection.tsx
@@ -30,6 +30,19 @@ import type { FeedingEntry } from "@/types/booking";
 interface FeedingSectionProps {
   entries: FeedingEntry[];
   required?: boolean;
+  /**
+   * Whether staff may log a meal or add one here.
+   *
+   * FALSE on the booking page, and that is not a permission decision — it is
+   * that neither action writes anything. `handleLog` and `handleAdd` below set
+   * component state and toast; a reload loses both. That was invisible while
+   * this panel was empty for every real booking, and became reachable the
+   * moment it started rendering the owner's schedule, so the controls are
+   * hidden rather than left to lose somebody's work.
+   *
+   * Recorded in docs/quality/debt-map.md: logging a feeding is not built.
+   */
+  canLog?: boolean;
 }
 
 const FEEDBACK_OPTIONS = facilityConfig.careTaskFeedback.feeding;
@@ -59,7 +72,11 @@ function fmtTimestamp(ts: string) {
 
 let _feedId = 100;
 
-export function FeedingSection({ entries, required }: FeedingSectionProps) {
+export function FeedingSection({
+  entries,
+  required,
+  canLog = true,
+}: FeedingSectionProps) {
   const [items, setItems] = useState(entries);
   const [addOpen, setAddOpen] = useState(false);
   const [newEntry, setNewEntry] = useState({
@@ -127,15 +144,17 @@ export function FeedingSection({ entries, required }: FeedingSectionProps) {
               </Badge>
             )}
           </CardTitle>
-          <Button
-            variant="outline"
-            size="sm"
-            className="h-7 gap-1 text-[11px]"
-            onClick={() => setAddOpen(!addOpen)}
-          >
-            <Plus className="size-3" />
-            Add Meal
-          </Button>
+          {canLog && (
+            <Button
+              variant="outline"
+              size="sm"
+              className="h-7 gap-1 text-[11px]"
+              onClick={() => setAddOpen(!addOpen)}
+            >
+              <Plus className="size-3" />
+              Add Meal
+            </Button>
+          )}
         </div>
       </CardHeader>
       <CardContent className="pt-0">
@@ -245,7 +264,9 @@ export function FeedingSection({ entries, required }: FeedingSectionProps) {
           <div className="py-6 text-center">
             <UtensilsCrossed className="text-muted-foreground/20 mx-auto size-8" />
             <p className="text-muted-foreground mt-2 text-xs">
-              No feeding instructions — click &quot;Add Meal&quot; to add
+              {canLog
+                ? "No feeding instructions — click “Add Meal” to add"
+                : "No feeding instructions were given for this booking"}
             </p>
           </div>
         ) : (
@@ -297,7 +318,7 @@ export function FeedingSection({ entries, required }: FeedingSectionProps) {
                         </p>
                       )}
                     </div>
-                  ) : (
+                  ) : canLog ? (
                     <Select onValueChange={(v) => handleLog(entry.id, v)}>
                       <SelectTrigger className="h-7 w-[140px] text-[11px]">
                         <SelectValue placeholder="Log meal..." />
@@ -314,7 +335,7 @@ export function FeedingSection({ entries, required }: FeedingSectionProps) {
                         ))}
                       </SelectContent>
                     </Select>
-                  )}
+                  ) : null}
                 </div>
                 {entry.notes && (
                   <p className="text-muted-foreground bg-muted/30 mt-1 ml-6 rounded-sm px-2 py-1 text-[11px]">

--- a/src/components/bookings/MedicationSection.tsx
+++ b/src/components/bookings/MedicationSection.tsx
@@ -46,6 +46,19 @@ interface MedicationSectionProps {
    * button. Source (incidentId) is kept in the data only, never shown to staff.
    */
   bookingId?: number;
+  /**
+   * Whether staff may record a dose or add a medication here.
+   *
+   * FALSE on the booking page. Not a permission decision: `handleAdminister`
+   * and `handleAdd` set component state and toast, and a reload loses both.
+   * That was invisible while this panel was empty for every real booking, and
+   * became reachable the moment it started rendering the owner's medication
+   * list — so the controls are hidden rather than left to lose a dose record,
+   * which is the worst thing on this page to lose.
+   *
+   * Recorded in docs/quality/debt-map.md: administering a dose is not built.
+   */
+  canLog?: boolean;
 }
 
 // Map an incident-sourced medication onto the booking medication shape so the
@@ -121,6 +134,7 @@ export function MedicationSection({
   entries,
   required,
   bookingId,
+  canLog = true,
 }: MedicationSectionProps) {
   const [meds, setMeds] = useState<MedicationEntry[]>(() => [
     ...entries,
@@ -236,15 +250,17 @@ export function MedicationSection({
               </Badge>
             )}
           </CardTitle>
-          <Button
-            variant="outline"
-            size="sm"
-            className="h-7 gap-1 text-[11px]"
-            onClick={() => setAddOpen(!addOpen)}
-          >
-            <Plus className="size-3" />
-            Add Medication
-          </Button>
+          {canLog && (
+            <Button
+              variant="outline"
+              size="sm"
+              className="h-7 gap-1 text-[11px]"
+              onClick={() => setAddOpen(!addOpen)}
+            >
+              <Plus className="size-3" />
+              Add Medication
+            </Button>
+          )}
         </div>
       </CardHeader>
       <CardContent className="pt-0">
@@ -383,7 +399,9 @@ export function MedicationSection({
           <div className="py-6 text-center">
             <Pill className="text-muted-foreground/20 mx-auto size-8" />
             <p className="text-muted-foreground mt-2 text-xs">
-              No medications — click &quot;Add Medication&quot; to add
+              {canLog
+                ? "No medications — click “Add Medication” to add"
+                : "No medications were given for this booking"}
             </p>
           </div>
         ) : (
@@ -465,7 +483,7 @@ export function MedicationSection({
                             </p>
                           )}
                         </div>
-                        {dose.status === "pending" && (
+                        {canLog && dose.status === "pending" && (
                           <div className="flex items-center gap-1">
                             {/* Note popover */}
                             <Popover

--- a/src/lib/bookings/care-instructions.ts
+++ b/src/lib/bookings/care-instructions.ts
@@ -1,0 +1,154 @@
+import type {
+  FeedingEntry,
+  FeedingScheduleItem,
+  MedicationEntry,
+  MedicationItem,
+} from "@/types/booking";
+
+// ============================================================================
+// The owner's care instructions, in the shape the booking page renders.
+//
+// ── THE GAP THIS CLOSES ───────────────────────────────────────────────────
+//
+// Reported from the running app: the booking detail page's FEEDING
+// INSTRUCTIONS and MEDICATIONS panels were empty, and had been for every
+// booking since the migration.
+//
+// They read `booking.feedingInstructions` and `booking.medicationInstructions`.
+// The booking wizard collects and stores `booking.feedingSchedule` and
+// `booking.medications`. Different names AND different types — so the panels
+// could never fill from a booking made in this app. The only things that ever
+// populated them were two hand-written entries in `src/data/bookings.ts`,
+// which is why it looked right with demo data and empty with real data.
+//
+// ── WHY A MAPPING RATHER THAN A RENAME ────────────────────────────────────
+//
+// The two shapes are different on purpose and both are worth keeping:
+//
+//   FeedingScheduleItem  what the OWNER asked for — occasions, components,
+//                        prep, allergies, what to do if the dog refuses.
+//                        Collected once, at booking.
+//   FeedingEntry         what STAFF DO — a meal at a time, with a status, who
+//                        completed it and how it went.
+//
+// Renaming one to the other would lose the distinction and, worse, would imply
+// the owner's instructions are a completed care record. So the schedule is
+// projected into the entry shape for display, with `status: "pending"`: this is
+// what has been asked for, and none of it has been done yet.
+//
+// Pure and total: no dates, no ids from outside, nothing that can throw. That
+// is what lets the page call it during render.
+// ============================================================================
+
+/**
+ * `twice_daily` -> "Twice daily".
+ *
+ * The enums are stored as snake_case and were rendering raw on the booking
+ * page, which reads as a leaked database value rather than a dose.
+ */
+function humanise(value: string | null | undefined): string {
+  if (!value) return "";
+  const spaced = value.replace(/_/g, " ").trim();
+  return spaced.charAt(0).toUpperCase() + spaced.slice(1);
+}
+
+/** "1.5 cups Kibble + 1 scoop Topper", or "" when a meal names nothing. */
+function describeAmount(
+  components: FeedingScheduleItem["occasions"][number]["components"],
+): string {
+  return components
+    .map((c) => [c.amount, c.unit].filter(Boolean).join(" ").trim())
+    .filter(Boolean)
+    .join(" + ");
+}
+
+function describeFood(
+  components: FeedingScheduleItem["occasions"][number]["components"],
+  source: FeedingScheduleItem["source"],
+): string {
+  const named = components.map((c) => c.name.trim()).filter(Boolean);
+  if (named.length > 0) return [...new Set(named)].join(", ");
+  // `source` is the fallback rather than a blank: "owner" or "facility" still
+  // tells the person at the desk where the food comes from.
+  return humanise(source);
+}
+
+/**
+ * One display entry per feeding OCCASION, not per schedule item.
+ *
+ * A schedule is "breakfast and dinner, this food, these allergies" — one item
+ * covering the whole stay. The panel lists meals, so a two-occasion schedule
+ * becomes two rows. Collapsing them into one would hide the second meal.
+ */
+export function feedingEntriesFromSchedule(
+  schedule: FeedingScheduleItem[] | undefined,
+): FeedingEntry[] {
+  if (!schedule?.length) return [];
+
+  return schedule.flatMap((item) =>
+    item.occasions.map((occasion) => {
+      // Everything the owner said that a meal row can carry, in the order
+      // somebody feeding the dog would want it.
+      const notes = [
+        item.prepNotes?.trim(),
+        item.feedingInstruction?.trim(),
+        item.allergies.length > 0
+          ? `Allergies: ${item.allergies.join(", ")}`
+          : "",
+        item.refusalNotes?.trim()
+          ? `If refused: ${item.refusalNotes.trim()}`
+          : "",
+        item.notes?.trim(),
+      ]
+        .filter(Boolean)
+        .join(" · ");
+
+      return {
+        id: `sched-${item.id}-${occasion.id}`,
+        label: occasion.label,
+        time: occasion.time,
+        amount: describeAmount(occasion.components),
+        foodType: describeFood(occasion.components, item.source),
+        instructions: notes || undefined,
+        // Asked for, not yet done. The panel's own status vocabulary.
+        status: "pending" as FeedingEntry["status"],
+      };
+    }),
+  );
+}
+
+/** The owner's medications, as the panel's dose rows. */
+export function medicationEntriesFromItems(
+  medications: MedicationItem[] | undefined,
+): MedicationEntry[] {
+  if (!medications?.length) return [];
+
+  return medications.map((med) => {
+    const instructions = [
+      med.purpose?.trim() ? `For ${med.purpose.trim()}` : "",
+      med.adminNotes?.trim(),
+      med.givenWithNotes?.trim(),
+      med.frequencyNotes?.trim(),
+      med.notes?.trim(),
+    ]
+      .filter(Boolean)
+      .join(" · ");
+
+    return {
+      id: med.id,
+      name: med.name,
+      // Strength belongs with the amount — "1 tablet" alone is not a dose.
+      dosage: [med.amount, med.strength].filter(Boolean).join(" ").trim(),
+      method: humanise(med.form),
+      frequency: humanise(med.frequency),
+      times: med.times,
+      instructions: instructions || undefined,
+      // `isHighRisk` is the owner's flag and `isCritical` is the panel's; they
+      // mean the same thing to the person holding the pill.
+      isCritical: med.isHighRisk === true,
+      // No doses: a dose is a record of something administered, and nothing
+      // has been. An empty list is the truthful start.
+      doses: [],
+    };
+  });
+}

--- a/tests/e2e/_sweep.ts
+++ b/tests/e2e/_sweep.ts
@@ -1,0 +1,95 @@
+import type { Browser } from "@playwright/test";
+
+import { ACCOUNTS, signIn } from "./_auth";
+
+// ============================================================================
+// Cancel every booking a spec's marker owns.
+//
+// ── WHY THIS IS SHARED, AND WHY IT RUNS TWICE ─────────────────────────────
+//
+// `bookings` has no DELETE policy, by design — a booking is cancelled, not
+// erased. So a spec that creates one can only cancel it, and the cancelled row
+// stays. That is fine: it is inert, and it is what the product would do.
+//
+// What is NOT fine is a booking left CONFIRMED. It shows on the facility's
+// bookings screen as real work, and it holds its kennel. Reported from the
+// running app on 2026-08-19: somebody opened a booking detail page, found it
+// nearly empty, and asked whether the product had lost their data — it was a
+// leftover `[e2e boarding-occupancy]` row, one of four.
+//
+// All four came from the same cause: the run died before `afterAll` could
+// execute. `role-editor-writes.spec.ts` records the same lesson from the other
+// direction — a leftover grant sent five unrelated specs red — and concludes
+// that cleaning up at the start is not ENOUGH. It is not. But it is the only
+// thing that heals a run that never reached its end, so the answer is both:
+//
+//   beforeAll  heal whatever the last run left behind
+//   afterAll   put back what this run took
+//
+// Neither alone is sufficient, and together they are self-correcting: a crashed
+// run is repaired by the next one rather than accumulating until somebody
+// notices from a screenshot.
+//
+// ── IT NEVER THROWS ───────────────────────────────────────────────────────
+//
+// A sweep that fails must not fail the suite: in `beforeAll` it would mask the
+// real tests, and in `afterAll` it would turn a green run red over tidying. It
+// logs what it could not do and returns.
+// ============================================================================
+
+interface SweepableBooking {
+  id: number;
+  specialRequests?: string;
+  status: string;
+}
+
+/**
+ * Cancel every non-cancelled booking whose `specialRequests` contains `marker`.
+ *
+ * @param marker the spec's own tag, e.g. `[e2e boarding-occupancy]`
+ * @returns how many were cancelled, for the log line
+ */
+export async function cancelBookingsMarked(
+  browser: Browser,
+  marker: string,
+  phase: "before" | "after" = "after",
+): Promise<number> {
+  const page = await browser.newPage();
+  try {
+    await signIn(page, ACCOUNTS.owner);
+
+    const response = await page.request.get("/api/bookings");
+    if (!response.ok()) {
+      console.log(`sweep(${phase}): could not read bookings, skipping`);
+      return 0;
+    }
+
+    const bookings = (await response.json()) as SweepableBooking[];
+    const mine = bookings.filter(
+      (b) => b.specialRequests?.includes(marker) && b.status !== "cancelled",
+    );
+
+    let cancelled = 0;
+    for (const b of mine) {
+      const res = await page.request.patch(`/api/bookings/${b.id}`, {
+        data: { status: "cancelled" },
+      });
+      if (res.ok()) cancelled++;
+      else console.log(`sweep(${phase}): id ${b.id} -> ${res.status()}`);
+    }
+
+    if (mine.length > 0) {
+      console.log(
+        `sweep(${phase}): ${cancelled}/${mine.length} booking(s) cancelled for ${marker}`,
+      );
+    }
+    return cancelled;
+  } catch (error) {
+    console.log(
+      `sweep(${phase}): ${error instanceof Error ? error.message : String(error)}`,
+    );
+    return 0;
+  } finally {
+    await page.close();
+  }
+}

--- a/tests/e2e/boarding-occupancy.spec.ts
+++ b/tests/e2e/boarding-occupancy.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from "@playwright/test";
 
 import { ACCOUNTS, signIn } from "./_auth";
+import { cancelBookingsMarked } from "./_sweep";
 
 // ============================================================================
 // A kennel holds one booking at a time, over real HTTP.
@@ -65,34 +66,17 @@ function stayBody(overrides: Record<string, unknown> = {}) {
 
 test.describe.configure({ mode: "serial" });
 
+// Both ends, on purpose: `afterAll` puts back what this run took, `beforeAll`
+// heals whatever a run that died mid-flight left behind. Four confirmed stays
+// from crashed runs sat in the live bookings list until 2026-08-19, when
+// somebody opened one and asked whether the product had lost their data. See
+// tests/e2e/_sweep.ts.
+test.beforeAll(async ({ browser }) => {
+  await cancelBookingsMarked(browser, MARKER, "before");
+});
+
 test.afterAll(async ({ browser }) => {
-  const page = await browser.newPage();
-  try {
-    await signIn(page, ACCOUNTS.owner);
-    const bookings = (await (
-      await page.request.get("/api/bookings")
-    ).json()) as {
-      id: number;
-      specialRequests?: string;
-      status: string;
-    }[];
-
-    const mine = bookings.filter(
-      (b) => b.specialRequests?.includes(MARKER) && b.status !== "cancelled",
-    );
-
-    let cancelled = 0;
-    for (const b of mine) {
-      const res = await page.request.patch(`/api/bookings/${b.id}`, {
-        data: { status: "cancelled" },
-      });
-      if (res.ok()) cancelled++;
-      else console.log(`cleanup: id ${b.id} -> ${res.status()}`);
-    }
-    console.log(`cleanup: ${cancelled}/${mine.length} stay(s) cancelled`);
-  } finally {
-    await page.close();
-  }
+  await cancelBookingsMarked(browser, MARKER, "after");
 });
 
 test.describe("boarding occupancy", () => {


### PR DESCRIPTION
> *"There were things missing in the facility side booking history — we designed the page to have a lot of details as it was with demo data. Idk if that is just temporary."*

Three causes. **Only one was a bug**, and it's fixed here.

## 1. They opened a test row

Its Special Requests read `[e2e boarding-occupancy]` and its `details` was `{}`. See the second half of this PR.

## 2. Mock cleanup — exactly as suspected

`src/data/bookings.ts` has 26 bookings, and **two** carry hand-written `feedingInstructions` / `medicationInstructions` arrays. Those two were what made the page look full. Measured against Postgres:

```
with feedingSchedule / medications / extras / add-ons     0 / 250
completely empty details                                174 / 250
```

Nothing is dropped on write — `bookingToRow` routes anything outside `COLUMN_FIELDS` into `details`. It's "nobody has entered one", not a lost write.

## 3. A real wiring gap

The panels rendered `booking.feedingInstructions` and `booking.medicationInstructions`. The wizard collects and stores `booking.feedingSchedule` and `booking.medications`. **Different names and different types** — so the panels could never fill from a booking made in this app, whatever anybody typed.

The two shapes are different on purpose and both are worth keeping:

| | |
|---|---|
| `FeedingScheduleItem` | what the **owner** asked for — occasions, prep, allergies, what to do if the dog refuses |
| `FeedingEntry` | what **staff did** — a meal, a status, who completed it |

So `lib/bookings/care-instructions.ts` projects the first into the second for display, with `status: "pending"` — *asked for, not yet done* — rather than renaming either. The fixture field still wins when present, so the demo bookings are unchanged.

**Verified against the live database** with a booking carrying a real schedule:

> **Breakfast** · 8:00 AM · 1.5 cups · Acana Large Breed
> *Add warm water and stir · Allergies: chicken · If refused: Call before offering anything else*
> **Dinner** · 5:30 PM · 1.5 cups + 1 tbsp · Acana Large Breed, Pumpkin puree
> **Apoquel** `CRITICAL` · 1 tablet 16mg · Tablet · Twice daily

The snake_case enums are humanised too — `twice_daily` was rendering raw.

## And the panels stopped offering actions that persist nothing

`handleLog`, `handleAdd`, `handleAdminister` and `handleAddNote` set component state and toast; a reload loses all of it. That was invisible while the panels were empty and became **reachable the moment they rendered real instructions** — so `canLog={false}` hides Add Meal, Add Medication, Log meal and Give, rather than leaving them to lose a dose record.

**Logging a feeding and administering a dose are not built.** That's now the highest-value thing to add to this page, because staff will expect to tick these off.

## Four e2e bookings were sitting in the live bookings list

The suite is better behaved than it looked: **211 of 215** marked bookings were already cancelled, and cancelled rows accumulating is *by design* — `bookings` has no DELETE policy.

**Four were still `confirmed`**, from runs that died before `afterAll` could execute. They showed on the bookings screen as real work and held their kennels — and one of them is the booking that prompted this report.

`tests/e2e/_sweep.ts` cancels every booking carrying a spec's marker, and `boarding-occupancy` now calls it from **`beforeAll` as well as `afterAll`**. `role-editor-writes` concluded that cleaning up at the start is not *enough* — it isn't, but it's the only thing that heals a run which never reached its end. Together they're self-correcting; alone, neither is.

Proven in the spec run: `sweep(after): 6/6 booking(s) cancelled`. The other seventeen specs that create marked bookings should adopt the pair.

Cleared by hand at the same time: **live bookings 38 → 34**, all real.

## Still fixture-backed on the same page

Worth knowing, not fixed here: the **Guest Journal** panel renders a different pet's stay entirely — dates, kennel and owner from `src/data/boarding.ts` — sitting directly below the now-real care panels.

## Verified

- `typecheck` / `lint` / `format:check` / `build` green — **no new lint warnings** (per-file diff against baseline).
- All seven project gates pass.
- `boarding-occupancy` 11/11, and **62 e2e passed / 1 skipped / 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
