### PR TITLE
feat(bookings): the Payment Summary is a breakdown

### DIFF
--- a/docs/quality/debt-map.md
+++ b/docs/quality/debt-map.md
@@ -2203,6 +2203,68 @@ toast; a reload lost all of it. That was invisible while the panels were empty
 and became reachable the moment they started rendering real instructions, so
 `canLog={false}` hid Add Meal, Add Medication, Log meal and Give.
 
+### 🟢 The booking's Payment Summary is a breakdown (was 🟡)
+
+Reported from the running app: _"in here we are supposed to have all the
+breakdown"_, over a panel reading Base Price $100 / Total $100.
+
+**The panel was less bare than it looked** — it already had Base Price,
+Discount, Added Items and Total. It showed two rows because that booking had
+none of the rest. What it genuinely lacked: the individual **lines** (every
+`booking_line_items` row collapsed into one "Added Items" figure), the **tip**,
+and **paid / balance** — so a screen whose header said "Pay by card — $100.00"
+never said what was owed.
+
+The rich `InvoicePanel` renders only when `booking.invoice` exists, and that
+blob is on exactly the **26 migrated fixture bookings**. Every booking made
+since the migration got the stub.
+
+`BookingPaymentBreakdown` builds it from rows instead. Every line names a
+source, and `GET /api/bookings/<ref>/line-items` was added for the lines — a
+separate read rather than a join on `BOOKING_SELECT`, which feeds the bookings
+LIST too and would pay for lines on a screen that shows none.
+
+**THE TRAP, and it nearly shipped: `bookings.amount_due` is what a booking
+COSTS, not what is owed.** Booking 569 carries `amount_paid 200` AND
+`amount_due 200`. Reading it as the balance would have printed "Balance due
+$200.00" on a booking settled in full, on the screen somebody uses to decide
+whether to ask a customer for money. The balance comes from `balanceOf()` — the
+same helper the "Pay by card" button uses, so the two figures on the screen
+cannot disagree. Verified against both shapes:
+
+```
+569  Boarding $180 · Late pickup (73 min) $20 · Total $200 · Paid −$200 · Settled $0
+426  Daycare  $60  · Bag of food 2 × $12  $24 · Total $84  · Balance due $84
+```
+
+**No tax line, deliberately.** The fixture invoice showed GST 5% and QST 9.975%.
+`facility_settings` has six domains and none is tax, so a rate would be one
+chosen on the facility's behalf and printed on something they hand a customer.
+
+### 🔴 The terminal receipt cannot itemise, because no Clover order is created
+
+The same report asked for the printed receipt to carry the breakdown. It cannot
+today, and not for a UI reason: **nothing in this codebase creates a Clover
+order.** Both money paths send a bare amount —
+
+```
+lib/clover/terminal.ts   { amount, externalPaymentId, final, tipAmount? }
+lib/clover/charge.ts     { amount, currency, source, ecomind, capture }
+```
+
+Clover prints what is on the ORDER. With no order and no line items, the device
+has one number to print, so the receipt is a total by construction.
+
+**What it takes:** create an order on the merchant, add a line item per charged
+line (the same lines the panel above now renders), then take the payment against
+that order id rather than a naked amount.
+
+**Why it is not done here:** it changes the live money path, on the one leg of
+the Clover integration that has never been exercised in production — the
+terminal tender has never been clicked (see the Clover notes). It needs the
+sandbox device in hand to verify, and shipping an unverified change to how money
+is taken is worse than a receipt that under-reports.
+
 ### 🟢 Logging a feeding and giving a dose are real (was 🔴 — the follow-on)
 
 `public.care_log_entries` (20260819140000). A row is one execution of one

--- a/src/app/api/bookings/[ref]/line-items/route.ts
+++ b/src/app/api/bookings/[ref]/line-items/route.ts
@@ -44,6 +44,84 @@ async function resolveBooking(
   return (data as { id: string; facility_id: string } | null) ?? null;
 }
 
+export interface BookingLineItem {
+  id: string;
+  kind: "item" | "fee";
+  name: string;
+  unitPrice: number;
+  quantity: number;
+  price: number;
+  authorName: string;
+  createdAt: string;
+}
+
+/**
+ * The lines on a booking's bill.
+ *
+ * Added so the booking page can show a BREAKDOWN rather than a total. It had
+ * only `extras_total` — one number — so a bill of "Boarding, plus a bag of
+ * food, plus a late fee" rendered as "Base Price / Total", which is what the
+ * facility reported: "we are supposed to have all the breakdown".
+ *
+ * A separate read rather than a join on BOOKING_SELECT: that select feeds the
+ * bookings LIST too, and hanging every booking's lines off it would pay for
+ * them on a screen that shows none of them.
+ */
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ ref: string }> },
+) {
+  const user = await getCurrentUser().catch(() => null);
+  if (!user) {
+    return NextResponse.json({ error: "Not signed in." }, { status: 401 });
+  }
+
+  const supabase = await createServerClient();
+  const booking = await resolveBooking(supabase, (await params).ref);
+  if (!booking) {
+    return NextResponse.json({ error: "No such booking." }, { status: 404 });
+  }
+
+  const { data, error } = await supabase
+    .from("booking_line_items")
+    .select(
+      "id, kind, name, unit_price, quantity, price, author_name, created_at",
+    )
+    .eq("booking_id", booking.id)
+    .order("created_at", { ascending: true });
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  const rows = (data ?? []) as {
+    id: string;
+    kind: "item" | "fee";
+    name: string;
+    unit_price: number | string;
+    quantity: number;
+    price: number | string | null;
+    author_name: string;
+    created_at: string;
+  }[];
+
+  return NextResponse.json(
+    rows.map((r) => ({
+      id: r.id,
+      kind: r.kind,
+      name: r.name,
+      unitPrice: Number(r.unit_price),
+      quantity: r.quantity,
+      // `price` is generated (unit_price * quantity); computing it here when
+      // absent would be a second definition of the same number.
+      price:
+        r.price === null ? Number(r.unit_price) * r.quantity : Number(r.price),
+      authorName: r.author_name,
+      createdAt: r.created_at,
+    })) satisfies BookingLineItem[],
+  );
+}
+
 export async function POST(
   request: NextRequest,
   { params }: { params: Promise<{ ref: string }> },

--- a/src/app/facility/dashboard/clients/[id]/bookings/[bookingId]/page.tsx
+++ b/src/app/facility/dashboard/clients/[id]/bookings/[bookingId]/page.tsx
@@ -51,6 +51,10 @@ import { PrintKennelCardsModal } from "@/components/facility/boarding/kennel-car
 import { StatusBadge } from "@/components/ui/StatusBadge";
 import { InvoicePanel } from "@/components/bookings/InvoicePanel";
 import {
+  AcceptPaymentButton,
+  BookingPaymentBreakdown,
+} from "@/components/bookings/BookingPaymentBreakdown";
+import {
   applyFeedingLog,
   applyMedicationLog,
   careLogStamp,
@@ -1585,76 +1589,26 @@ export default function ClientBookingDetailPage({
                     extraServiceItems={incidentCareItems}
                   />
                 ) : (
-                  <Card>
-                    <CardHeader className="bg-muted/30 pb-3">
-                      <CardTitle className="text-xs font-semibold tracking-wider uppercase">
-                        Payment Summary
-                      </CardTitle>
-                    </CardHeader>
-                    <CardContent className="pt-4">
-                      <div className="space-y-3">
-                        <div className="flex justify-between text-sm">
-                          <span className="text-muted-foreground">
-                            Base Price
-                          </span>
-                          <span className="font-[tabular-nums] font-medium">
-                            ${booking.basePrice.toFixed(2)}
-                          </span>
-                        </div>
-                        {booking.discount > 0 && (
-                          <div className="flex justify-between text-sm">
-                            <span className="text-muted-foreground">
-                              Discount
-                            </span>
-                            <span className="font-[tabular-nums] font-medium text-emerald-600">
-                              -${booking.discount.toFixed(2)}
-                            </span>
-                          </div>
-                        )}
-                        {addedSubtotal > 0 && (
-                          <div className="flex justify-between text-sm">
-                            <span className="text-muted-foreground">
-                              Added Items
-                            </span>
-                            <span className="font-[tabular-nums] font-medium text-amber-600">
-                              +${addedSubtotal.toFixed(2)}
-                            </span>
-                          </div>
-                        )}
-                        {incidentCareTotal > 0 && (
-                          <div className="flex justify-between text-sm">
-                            <span className="text-muted-foreground">
-                              Incident Care
-                            </span>
-                            <span className="font-[tabular-nums] font-medium text-amber-600">
-                              +${incidentCareTotal.toFixed(2)}
-                            </span>
-                          </div>
-                        )}
-                        <Separator />
-                        <div className="flex items-baseline justify-between">
-                          <span className="text-sm font-semibold">Total</span>
-                          <span className="font-[tabular-nums] text-2xl font-bold">
-                            $
-                            {(
-                              booking.totalCost +
-                              addedSubtotal +
-                              incidentCareTotal
-                            ).toFixed(2)}
-                          </span>
-                        </div>
-                        {!isPaid && !isCancelled && (
-                          <Button
-                            className="mt-2 h-10 w-full gap-1.5"
-                            onClick={() => setPaymentOpen(true)}
-                          >
-                            <CreditCard className="size-4" />
-                            Accept Payment
-                          </Button>
-                        )}
-                      </div>
-                    </CardContent>
-                  </Card>
+                  // ── THE BREAKDOWN, LINE BY LINE ──────────────────────────
+                  //
+                  // This was Base Price / Discount / Added Items / Total, with
+                  // "Added Items" aggregating every line into one number, no
+                  // tip, and no paid-or-owing at all — so a booking with
+                  // nothing added showed two rows, which is what the facility
+                  // reported. Each line now names what it is and where it came
+                  // from; see the component for which source each has.
+                  <BookingPaymentBreakdown
+                    booking={booking}
+                    incidentCareTotal={incidentCareTotal}
+                    action={
+                      !isPaid && !isCancelled ? (
+                        <AcceptPaymentButton
+                          amount={balanceOf(booking)}
+                          onClick={() => setPaymentOpen(true)}
+                        />
+                      ) : null
+                    }
+                  />
                 ))}
             </div>
           </div>

--- a/src/components/bookings/BookingPaymentBreakdown.tsx
+++ b/src/components/bookings/BookingPaymentBreakdown.tsx
@@ -1,0 +1,259 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { CreditCard, Loader2 } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { balanceOf } from "@/lib/api/booking-money";
+import type { BookingLineItem } from "@/app/api/bookings/[ref]/line-items/route";
+import type { Booking } from "@/types/booking";
+
+// ============================================================================
+// What this booking costs, line by line.
+//
+// ── WHAT IT REPLACED ──────────────────────────────────────────────────────
+//
+// Two rows — "Base Price" and "Total" — shown whenever `booking.invoice` was
+// absent. That blob only exists on the 26 migrated fixture bookings, so every
+// booking made since the migration rendered the stub. Reported from the running
+// app: "in here we are supposed to have all the breakdown".
+//
+// ── EVERY LINE HERE HAS A SOURCE ──────────────────────────────────────────
+//
+//   the service      bookings.base_price
+//   added lines      booking_line_items (a bag of food, a late fee) —
+//                    GET /api/bookings/<ref>/line-items
+//   discount         bookings.discount
+//   tip              bookings.tip_amount
+//   total            bookings.amount_due — which is what it COSTS, price plus
+//                    extras, NOT the outstanding balance. The name is a trap:
+//                    booking 569 carries amount_paid 200 AND amount_due 200.
+//   paid             bookings.amount_paid, derived by the database from the
+//                    payments ledger (20260806680000) — never computed here
+//   balance          balanceOf(), the same helper the "Pay by card" button
+//                    uses, so the two figures on this screen cannot disagree
+//
+// ── AND NO TAX LINE, DELIBERATELY ─────────────────────────────────────────
+//
+// The fixture invoice showed GST 5% and QST 9.975%. There is no tax
+// configuration anywhere real: `facility_settings` has six domains and none of
+// them is tax. Rendering a tax line would mean choosing a rate on the
+// facility's behalf and putting it on something they hand to a customer, so
+// this shows what is charged and stays quiet about how it is composed until
+// the facility can say.
+// ============================================================================
+
+interface BookingPaymentBreakdownProps {
+  booking: Booking;
+  /**
+   * Incident-care charges, which come from `src/data/incidents` rather than
+   * from `booking_line_items`. Passed in rather than read here so this
+   * component keeps one source per line and the fixture stays visible at the
+   * call site until incidents are rows.
+   */
+  incidentCareTotal?: number;
+  /** Rendered under the totals — the existing Accept Payment control. */
+  action?: React.ReactNode;
+}
+
+function Money({ value, bold }: { value: number; bold?: boolean }) {
+  return (
+    <span
+      className={bold ? "text-base font-bold" : "text-muted-foreground text-sm"}
+    >
+      {value < 0 ? "−" : ""}${Math.abs(value).toFixed(2)}
+    </span>
+  );
+}
+
+function Line({
+  label,
+  hint,
+  value,
+  bold,
+  tone,
+}: {
+  label: string;
+  hint?: string;
+  value: number;
+  bold?: boolean;
+  tone?: string;
+}) {
+  return (
+    <div className="flex items-baseline justify-between gap-4 py-1.5">
+      <div className="min-w-0">
+        <span className={bold ? "text-sm font-semibold" : "text-sm"}>
+          {label}
+        </span>
+        {hint && (
+          <span className="text-muted-foreground ml-2 text-xs">{hint}</span>
+        )}
+      </div>
+      <span className={tone}>
+        <Money value={value} bold={bold} />
+      </span>
+    </div>
+  );
+}
+
+export function BookingPaymentBreakdown({
+  booking,
+  incidentCareTotal = 0,
+  action,
+}: BookingPaymentBreakdownProps) {
+  const { data: lineItems, isPending } = useQuery({
+    queryKey: ["bookings", booking.id, "line-items"],
+    queryFn: async (): Promise<BookingLineItem[]> => {
+      const response = await fetch(`/api/bookings/${booking.id}/line-items`);
+      if (!response.ok) throw new Error("Could not read the bill.");
+      return (await response.json()) as BookingLineItem[];
+    },
+    staleTime: 30_000,
+  });
+
+  const items = lineItems ?? [];
+  const extras = items.reduce((sum, i) => sum + i.price, 0);
+  const discount = booking.discount ?? 0;
+  const tip = booking.tipAmount ?? 0;
+
+  // `amountDue` and `amountPaid` are the database's, derived from the payments
+  // ledger. The subtotal is the only figure assembled here, and only so the
+  // lines above it add up on screen.
+  // The subtotal is the only figure assembled here, and only so the lines
+  // above it add up on screen. The total and the balance are the database's.
+  const subtotal = booking.basePrice + extras + incidentCareTotal - discount;
+  const paid = booking.amountPaid ?? 0;
+  // NOT `booking.amountDue` for the balance — that column is the COST, not
+  // what is owed. Using it would have shown "Balance due $200" on a booking
+  // paid in full (booking 569 carries amount_paid 200 AND amount_due 200).
+  // balanceOf() is what the "Pay by card" button uses, so the two figures on
+  // this screen cannot disagree.
+  const total = booking.amountDue ?? subtotal;
+  const balance = balanceOf(booking);
+
+  // `service` is stored lowercase ("boarding"); `serviceType` is the named
+  // package when there is one. Either way it is the thing being charged for,
+  // so it reads as a line on a bill rather than as a column value.
+  const raw = booking.serviceType || booking.service;
+  const serviceLabel = raw.charAt(0).toUpperCase() + raw.slice(1);
+
+  return (
+    <Card>
+      <CardHeader className="bg-muted/30 pb-3">
+        <CardTitle className="text-xs font-semibold tracking-wider uppercase">
+          Payment Summary
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="pt-4">
+        <div className="divide-y">
+          <div className="pb-1">
+            <Line
+              label={serviceLabel}
+              hint="Service"
+              value={booking.basePrice}
+            />
+          </div>
+
+          {isPending ? (
+            <div className="py-2">
+              <Skeleton className="h-4 w-2/3" />
+            </div>
+          ) : items.length > 0 ? (
+            <div className="py-1">
+              {items.map((item) => (
+                <Line
+                  key={item.id}
+                  label={item.name}
+                  hint={
+                    item.quantity > 1
+                      ? `${item.quantity} × $${item.unitPrice.toFixed(2)}`
+                      : item.kind === "fee"
+                        ? "Fee"
+                        : undefined
+                  }
+                  value={item.price}
+                />
+              ))}
+            </div>
+          ) : null}
+
+          {incidentCareTotal > 0 && (
+            <div className="py-1">
+              <Line
+                label="Incident care"
+                hint="From an incident report"
+                value={incidentCareTotal}
+              />
+            </div>
+          )}
+
+          {discount > 0 && (
+            <div className="py-1">
+              <Line
+                label="Discount"
+                hint={booking.discountReason}
+                value={-discount}
+                tone="text-emerald-600"
+              />
+            </div>
+          )}
+
+          <div className="py-1">
+            <Line label="Subtotal" value={subtotal} bold />
+          </div>
+
+          {tip > 0 && (
+            <div className="py-1">
+              <Line label="Tip" value={tip} />
+            </div>
+          )}
+
+          <div className="py-1">
+            <Line label="Total" value={total + tip} bold />
+          </div>
+
+          {paid > 0 && (
+            <div className="py-1">
+              <Line label="Paid" value={-paid} tone="text-emerald-600" />
+            </div>
+          )}
+
+          <div className="pt-1">
+            <Line
+              label={balance > 0 ? "Balance due" : "Settled"}
+              value={balance}
+              bold
+              tone={balance > 0 ? "text-amber-700" : "text-emerald-600"}
+            />
+          </div>
+        </div>
+
+        {action && <div className="mt-4">{action}</div>}
+      </CardContent>
+    </Card>
+  );
+}
+
+/** The Accept Payment control, unchanged, for the parent to pass in. */
+export function AcceptPaymentButton({
+  onClick,
+  busy,
+  amount,
+}: {
+  onClick: () => void;
+  busy?: boolean;
+  amount: number;
+}) {
+  return (
+    <Button className="w-full gap-2" onClick={onClick} disabled={busy}>
+      {busy ? (
+        <Loader2 className="size-4 animate-spin" />
+      ) : (
+        <CreditCard className="size-4" />
+      )}
+      Accept Payment{amount > 0 ? ` — $${amount.toFixed(2)}` : ""}
+    </Button>
+  );
+}


### PR DESCRIPTION
> *"In here we are supposed to have all the breakdown"* — over a panel reading **Base Price $100 / Total $100**.

## The panel was less bare than it looked

It already had Base Price, Discount, Added Items and Total. It showed two rows because **that booking had none of the rest**. What it genuinely lacked:

- the individual **lines** — every `booking_line_items` row collapsed into one "Added Items" figure
- the **tip**
- **paid / balance** — so a screen whose header said *"Pay by card — $100.00"* never said what was owed

The rich `InvoicePanel` renders only when `booking.invoice` exists, and that blob is on exactly the **26 migrated fixture bookings**. Every booking made since the migration got the stub.

## Built from rows, and every line names its source

| line | source |
|---|---|
| the service | `bookings.base_price` |
| added lines | `booking_line_items`, via a new `GET /api/bookings/<ref>/line-items` |
| incident care | `src/data/incidents` — still a fixture, passed in from the call site so it stays visible |
| discount | `bookings.discount` |
| tip | `bookings.tip_amount` |
| paid | `bookings.amount_paid`, derived from the payments ledger |
| balance | `balanceOf()` |

A **separate read** rather than a join on `BOOKING_SELECT` — that select feeds the bookings *list* too, and hanging every booking's lines off it would pay for them on a screen that shows none.

## ⚠️ The trap, which nearly shipped

**`bookings.amount_due` is what a booking COSTS, not what is owed.** Booking 569 carries `amount_paid 200` **and** `amount_due 200`.

Reading it as the balance would have printed **"Balance due $200.00" on a booking settled in full** — on the screen somebody uses to decide whether to ask a customer for money. The balance now comes from `balanceOf()`, the same helper the "Pay by card" button uses, so the two figures on the screen cannot disagree.

**Verified against both shapes on the live database:**

```
569   Boarding $180 · Late pickup (73 min) $20 · Total $200 · Paid −$200 · Settled $0
426   Daycare  $60  · Bag of food 2 × $12  $24 · Total $84  · Balance due $84
```

## No tax line, deliberately

The fixture invoice showed GST 5% and QST 9.975%. `facility_settings` has six domains and **none is tax**, so a rate here would be one chosen on the facility's behalf and printed on something they hand a customer.

## The printed receipt is NOT fixed — and it isn't a UI problem

The same report asked for the terminal receipt to carry the breakdown. It can't today, for a concrete reason: **nothing in this codebase creates a Clover order.** Both money paths send a bare amount —

```
lib/clover/terminal.ts   { amount, externalPaymentId, final, tipAmount? }
lib/clover/charge.ts     { amount, currency, source, ecomind, capture }
```

Clover prints what's on the **order**. With no order and no line items, the device has one number to print — the receipt is a total by construction.

**What it takes:** create an order on the merchant, add a line item per charged line (the same lines this panel now renders), then take the payment against that order id rather than a naked amount.

**Why it isn't in this PR:** it changes the live money path, on the one leg of the Clover integration that has never been exercised in production — the terminal tender has never been clicked. It needs the sandbox device in hand to verify, and shipping an unverified change to how money is taken is worse than a receipt that under-reports. Recorded in the debt map.

## Verified

- `typecheck` / `lint` / `format:check` / `build` green.
- All **eight** project gates, including `check:pricing`.
- **62 e2e passed / 1 skipped / 0 failed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
