### PR TITLE
feat(bookings): a care log entry outlives the page

### DIFF
--- a/docs/quality/debt-map.md
+++ b/docs/quality/debt-map.md
@@ -2199,11 +2199,49 @@ yet done — rather than renaming either.
 
 **And the panels stopped offering actions that persist nothing.** `handleLog`,
 `handleAdd`, `handleAdminister` and `handleAddNote` set component state and
-toast; a reload loses all of it. That was invisible while the panels were empty
+toast; a reload lost all of it. That was invisible while the panels were empty
 and became reachable the moment they started rendering real instructions, so
-`canLog={false}` hides Add Meal, Add Medication, Log meal and Give. **Logging a
-feeding and administering a dose are not built** — the highest-value thing to
-build next on this page, because staff will expect to tick these off.
+`canLog={false}` hid Add Meal, Add Medication, Log meal and Give.
+
+### 🟢 Logging a feeding and giving a dose are real (was 🔴 — the follow-on)
+
+`public.care_log_entries` (20260819140000). A row is one execution of one
+scheduled task: booking, pet, `task_key`, `task_type`, day, clock time, outcome,
+notes, and who recorded it — the name snapshotted, because a journal that
+renames itself when somebody leaves the business is not a journal.
+
+**The permission was the interesting part.** The first draft gated writes on
+`edit_pet_records`, which reads sensibly and is wrong: measured against the
+presets, that key belongs to owner, admin, manager and supervisor — so the
+caretaker and the boarding attendant, the people who actually put the bowl down,
+could not record it. The right keys already existed and did not need inventing:
+
+```
+log_feedings / log_medications / log_potty_breaks
+  admin, boarding_attendant, caretaker, daycare_attendant, manager, owner, supervisor
+```
+
+`private.care_log_permission_for(task_type)` maps a row to the key its own type
+names, and the insert policy asks for that. Proved on production: a caretaker
+writes a feeding and a medication; a groomer and a receptionist are refused,
+while both can still READ. `supabase/tests/care-log.sql` keeps it that way.
+
+**One row per (booking, task, day)**, which is what `careLogStore.log()` merely
+intended — correcting a mis-tapped "refused" edits the record instead of
+appending a second meal. Enforced by `care_log_one_per_task_per_day`, and the
+route upserts on it. **No DELETE policy**: a wrong entry is corrected, and the
+correction is the record.
+
+**Still the in-memory store:** the Guest Journal and Daily Care read
+`src/data/care-log-store.ts` — `let executions` at module scope, seeded from
+fixtures. They carry photos, health observations and generated task schedules
+that `care_log_entries` does not model yet, so both exist. That is the next
+thing to converge, and when it does the store goes.
+
+**Not built, and deliberately:** adding an unplanned meal or a note on a dose
+that has not been given. `care_log_entries` records the EXECUTION of a scheduled
+task, so neither has a home; the note travels with the dose when it is given,
+which is the path that persists.
 
 **The sharper measurement**, taken afterwards: exactly **2** of 257 bookings
 carry `feedingInstructions` and **2** carry `medicationInstructions` — the two

--- a/src/app/api/care-log/route.ts
+++ b/src/app/api/care-log/route.ts
@@ -1,0 +1,228 @@
+import { NextResponse, type NextRequest } from "next/server";
+
+import { getViewer } from "@/lib/auth/viewer";
+import { createServerClient, getCurrentUser } from "@/lib/supabase/server";
+import { writeFailure } from "@/lib/api/write-failure";
+
+// ============================================================================
+// What was actually done for a booking: meals, doses, rounds.
+//
+// ── WHAT THIS REPLACES ────────────────────────────────────────────────────
+//
+// Nothing on the server, which was the problem. `src/data/care-log-store.ts`
+// held executions in a module-level array and the booking page's FEEDING and
+// MEDICATIONS panels each kept their own `useState` copy. A reload lost the
+// lot, and the panels' controls were hidden on 2026-08-19 rather than left to
+// lose a dose record (PR #145).
+//
+// ── THE FACILITY IS NEVER SENT ────────────────────────────────────────────
+//
+// `care_log_set_facility` derives it from the booking, and the booking is
+// resolved here through an RLS read the CALLER has to be able to make. So
+// naming somebody else's booking returns nothing to write against rather than
+// writing against it.
+//
+// ── UPSERT, BECAUSE CORRECTING A MEAL IS NOT A SECOND MEAL ────────────────
+//
+// One row per (booking, task, day), enforced by
+// `care_log_one_per_task_per_day`. Logging the same slot again edits the
+// record — which is what the mock store did, and what somebody who mis-taps
+// "refused" instead of "ate all" needs.
+// ============================================================================
+
+export const dynamic = "force-dynamic";
+
+const TASK_TYPES = [
+  "feeding",
+  "medication",
+  "potty",
+  "cleaning",
+  "walk",
+  "addon",
+  "other",
+] as const;
+
+export interface CareLogEntry {
+  id: string;
+  bookingRef: number;
+  petRef: number | null;
+  taskKey: string;
+  taskType: (typeof TASK_TYPES)[number];
+  occurredOn: string;
+  executedAt: string;
+  servedAt: string | null;
+  outcome: string;
+  notes: string | null;
+  recordedByName: string | null;
+  createdAt: string;
+}
+
+const SELECT =
+  "id, task_key, task_type, occurred_on, executed_at, served_at, outcome, notes, recorded_by_name, created_at, bookings!inner(ref), pets(ref)";
+
+type Row = {
+  id: string;
+  task_key: string;
+  task_type: CareLogEntry["taskType"];
+  occurred_on: string;
+  executed_at: string;
+  served_at: string | null;
+  outcome: string;
+  notes: string | null;
+  recorded_by_name: string | null;
+  created_at: string;
+  bookings: { ref: number } | null;
+  pets: { ref: number } | null;
+};
+
+function toEntry(row: Row): CareLogEntry {
+  return {
+    id: row.id,
+    bookingRef: row.bookings?.ref ?? 0,
+    petRef: row.pets?.ref ?? null,
+    taskKey: row.task_key,
+    taskType: row.task_type,
+    occurredOn: row.occurred_on,
+    // Postgres `time` comes back as "08:00:00"; the panels render "HH:MM".
+    executedAt: row.executed_at.slice(0, 5),
+    servedAt: row.served_at ? row.served_at.slice(0, 5) : null,
+    outcome: row.outcome,
+    notes: row.notes,
+    recordedByName: row.recorded_by_name,
+    createdAt: row.created_at,
+  };
+}
+
+export async function GET(request: NextRequest) {
+  const user = await getCurrentUser().catch(() => null);
+  if (!user) {
+    return NextResponse.json({ error: "Not signed in." }, { status: 401 });
+  }
+
+  const bookingRef = Number(
+    new URL(request.url).searchParams.get("bookingRef"),
+  );
+  if (!Number.isFinite(bookingRef)) {
+    return NextResponse.json(
+      { error: "bookingRef is required." },
+      { status: 400 },
+    );
+  }
+
+  const supabase = await createServerClient();
+  const { data, error } = await supabase
+    .from("care_log_entries")
+    .select(SELECT)
+    .eq("bookings.ref", bookingRef)
+    .order("occurred_on", { ascending: true })
+    .order("executed_at", { ascending: true });
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  return NextResponse.json((data as unknown as Row[]).map(toEntry));
+}
+
+interface LogInput {
+  bookingRef?: number;
+  petRef?: number | null;
+  taskKey?: string;
+  taskType?: string;
+  occurredOn?: string;
+  executedAt?: string;
+  servedAt?: string | null;
+  outcome?: string;
+  notes?: string | null;
+}
+
+export async function POST(request: NextRequest) {
+  const viewer = await getViewer();
+  if (viewer.source !== "session") {
+    return NextResponse.json({ error: "Not signed in." }, { status: 401 });
+  }
+
+  const input = (await request.json().catch(() => ({}))) as LogInput;
+
+  if (!input.bookingRef || !input.taskKey?.trim() || !input.outcome?.trim()) {
+    return NextResponse.json(
+      { error: "A booking, a task and an outcome are required." },
+      { status: 422 },
+    );
+  }
+  if (
+    !input.taskType ||
+    !TASK_TYPES.includes(input.taskType as CareLogEntry["taskType"])
+  ) {
+    return NextResponse.json(
+      { error: `taskType must be one of: ${TASK_TYPES.join(", ")}.` },
+      { status: 422 },
+    );
+  }
+
+  const supabase = await createServerClient();
+
+  // Through RLS as the caller. A booking they cannot see is a booking they
+  // cannot log against, and it fails here with a sentence rather than as a
+  // foreign-key violation further down.
+  const { data: booking } = await supabase
+    .from("bookings")
+    .select("id")
+    .eq("ref", input.bookingRef)
+    .maybeSingle();
+
+  if (!booking) {
+    return NextResponse.json(
+      { error: `No booking ${input.bookingRef} you can log against.` },
+      { status: 404 },
+    );
+  }
+
+  let petId: string | null = null;
+  if (input.petRef != null) {
+    const { data: pet } = await supabase
+      .from("pets")
+      .select("id")
+      .eq("ref", input.petRef)
+      .maybeSingle();
+    if (!pet) {
+      return NextResponse.json(
+        { error: "That pet could not be found." },
+        { status: 404 },
+      );
+    }
+    petId = pet.id as string;
+  }
+
+  const { data, error } = await supabase
+    .from("care_log_entries")
+    .upsert(
+      {
+        booking_id: booking.id as string,
+        pet_id: petId,
+        task_key: input.taskKey.trim(),
+        task_type: input.taskType,
+        occurred_on: input.occurredOn ?? new Date().toISOString().slice(0, 10),
+        executed_at: input.executedAt ?? new Date().toTimeString().slice(0, 5),
+        served_at: input.servedAt ?? null,
+        outcome: input.outcome.trim(),
+        notes: input.notes?.trim() || null,
+        recorded_by: viewer.userId,
+        // Snapshotted, not joined: a journal that renames itself when somebody
+        // leaves the business is not a journal.
+        recorded_by_name: viewer.fullName ?? viewer.email ?? null,
+      } as never,
+      { onConflict: "booking_id,task_key,occurred_on" },
+    )
+    .select(SELECT)
+    .single();
+
+  if (error) {
+    return writeFailure(error, {
+      denied: "You are not allowed to log this kind of care at this facility.",
+      duplicate: "That task is already logged for this day.",
+    });
+  }
+
+  return NextResponse.json(toEntry(data as unknown as Row), { status: 201 });
+}

--- a/src/app/facility/dashboard/clients/[id]/bookings/[bookingId]/page.tsx
+++ b/src/app/facility/dashboard/clients/[id]/bookings/[bookingId]/page.tsx
@@ -40,7 +40,7 @@ import { Dialog, DialogContent } from "@/components/ui/dialog";
 import { CreateIncidentModal } from "@/components/incidents/CreateIncidentModal";
 import { getIncidentCareCharges } from "@/lib/incidents/incident-billing";
 import { getIncidentsForBooking, lockInStayCare } from "@/data/incidents";
-import { useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { estimates } from "@/data/estimates";
 import { clientQueries } from "@/lib/api/client";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -51,9 +51,14 @@ import { PrintKennelCardsModal } from "@/components/facility/boarding/kennel-car
 import { StatusBadge } from "@/components/ui/StatusBadge";
 import { InvoicePanel } from "@/components/bookings/InvoicePanel";
 import {
+  applyFeedingLog,
+  applyMedicationLog,
+  careLogStamp,
   feedingEntriesFromSchedule,
   medicationEntriesFromItems,
+  medicationTaskKey,
 } from "@/lib/bookings/care-instructions";
+import { careLogKeys, careLogQueries, logCare } from "@/lib/api/care-log";
 import { BookingNotes } from "@/components/bookings/BookingNotes";
 import { BookingModal } from "@/components/bookings/modals/BookingModal";
 import { ProcessPaymentModal } from "@/components/bookings/modals/ProcessPaymentModal";
@@ -204,6 +209,37 @@ export default function ClientBookingDetailPage({
   const { data: allClients = [], isPending: clientPending } = useQuery(
     clientQueries.all(),
   );
+  // ── THE CARE LOG ────────────────────────────────────────────────────────
+  //
+  // What was actually done, from `care_log_entries` (20260819140000). Before
+  // that table the FEEDING and MEDICATIONS panels kept their own useState and
+  // a reload lost every meal and dose, which is why their controls were hidden
+  // in PR #145.
+  //
+  // `logDay` is fixed for the life of the mount rather than read per render:
+  // `new Date()` in a render body is what the React Compiler rules exist to
+  // stop, and a journal that silently rolled over at midnight mid-shift would
+  // file the 00:05 dose against tomorrow.
+  const queryClient = useQueryClient();
+  const { data: careLog } = useQuery({
+    ...careLogQueries.forBooking(bookingId),
+    enabled: Number.isFinite(bookingId),
+  });
+  const [logDay] = useState(() => new Date().toISOString().slice(0, 10));
+
+  const recordCare = useMutation({
+    mutationFn: logCare,
+    onSuccess: () =>
+      queryClient.invalidateQueries({
+        queryKey: careLogKeys.forBooking(bookingId),
+      }),
+    onError: (error: unknown) =>
+      toast.error("Not recorded", {
+        description:
+          error instanceof Error ? error.message : "Please try again.",
+      }),
+  });
+
   const takePayment = useTakeBookingPayment();
   const cancelBooking = useCancelBooking();
   const refundBooking = useRefundBooking();
@@ -1235,15 +1271,27 @@ export default function ClientBookingDetailPage({
                           still render; everything else falls through to the
                           owner's schedule, projected into the same shape. */}
                       <FeedingSection
-                        entries={
+                        key={`feed-${careLogStamp(careLog)}`}
+                        entries={applyFeedingLog(
                           booking.feedingInstructions?.length
                             ? booking.feedingInstructions
                             : feedingEntriesFromSchedule(
                                 booking.feedingSchedule,
-                              )
-                        }
+                              ),
+                          careLog,
+                          logDay,
+                        )}
                         required={feedingMode === "required"}
-                        canLog={false}
+                        onLog={(entryId, outcome) =>
+                          recordCare.mutate({
+                            bookingRef: booking.id,
+                            petRef: pet?.id ?? null,
+                            taskKey: entryId,
+                            taskType: "feeding",
+                            outcome,
+                            occurredOn: logDay,
+                          })
+                        }
                       />
                     </div>
                   )}
@@ -1253,14 +1301,33 @@ export default function ClientBookingDetailPage({
                       className="rounded-xl transition-shadow"
                     >
                       <MedicationSection
-                        entries={
+                        key={`med-${careLogStamp(careLog)}`}
+                        entries={applyMedicationLog(
                           booking.medicationInstructions?.length
                             ? booking.medicationInstructions
-                            : medicationEntriesFromItems(booking.medications)
-                        }
+                            : medicationEntriesFromItems(
+                                booking.medications,
+                                logDay,
+                              ),
+                          careLog,
+                          logDay,
+                        )}
                         required={medicationMode === "required"}
                         bookingId={booking.id}
-                        canLog={false}
+                        onLog={(medicationId, scheduledAt, outcome, notes) =>
+                          recordCare.mutate({
+                            bookingRef: booking.id,
+                            petRef: pet?.id ?? null,
+                            taskKey: medicationTaskKey(
+                              medicationId,
+                              scheduledAt,
+                            ),
+                            taskType: "medication",
+                            outcome,
+                            notes,
+                            occurredOn: logDay,
+                          })
+                        }
                       />
                     </div>
                   )}

--- a/src/components/bookings/FeedingSection.tsx
+++ b/src/components/bookings/FeedingSection.tsx
@@ -40,9 +40,19 @@ interface FeedingSectionProps {
    * moment it started rendering the owner's schedule, so the controls are
    * hidden rather than left to lose somebody's work.
    *
-   * Recorded in docs/quality/debt-map.md: logging a feeding is not built.
+   * TRUE again on the booking page as of the care-log table
+   * (20260819140000) — but only when `onLog` is supplied, because that is what
+   * makes it persist.
    */
   canLog?: boolean;
+  /**
+   * Record a meal. The parent owns the write and the refetch; this panel just
+   * says which slot and how it went.
+   *
+   * Absent means the panel is a display, which is what it was before there was
+   * anywhere to write to.
+   */
+  onLog?: (entryId: string, outcome: string) => void;
 }
 
 const FEEDBACK_OPTIONS = facilityConfig.careTaskFeedback.feeding;
@@ -76,6 +86,7 @@ export function FeedingSection({
   entries,
   required,
   canLog = true,
+  onLog,
 }: FeedingSectionProps) {
   const [items, setItems] = useState(entries);
   const [addOpen, setAddOpen] = useState(false);
@@ -88,6 +99,9 @@ export function FeedingSection({
   });
 
   const handleLog = (id: string, feedback: string) => {
+    // Optimistic, then authoritative: the row turns over immediately and the
+    // parent's refetch replaces it with what the database stored. This used to
+    // be the ONLY thing that happened, which is why a reload lost it.
     setItems((prev) =>
       prev.map((e) =>
         e.id === id
@@ -103,7 +117,7 @@ export function FeedingSection({
           : e,
       ),
     );
-    toast.success("Feeding logged");
+    onLog?.(id, feedback);
   };
 
   const handleAdd = () => {
@@ -128,7 +142,9 @@ export function FeedingSection({
       instructions: "",
     });
     setAddOpen(false);
-    toast.success("Meal added");
+    // No toast: nothing is written. Adding an unplanned meal has no home in
+    // `care_log_entries` — that row executes a SCHEDULED task — so this stays
+    // local until the schedule can be amended. `canLog` hides it meanwhile.
   };
 
   return (
@@ -307,7 +323,13 @@ export function FeedingSection({
                   {entry.status === "completed" ? (
                     <div className="shrink-0 text-right">
                       <span className="rounded-full bg-emerald-50 px-2 py-0.5 text-[10px] font-semibold text-emerald-700">
-                        {entry.feedback}
+                        {/* A logged outcome arrives as its stored value
+                            ("ate_all"); one logged in this session arrives as
+                            a label. Both are put through the same lookup so
+                            the row reads the same either way. */}
+                        {FEEDBACK_OPTIONS.find(
+                          (o) => o.value === entry.feedback,
+                        )?.label ?? entry.feedback}
                       </span>
                       {entry.completedBy && (
                         <p className="text-muted-foreground mt-0.5 text-[10px]">

--- a/src/components/bookings/MedicationSection.tsx
+++ b/src/components/bookings/MedicationSection.tsx
@@ -56,9 +56,21 @@ interface MedicationSectionProps {
    * list — so the controls are hidden rather than left to lose a dose record,
    * which is the worst thing on this page to lose.
    *
-   * Recorded in docs/quality/debt-map.md: administering a dose is not built.
+   * TRUE again on the booking page as of the care-log table
+   * (20260819140000) — but only when `onLog` is supplied, because that is what
+   * makes it persist.
    */
   canLog?: boolean;
+  /**
+   * Record a dose. The parent owns the write and the refetch; this panel says
+   * which medication, which scheduled time, and how it went.
+   */
+  onLog?: (
+    medicationId: string,
+    scheduledAt: string,
+    outcome: string,
+    notes?: string,
+  ) => void;
 }
 
 // Map an incident-sourced medication onto the booking medication shape so the
@@ -135,6 +147,7 @@ export function MedicationSection({
   required,
   bookingId,
   canLog = true,
+  onLog,
 }: MedicationSectionProps) {
   const [meds, setMeds] = useState<MedicationEntry[]>(() => [
     ...entries,
@@ -174,7 +187,11 @@ export function MedicationSection({
           : med,
       ),
     );
-    toast.success("Medication administered");
+    // Optimistic, then authoritative — the parent writes it and refetches.
+    // This used to be the only thing that happened, so a reload lost the dose.
+    const med = meds.find((m) => m.id === medId);
+    const dose = med?.doses[doseIdx];
+    if (med && dose) onLog?.(med.id, dose.scheduledAt, "given", notes);
   };
 
   const handleAddNote = (medId: string, doseIdx: number) => {
@@ -192,7 +209,9 @@ export function MedicationSection({
     );
     setDoseNote("");
     setNotePopover(null);
-    toast.success("Note added");
+    // A note on a dose that has not been given yet has nowhere to live —
+    // `care_log_entries` records an EXECUTION — so this stays local. Giving
+    // the dose sends the note along with it, which is the path that persists.
   };
 
   const handleAdd = () => {

--- a/src/lib/api/care-log.ts
+++ b/src/lib/api/care-log.ts
@@ -1,0 +1,68 @@
+import type { CareLogEntry } from "@/app/api/care-log/route";
+
+// ============================================================================
+// The care log, from Postgres.
+//
+// Replaces `src/data/care-log-store.ts` for the booking page's FEEDING and
+// MEDICATIONS panels: a module-level `let executions` with a hand-rolled
+// subscribe, seeded from fixtures and lost on reload.
+//
+// The Guest Journal and Daily Care still use that store — they carry photos,
+// health observations and generated task schedules that this does not model
+// yet — so both exist for now, and the debt map says which is which.
+// ============================================================================
+
+export type { CareLogEntry };
+
+export interface LogCareInput {
+  bookingRef: number;
+  petRef?: number | null;
+  /** The scheduled slot this executes, e.g. `feed-1001-08:00`. */
+  taskKey: string;
+  taskType: CareLogEntry["taskType"];
+  outcome: string;
+  /** Defaults to today, server-side. */
+  occurredOn?: string;
+  /** "HH:MM". Defaults to now, server-side. */
+  executedAt?: string;
+  servedAt?: string | null;
+  notes?: string | null;
+}
+
+export const careLogKeys = {
+  forBooking: (bookingRef: number) => ["care-log", bookingRef] as const,
+};
+
+export const careLogQueries = {
+  forBooking: (bookingRef: number) => ({
+    queryKey: careLogKeys.forBooking(bookingRef),
+    queryFn: async (): Promise<CareLogEntry[]> => {
+      const response = await fetch(`/api/care-log?bookingRef=${bookingRef}`);
+      if (!response.ok) {
+        const body = (await response.json().catch(() => ({}))) as {
+          error?: string;
+        };
+        throw new Error(body.error ?? "Could not read the care log.");
+      }
+      return (await response.json()) as CareLogEntry[];
+    },
+    // A booking's log is read while somebody is standing at the kennel; a
+    // stale minute is fine, a refetch on every focus is noise.
+    staleTime: 60_000,
+  }),
+};
+
+export async function logCare(input: LogCareInput): Promise<CareLogEntry> {
+  const response = await fetch("/api/care-log", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(input),
+  });
+  if (!response.ok) {
+    const body = (await response.json().catch(() => ({}))) as {
+      error?: string;
+    };
+    throw new Error(body.error ?? "Could not record that.");
+  }
+  return (await response.json()) as CareLogEntry;
+}

--- a/src/lib/bookings/care-instructions.ts
+++ b/src/lib/bookings/care-instructions.ts
@@ -1,3 +1,4 @@
+import type { CareLogEntry } from "@/app/api/care-log/route";
 import type {
   FeedingEntry,
   FeedingScheduleItem,
@@ -117,9 +118,16 @@ export function feedingEntriesFromSchedule(
   );
 }
 
-/** The owner's medications, as the panel's dose rows. */
+/**
+ * The owner's medications, as the panel's dose rows.
+ *
+ * @param day the stay day these doses belong to, `YYYY-MM-DD`. The panel
+ *   formats `scheduledAt` with `new Date(...)`, so a bare "08:00" renders as
+ *   "12:undefined AM" — it needs a timestamp, and a timestamp needs a day.
+ */
 export function medicationEntriesFromItems(
   medications: MedicationItem[] | undefined,
+  day: string,
 ): MedicationEntry[] {
   if (!medications?.length) return [];
 
@@ -146,9 +154,119 @@ export function medicationEntriesFromItems(
       // `isHighRisk` is the owner's flag and `isCritical` is the panel's; they
       // mean the same thing to the person holding the pill.
       isCritical: med.isHighRisk === true,
-      // No doses: a dose is a record of something administered, and nothing
-      // has been. An empty list is the truthful start.
-      doses: [],
+      // One pending dose per scheduled time. A medication with times and no
+      // doses renders as a name with nothing to give, which is not what
+      // "twice daily at 08:00 and 20:00" means.
+      doses: med.times.map((t) => ({
+        scheduledAt: `${day}T${t}:00`,
+        status: "pending" as const,
+      })),
     };
   });
+}
+
+// ============================================================================
+// Folding the care log back in.
+//
+// The entries above are what was ASKED FOR. `care_log_entries` is what was
+// DONE. These merge the second into the first so one panel shows both, which
+// is how somebody at the kennel reads it: this meal, at this time, and whether
+// it happened.
+//
+// Keyed on the entry's own id for feeding and on `<medication>#<time>` for a
+// dose. Those keys are what the panel sends back as `task_key`, so the round
+// trip is closed: the same string identifies the slot going out and coming in.
+// ============================================================================
+
+/** The task key a feeding row logs under. */
+export function feedingTaskKey(entry: FeedingEntry): string {
+  return entry.id;
+}
+
+/**
+ * The task key one scheduled dose logs under.
+ *
+ * Keyed on the TIME OF DAY, never the full timestamp: the same 08:00 dose
+ * recurs every day of a stay, and `care_log_entries` already separates the
+ * days with `occurred_on`. A date-qualified key would make the constraint
+ * that keeps one record per dose per day do nothing.
+ *
+ * Accepts either form, because `scheduledAt` is a timestamp for display and
+ * an "HH:MM" on the fixture path.
+ */
+export function medicationTaskKey(
+  medicationId: string,
+  scheduledAt: string,
+): string {
+  const time = scheduledAt.includes("T")
+    ? scheduledAt.slice(11, 16)
+    : scheduledAt.slice(0, 5);
+  return `${medicationId}#${time}`;
+}
+
+/** A stamp that changes whenever the log does, for remounting the panels. */
+export function careLogStamp(log: CareLogEntry[] | undefined): string {
+  if (!log?.length) return "empty";
+  return `${log.length}:${log.map((e) => e.id).join("")}`.slice(0, 120);
+}
+
+function forDay(
+  log: CareLogEntry[] | undefined,
+  taskKey: string,
+  day: string,
+): CareLogEntry | undefined {
+  return log?.find((e) => e.taskKey === taskKey && e.occurredOn === day);
+}
+
+export function applyFeedingLog(
+  entries: FeedingEntry[],
+  log: CareLogEntry[] | undefined,
+  day: string,
+): FeedingEntry[] {
+  return entries.map((entry) => {
+    const done = forDay(log, feedingTaskKey(entry), day);
+    if (!done) return entry;
+    return {
+      ...entry,
+      status: "completed" as FeedingEntry["status"],
+      feedback: done.outcome,
+      completedBy: done.recordedByName ?? "Staff",
+      // The panel formats this as a time; the row carries the day and the
+      // clock time separately, so they are put back together here.
+      completedAt: `${done.occurredOn}T${done.executedAt}:00`,
+      notes: done.notes ?? entry.notes,
+    };
+  });
+}
+
+export function applyMedicationLog(
+  entries: MedicationEntry[],
+  log: CareLogEntry[] | undefined,
+  day: string,
+): MedicationEntry[] {
+  return entries.map((med) => ({
+    ...med,
+    doses: med.doses.map((dose) => {
+      const done = forDay(
+        log,
+        medicationTaskKey(med.id, dose.scheduledAt),
+        day,
+      );
+      if (!done) return dose;
+      return {
+        ...dose,
+        // The log's own vocabulary, narrowed to what a dose can be. Anything
+        // unrecognised counts as given rather than silently pending — the row
+        // exists because somebody acted.
+        status: (["given", "skipped", "refused"] as const).includes(
+          done.outcome as "given" | "skipped" | "refused",
+        )
+          ? (done.outcome as "given" | "skipped" | "refused")
+          : ("given" as const),
+        administeredBy: done.recordedByName ?? "Staff",
+        administeredAt: `${done.occurredOn}T${done.executedAt}:00`,
+        notes: done.notes ?? dose.notes,
+      };
+    }),
+  }));
 }

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -359,6 +359,84 @@ export type Database = {
           },
         ];
       };
+      care_log_entries: {
+        Row: {
+          id: string;
+          facility_id: string;
+          booking_id: string;
+          pet_id: string | null;
+          task_key: string;
+          task_type: string;
+          occurred_on: string;
+          executed_at: string;
+          served_at: string | null;
+          outcome: string;
+          notes: string | null;
+          recorded_by: string | null;
+          recorded_by_name: string | null;
+          created_at: string;
+          updated_at: string;
+        };
+        Insert: {
+          id?: string;
+          // Derived by care_log_set_facility from the booking; sending one is
+          // accepted and overwritten, so it is optional here and never sent.
+          facility_id?: string;
+          booking_id: string;
+          pet_id?: string | null;
+          task_key: string;
+          task_type: string;
+          occurred_on?: string;
+          executed_at?: string;
+          served_at?: string | null;
+          outcome: string;
+          notes?: string | null;
+          recorded_by?: string | null;
+          recorded_by_name?: string | null;
+          created_at?: string;
+          updated_at?: string;
+        };
+        Update: {
+          id?: string;
+          facility_id?: string;
+          booking_id?: string;
+          pet_id?: string | null;
+          task_key?: string;
+          task_type?: string;
+          occurred_on?: string;
+          executed_at?: string;
+          served_at?: string | null;
+          outcome?: string;
+          notes?: string | null;
+          recorded_by?: string | null;
+          recorded_by_name?: string | null;
+          created_at?: string;
+          updated_at?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "care_log_entries_booking_id_fkey";
+            columns: ["booking_id"];
+            isOneToOne: false;
+            referencedRelation: "bookings";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "care_log_entries_pet_id_fkey";
+            columns: ["pet_id"];
+            isOneToOne: false;
+            referencedRelation: "pets";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "care_log_entries_facility_id_fkey";
+            columns: ["facility_id"];
+            isOneToOne: false;
+            referencedRelation: "facilities";
+            referencedColumns: ["id"];
+          },
+        ];
+      };
       daycare_attendance: {
         Row: {
           author_name: string;

--- a/supabase/migrations/20260819140000_a_care_log_entry_outlives_the_page.sql
+++ b/supabase/migrations/20260819140000_a_care_log_entry_outlives_the_page.sql
@@ -1,0 +1,222 @@
+-- ============================================================================
+-- A care log entry is a record, and a record has to survive a reload.
+--
+-- ── WHAT THIS REPLACES ────────────────────────────────────────────────────
+--
+-- `src/data/care-log-store.ts`: `let executions: TaskExecution[]` at module
+-- scope, seeded with fixture entries, with `log()` pushing onto the array and
+-- notifying subscribers. Not even localStorage — a module-level variable, so a
+-- refresh loses it and two requests of the same session on serverless never
+-- shared one.
+--
+-- The booking page's FEEDING and MEDICATIONS panels had their own copy of the
+-- same problem: `useState` plus `toast.success("Feeding logged")`. Those
+-- controls were hidden on 2026-08-19 rather than left to lose somebody's work
+-- (PR #145). This is what lets them come back.
+--
+-- ── WHY A TABLE AND NOT A JSONB COLUMN ON THE BOOKING ─────────────────────
+--
+-- The instructions belong to the booking — one feeding plan for the stay — and
+-- they live in `bookings.details`. An EXECUTION is a different thing: it has an
+-- actor, a clock time, an outcome and a day, and there are many per booking per
+-- day. Appending them to the booking's jsonb would mean every log rewriting the
+-- whole booking row, no way to ask "what did this member of staff do today",
+-- and a lost update whenever two people log at once — which is exactly what a
+-- morning shift is.
+--
+-- ── UPSERT BY (BOOKING, TASK, DAY), WHICH THE MOCK ALREADY DID ────────────
+--
+-- `careLogStore.log()` upserted on `taskId + date` so that correcting a
+-- mis-logged meal edited the record instead of appending a second one. That is
+-- the right behaviour and it becomes a unique constraint here, so the database
+-- enforces what the mock merely intended: one execution per scheduled task per
+-- day, correctable.
+--
+-- ── WHO MAY READ IT ───────────────────────────────────────────────────────
+--
+-- Facility staff with `view_pet_records`, and platform admins. Writing is
+-- narrower and per task type — see `care_log_permission_for` below. NOT the
+-- pet's owner, deliberately, for now: `notes` is where staff write candidly about an
+-- animal ("resisted the pill", "snapped at the neighbour"), and showing an
+-- owner their dog's day is a product decision about what to show, not a policy
+-- to make by accident in a migration. When it is made, this is one clause.
+-- ============================================================================
+
+create table if not exists public.care_log_entries (
+  id           uuid primary key default gen_random_uuid(),
+
+  -- Derived from the booking by trigger, never accepted from a request. Same
+  -- rule as pets_set_facility: a caller naming a facility here would be naming
+  -- one they might have no business in.
+  facility_id  uuid not null references public.facilities (id) on delete cascade,
+  booking_id   uuid not null references public.bookings (id) on delete cascade,
+  -- Nullable: a stay-level task (kennel cleaning) belongs to the booking and
+  -- not to one animal. `on delete set null` keeps the record when a pet row
+  -- goes — what happened still happened.
+  pet_id       uuid references public.pets (id) on delete set null,
+
+  -- The scheduled task this executes, e.g. `feed-<bookingRef>-08:00`. Opaque to
+  -- the database; it is the app's handle for "the breakfast slot".
+  task_key     text not null,
+  task_type    text not null
+    check (task_type in ('feeding','medication','potty','cleaning','walk','addon','other')),
+
+  occurred_on  date not null,
+  executed_at  time not null,
+  /** Feeding only: when the food was put down, as distinct from when it was judged. */
+  served_at    time,
+
+  outcome      text not null,
+  notes        text,
+
+  -- Who. `profiles` rather than `staff`, because the actor is a person with a
+  -- session; the staff row is which job they hold. Nullable so a record
+  -- outlives the account, and the name is snapshotted for the same reason —
+  -- a journal that renames itself when somebody leaves is not a journal.
+  recorded_by      text references public.profiles (id) on delete set null,
+  recorded_by_name text,
+
+  created_at   timestamptz not null default now(),
+  updated_at   timestamptz not null default now(),
+
+  -- One execution per scheduled task per day, correctable in place. This is
+  -- careLogStore's upsert, enforced.
+  constraint care_log_one_per_task_per_day
+    unique (booking_id, task_key, occurred_on)
+);
+
+comment on table public.care_log_entries is
+  'What was actually done for a booking, day by day: meals, doses, rounds. The instructions live on bookings.details; this is the execution of them.';
+
+create index if not exists care_log_entries_booking_day_idx
+  on public.care_log_entries (booking_id, occurred_on);
+create index if not exists care_log_entries_facility_day_idx
+  on public.care_log_entries (facility_id, occurred_on);
+
+-- ── The facility comes from the booking ────────────────────────────────────
+
+create or replace function private.care_log_inherit_facility()
+returns trigger
+language plpgsql
+security definer
+set search_path to ''
+as $fn$
+declare
+  v_facility uuid;
+  v_client   uuid;
+begin
+  select b.facility_id, b.client_id into v_facility, v_client
+    from public.bookings b where b.id = new.booking_id;
+
+  if v_facility is null then
+    raise exception 'No such booking: %', new.booking_id
+      using errcode = '23503';
+  end if;
+
+  new.facility_id := v_facility;
+
+  -- A pet on somebody else's booking is not a typo to tidy up silently; the
+  -- same refusal booking_pets makes, for the same reason.
+  if new.pet_id is not null then
+    if not exists (
+      select 1 from public.pets p
+       where p.id = new.pet_id and p.client_id = v_client
+    ) then
+      raise exception 'That pet is not on this booking''s client record.'
+        using errcode = '23514';
+    end if;
+  end if;
+
+  new.updated_at := now();
+  return new;
+end;
+$fn$;
+
+drop trigger if exists care_log_set_facility on public.care_log_entries;
+create trigger care_log_set_facility
+  before insert or update on public.care_log_entries
+  for each row execute function private.care_log_inherit_facility();
+
+-- ── WHICH PERMISSION, AND WHY IT DEPENDS ON THE TASK ──────────────────────
+--
+-- The first draft of this gated writes on `edit_pet_records`. Measured against
+-- the presets, that was wrong for the product: `edit_pet_records` belongs to
+-- owner, admin, manager and supervisor — so the caretaker and the boarding
+-- attendant, the people who actually put the bowl down and hold the pill,
+-- could not record having done it.
+--
+-- The right keys already existed and did not need inventing:
+--
+--   log_feedings       admin, boarding_attendant, caretaker, daycare_attendant,
+--   log_medications    manager, owner, supervisor
+--   log_potty_breaks
+--   log_cleaning       ...and sanitation
+--
+-- Changing a pet's medical profile and recording that you fed it are different
+-- authorities, and the catalogue already said so. This maps the row to the key
+-- its own `task_type` names.
+create or replace function private.care_log_permission_for(p_task_type text)
+returns text
+language sql
+immutable
+set search_path to ''
+as $fn$
+  select case p_task_type
+    when 'feeding'    then 'log_feedings'
+    when 'medication' then 'log_medications'
+    when 'potty'      then 'log_potty_breaks'
+    when 'cleaning'   then 'log_cleaning'
+    when 'walk'       then 'log_play_sessions'
+    when 'addon'      then 'log_play_sessions'
+    -- Anything else is not a routine round, so it takes the broader authority
+    -- rather than defaulting to the easiest one to hold.
+    else 'edit_pet_records'
+  end;
+$fn$;
+
+-- ── RLS ────────────────────────────────────────────────────────────────────
+
+alter table public.care_log_entries enable row level security;
+
+drop policy if exists care_log_entries_read on public.care_log_entries;
+create policy care_log_entries_read on public.care_log_entries
+  for select to authenticated
+  using (
+    private.is_platform_admin()
+    or private.has_permission(facility_id, 'view_pet_records')
+  );
+
+drop policy if exists care_log_entries_insert on public.care_log_entries;
+create policy care_log_entries_insert on public.care_log_entries
+  for insert to authenticated
+  with check (
+    private.has_permission(
+      facility_id, private.care_log_permission_for(task_type)
+    )
+  );
+
+-- Correcting a mis-logged meal is the whole reason for the unique constraint
+-- above, so UPDATE is allowed — by somebody who could have logged it, and the
+-- WITH CHECK re-asks in case the task_type is being changed too.
+drop policy if exists care_log_entries_update on public.care_log_entries;
+create policy care_log_entries_update on public.care_log_entries
+  for update to authenticated
+  using (
+    private.has_permission(
+      facility_id, private.care_log_permission_for(task_type)
+    )
+  )
+  with check (
+    private.has_permission(
+      facility_id, private.care_log_permission_for(task_type)
+    )
+  );
+
+-- NO delete policy. What happened, happened; a wrong entry is corrected, and
+-- the correction is the record. Same reasoning as bookings.
+
+comment on policy care_log_entries_read on public.care_log_entries is
+  'Facility staff with view_pet_records, and platform admins. Deliberately NOT the pet''s owner: notes are candid. See 20260819140000.';
+
+comment on function private.care_log_permission_for(text) is
+  'The permission a care log row needs, from its task_type. Routine rounds take their own log_* key so the staff who do the work can record it; anything else takes edit_pet_records.';

--- a/supabase/tests/care-log.sql
+++ b/supabase/tests/care-log.sql
@@ -1,0 +1,166 @@
+-- ============================================================================
+-- A care log entry is written by the person who did the work, and by nobody
+-- else.
+--
+--   psql "$(supabase status -o json | jq -r .DB_URL)" -f supabase/tests/care-log.sql
+--
+-- One transaction, rolled back.
+--
+-- ── WHAT THIS FILE IS REALLY ABOUT ────────────────────────────────────────
+--
+-- The first draft of `care_log_entries` gated writes on `edit_pet_records`.
+-- That reads sensibly and is wrong for the product: measured against the
+-- presets, `edit_pet_records` belongs to owner, admin, manager and supervisor —
+-- so the caretaker and the boarding attendant, the people who actually put the
+-- bowl down and hold the pill, could not record having done it.
+--
+-- C1 and C2 are the assertions that would have caught that. They are the point
+-- of this file: a permission model is only right if the person doing the work
+-- can record the work.
+--
+-- C5 is the other half. Recording care is not the same as being able to see
+-- the animal, so a groomer — who holds `view_pet_records` and not
+-- `log_feedings` — must be refused. Without it, "everyone who can read can
+-- write" passes silently.
+-- ============================================================================
+
+begin;
+
+set local client_min_messages to warning;
+
+create temp table tap (n int, name text, ok boolean, detail text);
+
+create or replace function pg_temp.t(i int, p text, ok boolean, d text default '')
+returns void language sql as $$
+  insert into tap(n, name, ok, detail) values (i, p, ok, d);
+$$;
+
+do $$
+declare
+  v_booking  uuid;
+  v_pet      uuid;
+  v_ok       boolean;
+  v_msg      text;
+  v_rows     int;
+begin
+  select b.id into v_booking
+    from public.bookings b
+    join public.facilities f on f.id = b.facility_id
+   where f.slug = 'yipyy-demo-facility'
+   order by b.ref limit 1;
+  select bp.pet_id into v_pet
+    from public.booking_pets bp where bp.booking_id = v_booking limit 1;
+
+  -- ── C1/C2: the people who do the work can record it ─────────────────────
+  for v_msg in
+    select m.profile_id from public.facility_memberships m
+      join public.facilities f on f.id = m.facility_id
+     where f.slug = 'yipyy-demo-facility' and m.role = 'caretaker' and m.is_active
+     limit 1
+  loop
+    perform set_config('request.jwt.claims',
+      json_build_object('sub', v_msg, 'role', 'authenticated')::text, true);
+  end loop;
+  execute 'set local role authenticated';
+
+  v_ok := true;
+  begin
+    insert into public.care_log_entries
+      (booking_id, pet_id, task_key, task_type, occurred_on, executed_at, outcome)
+    values (v_booking, v_pet, 'tap-feed', 'feeding', current_date, '08:00', 'ate_all');
+  exception when others then v_ok := false; v_msg := sqlerrm;
+  end;
+  perform pg_temp.t(1, 'a caretaker can log a feeding', v_ok, coalesce(v_msg, ''));
+
+  v_ok := true;
+  begin
+    insert into public.care_log_entries
+      (booking_id, pet_id, task_key, task_type, occurred_on, executed_at, outcome)
+    values (v_booking, v_pet, 'tap-med', 'medication', current_date, '08:00', 'given');
+  exception when others then v_ok := false; v_msg := sqlerrm;
+  end;
+  perform pg_temp.t(2, 'a caretaker can log a medication', v_ok, coalesce(v_msg, ''));
+
+  -- ── C3: one record per task per day, corrected rather than duplicated ────
+  insert into public.care_log_entries
+    (booking_id, pet_id, task_key, task_type, occurred_on, executed_at, outcome)
+  values (v_booking, v_pet, 'tap-feed', 'feeding', current_date, '08:30', 'ate_some')
+  on conflict (booking_id, task_key, occurred_on) do update
+    set outcome = excluded.outcome, executed_at = excluded.executed_at;
+
+  select count(*) into v_rows from public.care_log_entries
+   where booking_id = v_booking and task_key = 'tap-feed' and occurred_on = current_date;
+  perform pg_temp.t(3, 'logging the same slot twice corrects it, it does not duplicate',
+                    v_rows = 1, format('%s row(s)', v_rows));
+
+  select count(*) into v_rows from public.care_log_entries
+   where booking_id = v_booking and task_key = 'tap-feed' and outcome = 'ate_some';
+  perform pg_temp.t(4, 'and the correction is what is stored', v_rows = 1);
+
+  execute 'reset role';
+  perform set_config('request.jwt.claims', '', true);
+
+  -- ── C5: seeing the animal is not permission to record care for it ───────
+  for v_msg in
+    select m.profile_id from public.facility_memberships m
+      join public.facilities f on f.id = m.facility_id
+     where f.slug = 'yipyy-demo-facility' and m.role = 'groomer' and m.is_active
+     limit 1
+  loop
+    perform set_config('request.jwt.claims',
+      json_build_object('sub', v_msg, 'role', 'authenticated')::text, true);
+  end loop;
+  execute 'set local role authenticated';
+
+  v_ok := false;
+  begin
+    insert into public.care_log_entries
+      (booking_id, pet_id, task_key, task_type, occurred_on, executed_at, outcome)
+    values (v_booking, v_pet, 'tap-groomer', 'feeding', current_date, '09:00', 'ate_all');
+  exception when others then v_ok := true; v_msg := sqlerrm;
+  end;
+  perform pg_temp.t(5, 'a groomer, who may READ pet records, may not log a feeding',
+                    v_ok, coalesce(v_msg, 'the insert succeeded'));
+
+  -- ── C6: a groomer can still READ the log ────────────────────────────────
+  select count(*) into v_rows from public.care_log_entries where booking_id = v_booking;
+  perform pg_temp.t(6, 'a groomer can read the care log', v_rows >= 2,
+                    format('%s row(s) visible', v_rows));
+
+  -- ── C7: the facility is derived, never accepted ─────────────────────────
+  execute 'reset role';
+  perform set_config('request.jwt.claims', '', true);
+
+  select count(*) into v_rows from public.care_log_entries c
+    join public.bookings b on b.id = c.booking_id
+   where c.booking_id = v_booking and c.facility_id <> b.facility_id;
+  perform pg_temp.t(7, 'every entry carries its booking''s facility', v_rows = 0);
+
+  -- ── C8: a pet from another client cannot be attached ────────────────────
+  v_ok := false;
+  begin
+    insert into public.care_log_entries
+      (booking_id, pet_id, task_key, task_type, occurred_on, executed_at, outcome)
+    select v_booking, p.id, 'tap-alien', 'feeding', current_date, '10:00', 'ate_all'
+      from public.pets p
+     where p.client_id <> (select client_id from public.bookings where id = v_booking)
+     limit 1;
+  exception when others then v_ok := true; v_msg := sqlerrm;
+  end;
+  perform pg_temp.t(8, 'a pet from another client cannot be logged against this booking',
+                    v_ok, coalesce(v_msg, 'the insert succeeded'));
+end $$;
+
+select n, name, case when ok then 'PASS' else 'FAIL' end as result, detail
+  from tap order by n;
+
+do $$
+declare v_failed int;
+begin
+  select count(*) into v_failed from tap where not ok;
+  if v_failed > 0 then
+    raise exception '% assertion(s) failed', v_failed;
+  end if;
+end $$;
+
+rollback;


### PR DESCRIPTION
The follow-on from #145, where the FEEDING and MEDICATIONS controls were hidden because `handleLog`, `handleAdd` and `handleAdminister` set component state and toasted — a reload lost the lot. This is what lets them come back.

`public.care_log_entries` ([`20260819140000`](supabase/migrations/20260819140000_a_care_log_entry_outlives_the_page.sql)). A row is **one execution of one scheduled task**: booking, pet, `task_key`, `task_type`, day, clock time, outcome, notes, and who recorded it — the name snapshotted, because a journal that renames itself when somebody leaves the business is not a journal.

## Why a table and not jsonb on the booking

The *instructions* belong to the booking and live in `bookings.details`. An *execution* has an actor, a clock time and an outcome, and there are many per booking per day. Appending them to the jsonb would mean every log rewriting the whole booking row, no way to ask what a member of staff did today, and a lost update whenever two people log at once — which is exactly what a morning shift is.

## The permission was the interesting part

The first draft gated writes on `edit_pet_records`. That reads sensibly and **is wrong**: measured against the presets, that key belongs to owner, admin, manager and supervisor — so the **caretaker and the boarding attendant**, the people who actually put the bowl down and hold the pill, could not record having done it.

The right keys already existed and did not need inventing:

```
log_feedings / log_medications / log_potty_breaks
  admin, boarding_attendant, caretaker, daycare_attendant, manager, owner, supervisor
```

Changing a pet's medical profile and recording that you fed it are different authorities, and the catalogue already said so. `private.care_log_permission_for(task_type)` maps a row to the key its own type names.

**Measured on production:**

| | feeding | medication | read |
|---|---|---|---|
| caretaker | ✅ | ✅ | ✅ |
| groomer | ❌ | — | ✅ |
| reception | ❌ | — | ✅ |

`supabase/tests/care-log.sql` keeps it that way — C1/C2 are the assertions that would have caught the first draft; C5 is the one that stops *"everyone who can read can write"* passing silently.

## One row per (booking, task, day)

Which is what `careLogStore.log()` merely intended: correcting a mis-tapped "refused" **edits** the record instead of appending a second meal. Enforced by `care_log_one_per_task_per_day`; the route upserts on it. **No DELETE policy** — a wrong entry is corrected, and the correction is the record.

## Verified end to end

On a built server against the live database: logged a meal and a dose, **reloaded**, and both came back —

```
sched-fs-1-occ-1  feeding     ate_all  Dana Okafor
med-1#08:00       medication  given    Dana Okafor
```

rendering as **"Ate all (100% of meal) — Dana Okafor at 1:58 PM"** and **"Given by Dana Okafor at 1:58 PM"**, with the 20:00 dose still pending and giveable.

### Two rendering bugs I introduced and fixed

Doses showed **"12:undefined AM"** — the panel formats `scheduledAt` with `new Date()`, so a bare `"08:00"` is an Invalid Date; it now carries the day. And a logged outcome rendered as its stored value (`ate_all`) because only the in-session path went through the label lookup; both paths do now.

## Still the in-memory store

The Guest Journal and Daily Care read `src/data/care-log-store.ts`. They carry photos, health observations and generated task schedules that `care_log_entries` doesn't model yet, so both exist for now. Converging them is the next step, and the store goes with it.

**Not built, deliberately:** adding an unplanned meal, and a note on a dose that hasn't been given. A care log row records the *execution of a scheduled task*, so neither has a home; the note travels with the dose when it's given, which is the path that persists.

## Notes

`database.ts` was hand-extended rather than regenerated — the committed file is a maintained subset in its own order, and regenerating produces a 2,000-line diff.

## Verified

- `typecheck` / `lint` / `format:check` / `build` green — no new lint warnings (one fewer).
- All seven project gates pass, including `check:rls-writes` and `check:facility-from-session`.
- **62 e2e passed / 1 skipped / 0 failed.**
- Test rows cleared: `care_log_entries 0`, live bookings 34.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
