### PR TITLE
fix(bookings): the Guest Journal shows its own stay, or none

### DIFF
--- a/docs/quality/debt-map.md
+++ b/docs/quality/debt-map.md
@@ -2205,10 +2205,57 @@ and became reachable the moment they started rendering real instructions, so
 feeding and administering a dose are not built** — the highest-value thing to
 build next on this page, because staff will expect to tick these off.
 
-Still fixture-backed on the same page, and visibly wrong next to real data: the
-**Guest Journal** panel renders a different pet's stay (dates, kennel and owner
-from `src/data/boarding.ts`), and `boardingGuestForPrint` falls back to a
-synthesised guest for every real booking.
+**The sharper measurement**, taken afterwards: exactly **2** of 257 bookings
+carry `feedingInstructions` and **2** carry `medicationInstructions` — the two
+migrated fixture rows, refs 1 and 2. Every other booking, seeded or created, is
+sparse because nobody has entered anything. So the "rich" page anybody remembers
+is those two.
+
+### 🟢 The Guest Journal showed somebody else's stay (was 🔴 — the worst of these)
+
+Same page, found while fixing the care panels. `ReservationJournalPanel`
+resolved its guest two ways, and both were wrong for a real booking:
+
+```ts
+let matches = boardingGuests.filter((g) => g.bookingId === refId);
+if (matches.length === 0 && petIds?.length) {
+  matches = boardingGuests.filter((g) => petIds.includes(g.petId)); // any stay
+}
+```
+
+**The pet fallback** matched any stay in the fixture involving that animal. A
+December booking for Alice Johnson rendered `bg-001` — 22–29 April, owner "John
+Smith", Kennel 12 — with eight days of care entries: meals marked "Ate all",
+"Medications Given 08:05 AM". None of it happened for that animal, on the page
+staff read to find out what did. A pet has many stays; a journal belongs to one,
+so matching by pet can only ever be a guess.
+
+**The id spaces also overlap.** A numeric ref was turned into `bk-001`, and the
+fixture's ids run `bk-001`..`bk-024` while the seeded bookings start at ref 1 —
+so refs 1–24 collided. And the rows they name disagree:
+
+```
+booking ref 1   2–6 July 2026      Alice Johnson
+guest  bg-001   22–29 April 2026   "John Smith", Kennel 12, 7 nights
+```
+
+The fixture guest was never kept in step with the booking it claims, so even the
+"intended" match was wrong. A numeric ref now resolves to no journal; a STRING
+id still resolves, because that is what `DailyCareView` passes — a guest's own
+`bookingId`, read from the same fixture, where the match is correct by
+construction.
+
+The panel already had the right answer for a miss; the fallback was what stopped
+anyone seeing it. Its copy promised the journal "will populate automatically"
+once booking details are present, which is not built either, so it now says what
+is true.
+
+Verified on the running app: booking 1 shows no "John Smith", no "Kennel 12", no
+"Apr 22", no borrowed phone number, and Daily Care still renders its guests.
+
+Also still fixture-shaped, and harmless: `boardingGuestForPrint` synthesises a
+guest from the REAL booking and pet when no fixture row matches, so the printed
+kennel card carries the right animal.
 
 ### 🟢 Four e2e bookings were sitting in the live bookings list (was invisible)
 

--- a/src/components/guest-journal/ReservationJournalPanel.tsx
+++ b/src/components/guest-journal/ReservationJournalPanel.tsx
@@ -540,18 +540,48 @@ function GuestJournalContent({ guest }: { guest: BoardingGuest }) {
   );
 }
 
-export function ReservationJournalPanel({ bookingId, petIds }: Props) {
+export function ReservationJournalPanel({ bookingId }: Props) {
+  // ── MATCHED BY BOOKING, AND ONLY BY BOOKING ─────────────────────────────
+  //
+  // There used to be a fallback: when no guest carried this booking's id, it
+  // matched `boardingGuests` BY PET instead. Every real booking misses the
+  // first lookup — the fixture's ids are `bk-001`..`bk-024` — so every real
+  // booking fell through to the second and rendered somebody else's stay.
+  //
+  // Seen on a live booking on 2026-08-19: a December stay for Alice Johnson
+  // displayed bg-001 — 22–29 April, owner John Smith, Kennel 12 — together
+  // with eight days of care entries. Meals marked "Ate all", "Medications
+  // Given 08:05 AM". None of it happened for that animal, on the page staff
+  // read to find out what did.
+  //
+  // A pet has many stays; a journal belongs to ONE. Matching by pet can only
+  // ever be a guess, and the panel already has the right answer for a miss —
+  // the "Journal not yet built for this reservation" card below, which the
+  // fallback was what prevented anyone from seeing.
+  //
+  // ── AND A NUMERIC REF IS NOT A FIXTURE ID ──────────────────────────────
+  //
+  // It also turned `1` into `"bk-001"` and looked that up. The fixture's ids
+  // run bk-001..bk-024 and the seeded bookings start at ref 1, so the two id
+  // spaces overlap — and the rows they name do not agree:
+  //
+  //   booking ref 1   2-6 July 2026      Alice Johnson
+  //   guest  bg-001   22-29 April 2026   "John Smith", Kennel 12, 7 nights
+  //
+  // The fixture guest was never kept in step with the booking it claims. So a
+  // numeric ref — which is a Postgres row, something this fixture cannot know
+  // about — resolves to no journal rather than to a coincidence.
+  //
+  // A STRING id still resolves, because that is what DailyCareView passes: a
+  // guest's own `bookingId`, read from this same fixture, where the match is
+  // correct by construction.
+  //
+  // `petIds` is kept on the props: both call sites pass it, and it is what a
+  // real per-booking journal will filter on once one exists.
   const guests = useMemo(() => {
-    const refId =
-      typeof bookingId === "number"
-        ? `bk-${String(bookingId).padStart(3, "0")}`
-        : bookingId;
-    let matches = boardingGuests.filter((g) => g.bookingId === refId);
-    if (matches.length === 0 && petIds && petIds.length > 0) {
-      matches = boardingGuests.filter((g) => petIds.includes(g.petId));
-    }
-    return matches;
-  }, [bookingId, petIds]);
+    if (typeof bookingId !== "string" || bookingId === "") return [];
+    return boardingGuests.filter((g) => g.bookingId === bookingId);
+  }, [bookingId]);
 
   if (guests.length === 0) {
     return (
@@ -567,13 +597,14 @@ export function ReservationJournalPanel({ bookingId, petIds }: Props) {
             <AlertTriangle className="size-4 shrink-0" />
             <div>
               <p className="font-medium">
-                Journal not yet built for this reservation.
+                No journal for this reservation yet.
               </p>
               <p className="mt-0.5">
-                The Guest Journal is auto-generated from the feeding plan,
-                medications, and add-ons entered when the booking was confirmed.
-                Once those details are present this panel will populate
-                automatically.
+                A guest journal records what happened each day of a stay —
+                meals, medications and rounds, as staff complete them. Nothing
+                records those yet, so this panel stays empty rather than showing
+                another stay&apos;s entries. The care instructions themselves
+                are above.
               </p>
             </div>
           </div>


### PR DESCRIPTION
Found on the same page as #145, and **worse than what was reported**.

`ReservationJournalPanel` resolved its guest two ways, and both were wrong for a real booking:

```ts
let matches = boardingGuests.filter((g) => g.bookingId === refId);
if (matches.length === 0 && petIds?.length) {
  matches = boardingGuests.filter((g) => petIds.includes(g.petId));   // any stay
}
```

## The pet fallback

It matched **any stay in the fixture involving that animal**. A December booking for Alice Johnson rendered `bg-001` — 22–29 April, owner **"John Smith"**, Kennel 12 — with eight days of care entries: meals marked *"Ate all"*, *"Medications Given 08:05 AM"*.

None of it happened for that animal, **on the page staff read to find out what did**. A pet has many stays and a journal belongs to one, so matching by pet can only ever be a guess.

## The id spaces also overlap

A numeric ref was turned into `bk-001`; the fixture's ids run `bk-001`…`bk-024`; the seeded bookings start at ref 1. So refs 1–24 collided — and the rows they name disagree:

```
booking ref 1   2–6 July 2026      Alice Johnson
guest  bg-001   22–29 April 2026   "John Smith", Kennel 12, 7 nights
```

The fixture guest was never kept in step with the booking it claims, so even the *intended* match was wrong.

**A numeric ref** — a Postgres row this fixture cannot know about — now resolves to no journal. **A string id still resolves**, because that's what `DailyCareView` passes: a guest's own `bookingId`, read from the same fixture, where the match is correct by construction.

## The panel already had the right answer

It has an empty state. The fallback was what stopped anyone seeing it. Its copy promised the journal *"will populate automatically"* once booking details are present — which isn't built either — so it now says what's true and points at the care instructions above, which are.

## Verified on the running app

Booking 1 shows **no** "John Smith", **no** "Kennel 12", **no** "Apr 22", **no** borrowed phone number, **no** "Blue Buffalo"; the honest card is shown; the real client is still named. Daily Care still renders its guests.

## And a sharper number for #145

Exactly **2 of 257** bookings carry `feedingInstructions`, and 2 carry `medicationInstructions` — the two migrated fixture rows. Every other booking is sparse because nobody has entered anything. That's the whole of the "rich demo page" anyone remembers.

## Verified

- `typecheck` / `lint` / `format:check` / `build` green — no new lint warnings.
- All seven project gates pass.
- **62 e2e passed / 1 skipped / 0 failed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
