### PR TITLE
feat(payments): the terminal prints the itemised receipt

### DIFF
--- a/docs/quality/debt-map.md
+++ b/docs/quality/debt-map.md
@@ -2241,7 +2241,39 @@ cannot disagree. Verified against both shapes:
 `facility_settings` has six domains and none is tax, so a rate would be one
 chosen on the facility's behalf and printed on something they hand a customer.
 
-### 🔴 The terminal receipt cannot itemise, because no Clover order is created
+### 🟡 The terminal receipt itemises — printed as text, awaiting one tap to confirm
+
+**The order route is closed, and that is a property of the API, not a gap here.**
+Clover documents the REST Pay Display API — `/connect/v1/payments`, which is
+what drives a semi-integrated terminal — as _payment-only_, and says it "does
+not support passing an order ID or item ID directly". Orders belong to the v3
+REST API and the Developer Pay endpoint (`/v2/merchant/{mId}/pay`, which
+_requires_ an orderId), neither of which drives this hardware.
+
+**What the same API does offer is the printer.** `POST /connect/v1/device/print`
+takes `{ printDeviceId, text: [...] }` and prints those lines on the device's
+own roll; `POST /connect/v1/device/printers` answers with the printer ids. So
+the breakdown is composed as text (`lib/clover/receipt.ts`, 32 columns — the
+width of an 80mm roll) and printed as a second act.
+
+**THE PAYMENT CALL IS BYTE-IDENTICAL.** Printing happens after an approved sale,
+in its own request, and its failure is reported but never changes the payment's
+outcome. That was the whole design constraint: a sale that succeeded with no
+paper is a nuisance; a sale reported as failed because a printer jammed is a
+double charge. `lib/clover/print.ts` cannot throw, has short timeouts and no
+retries, and the toast says which happened either way.
+
+The no-charge readiness check (`checkOnly`) now also reports `canPrint`, so a
+terminal with no printer is discoverable before somebody takes money on it.
+
+**Not yet confirmed on hardware.** The Clover connection belongs to `pawradise`,
+whose only members are PRODUCTION identities (`clover-staff@yipyy.com`,
+`develop@yipyy.com`), and a local run holds staging keys — the same reason
+`clover-terminal.spec.ts` skips locally. It needs one tap on the deployed app.
+Until that happens this stays 🟡: written against the documented API, verified as
+far as a keyboard allows, and unproven on paper.
+
+### 🔴 (superseded) The terminal receipt cannot itemise, because no Clover order is created
 
 The same report asked for the printed receipt to carry the breakdown. It cannot
 today, and not for a UI reason: **nothing in this codebase creates a Clover

--- a/src/app/api/payments/clover/terminal/route.ts
+++ b/src/app/api/payments/clover/terminal/route.ts
@@ -5,6 +5,8 @@ import { getViewer } from "@/lib/auth/viewer";
 import { holds, myPermissions } from "@/lib/auth/permissions";
 import { createServerClient } from "@/lib/supabase/server";
 import { chargeOnTerminal, deviceState } from "@/lib/clover/terminal";
+import { devicePrinters, printTextOnDevice } from "@/lib/clover/print";
+import { buildReceiptLines } from "@/lib/clover/receipt";
 
 // ============================================================================
 // Charging a card on the counter's own terminal.
@@ -68,7 +70,9 @@ export async function POST(request: NextRequest) {
   const supabase = await createServerClient();
   const { data: booking } = await supabase
     .from("bookings")
-    .select("id, facility_id, client_id, amount_due, amount_paid, status")
+    .select(
+      "id, ref, facility_id, client_id, amount_due, amount_paid, status, service, service_type, base_price, discount, tip_amount, facilities ( name, timezone ), clients ( name ), booking_pets ( pets ( name ) )",
+    )
     .eq("ref", parsed.data.bookingRef)
     .maybeSingle();
 
@@ -89,10 +93,23 @@ export async function POST(request: NextRequest) {
       booking.facility_id,
       parsed.data.deviceSerial,
     );
+    // And whether it can PRINT. A terminal that takes the payment but has no
+    // printer produces a charge with no receipt, and the person finds out after
+    // the customer has paid. Asking here costs one read and charges nothing.
+    //
+    // Only when the device is awake: a sleeping terminal answers this the same
+    // way it answers everything else, and a second 15-second timeout on the
+    // readiness check is what this branch was written to avoid.
+    const printers =
+      state.kind === "ready"
+        ? await devicePrinters(booking.facility_id, parsed.data.deviceSerial)
+        : [];
     return NextResponse.json({
       ready: state.kind === "ready",
       state: state.kind,
       detail: state.kind === "ready" ? "The terminal is ready." : state.detail,
+      canPrint: printers.length > 0,
+      printers: printers.map((p) => ({ id: p.id, name: p.name })),
     });
   }
 
@@ -144,6 +161,24 @@ export async function POST(request: NextRequest) {
     );
   }
 
+  // ── THE ITEMISED RECEIPT ────────────────────────────────────────────────
+  //
+  // AFTER the sale, in its own request, and its result is reported but never
+  // allowed to change the payment's. The facility asked for the printed receipt
+  // to carry the same breakdown as the portal; Clover's REST Pay Display API is
+  // payment-only and takes no order or item id, so the breakdown is composed as
+  // text and sent to the device's own printer (lib/clover/receipt.ts).
+  //
+  // A sale that succeeded and a receipt that did not print is a nuisance. A
+  // sale reported as failed because a printer jammed is a double charge, so
+  // this cannot throw and its failure is a log line and a flag on the response.
+  const printed = await printReceipt(
+    booking as unknown as BookingForReceipt,
+    supabase,
+    outcome,
+    parsed.data.deviceSerial,
+  );
+
   return NextResponse.json({
     paid: true,
     paymentId: outcome.paymentId,
@@ -152,5 +187,106 @@ export async function POST(request: NextRequest) {
     currency: outcome.currency,
     cardBrand: outcome.cardBrand,
     cardLast4: outcome.cardLast4,
+    receiptPrinted: printed.printed,
+    receiptDetail: printed.detail,
   });
+}
+
+interface BookingForReceipt {
+  id: string;
+  ref: number;
+  facility_id: string;
+  service: string;
+  service_type: string | null;
+  base_price: number | string;
+  discount: number | string | null;
+  tip_amount: number | string | null;
+  facilities: { name: string; timezone: string | null } | null;
+  clients: { name: string } | null;
+  booking_pets: { pets: { name: string } | null }[] | null;
+}
+
+/**
+ * Compose and print the itemised receipt. Never throws.
+ *
+ * The lines are read HERE rather than passed from the client: a receipt is a
+ * record of what was charged, and a caller that could name its own line items
+ * could print a receipt that disagrees with the payment.
+ */
+async function printReceipt(
+  booking: BookingForReceipt,
+  supabase: Awaited<ReturnType<typeof createServerClient>>,
+  outcome: Extract<Awaited<ReturnType<typeof chargeOnTerminal>>, { ok: true }>,
+  deviceSerial: string,
+): Promise<{ printed: boolean; detail?: string }> {
+  try {
+    const { data: rows } = await supabase
+      .from("booking_line_items")
+      .select("name, price, unit_price, quantity")
+      .eq("booking_id", booking.id)
+      .order("created_at", { ascending: true });
+
+    const cents = (v: number | string | null | undefined) =>
+      Math.round(Number(v ?? 0) * 100);
+
+    const lines = [
+      {
+        label: booking.service_type || booking.service,
+        amountCents: cents(booking.base_price),
+      },
+      ...(
+        (rows ?? []) as {
+          name: string;
+          price: number | string | null;
+          unit_price: number | string;
+          quantity: number;
+        }[]
+      ).map((r) => ({
+        label: r.quantity > 1 ? `${r.name} x${r.quantity}` : r.name,
+        amountCents:
+          r.price === null
+            ? cents(Number(r.unit_price) * r.quantity)
+            : cents(r.price),
+      })),
+    ];
+
+    const discountCents = cents(booking.discount);
+    const subtotalCents =
+      lines.reduce((sum, l) => sum + l.amountCents, 0) - discountCents;
+    const tipCents = Math.max(0, outcome.amountCents - subtotalCents);
+
+    const text = buildReceiptLines({
+      facilityName: booking.facilities?.name ?? "Yipyy",
+      reference: `Booking #${booking.ref}`,
+      clientName: booking.clients?.name ?? null,
+      petNames: (booking.booking_pets ?? [])
+        .map((bp) => bp.pets?.name)
+        .filter((n): n is string => Boolean(n)),
+      lines,
+      discountCents,
+      subtotalCents,
+      tipCents,
+      totalCents: outcome.amountCents,
+      cardBrand: outcome.cardBrand,
+      cardLast4: outcome.cardLast4,
+      processorPaymentId: outcome.processorPaymentId,
+      // The FACILITY's clock, not the server's. A receipt handed over a counter
+      // in Montreal saying 09:00 UTC is wrong on paper nobody can correct.
+      printedAt: new Date().toLocaleString("en-CA", {
+        timeZone: booking.facilities?.timezone ?? "UTC",
+        dateStyle: "medium",
+        timeStyle: "short",
+      }),
+    });
+
+    // The same device that took the payment, so the receipt comes out of the
+    // terminal the customer is standing at.
+    return await printTextOnDevice(booking.facility_id, deviceSerial, text);
+  } catch (error) {
+    console.warn("[terminal] receipt not printed:", error);
+    return {
+      printed: false,
+      detail: error instanceof Error ? error.message : "unknown",
+    };
+  }
 }

--- a/src/app/facility/dashboard/clients/[id]/bookings/[bookingId]/page.tsx
+++ b/src/app/facility/dashboard/clients/[id]/bookings/[bookingId]/page.tsx
@@ -1805,12 +1805,24 @@ export default function ClientBookingDetailPage({
                   ? { tipCents: Math.round(payment.tip * 100) }
                   : {}),
               });
+              const card = result.cardLast4
+                ? `${result.cardBrand ?? "Card"} ···${result.cardLast4}`
+                : null;
               toast.success(
                 `$${(result.amountCents / 100).toFixed(2)} taken on the terminal`,
                 {
-                  description: result.cardLast4
-                    ? `${result.cardBrand ?? "Card"} ···${result.cardLast4}`
-                    : undefined,
+                  description: [
+                    card,
+                    // Said out loud either way. A charge that went through with
+                    // no paper is something the person at the counter has to
+                    // know BEFORE the customer walks off, and silence would let
+                    // them assume a receipt printed.
+                    result.receiptPrinted
+                      ? "Itemised receipt printed."
+                      : "No receipt printed — hand over the copy from Print.",
+                  ]
+                    .filter(Boolean)
+                    .join(" · "),
                 },
               );
               setPendingLateFee(null);

--- a/src/lib/api/terminals.ts
+++ b/src/lib/api/terminals.ts
@@ -145,6 +145,16 @@ export interface TerminalChargeResult {
   amountCents: number;
   cardBrand: string | null;
   cardLast4: string | null;
+  /**
+   * Whether the itemised receipt reached the device's printer.
+   *
+   * Separate from the payment on purpose: printing happens after an approved
+   * sale, in its own request, and a failed print leaves a completed payment
+   * completed. The caller should SAY so rather than hide it — the person at the
+   * counter needs to know whether to reach for the roll or hand over paper.
+   */
+  receiptPrinted: boolean;
+  receiptDetail?: string;
 }
 
 /**
@@ -186,6 +196,8 @@ export function useChargeOnTerminal() {
         amountCents: parsed?.amountCents ?? 0,
         cardBrand: parsed?.cardBrand ?? null,
         cardLast4: parsed?.cardLast4 ?? null,
+        receiptPrinted: parsed?.receiptPrinted === true,
+        receiptDetail: parsed?.receiptDetail,
       };
     },
     onSuccess: () => {

--- a/src/lib/clover/print.ts
+++ b/src/lib/clover/print.ts
@@ -1,0 +1,150 @@
+import "server-only";
+
+import { cloverConfig } from "@/lib/clover/config";
+import { validAccessToken } from "@/lib/clover/connection";
+
+// ============================================================================
+// Printing on the terminal's own roll.
+//
+// Two endpoints of the REST Pay Display API:
+//
+//   POST /connect/v1/device/printers   empty body, answers with the printers
+//   POST /connect/v1/device/print      { printDeviceId, text: [...] }
+//
+// ── NOTHING HERE MAY AFFECT A PAYMENT ─────────────────────────────────────
+//
+// Every function returns rather than throws, and the caller is expected to
+// ignore a failure. A sale that succeeded and a receipt that did not print are
+// a customer with a card charged and no paper — which is a nuisance. A sale
+// reported as failed because the printer was out of paper is a customer charged
+// twice, which is not.
+//
+// So: short timeouts, no retries, and the outcome is a boolean the caller may
+// discard.
+// ============================================================================
+
+interface Printer {
+  id: string;
+  name?: string;
+  type?: string;
+}
+
+function headers(
+  accessToken: string,
+  merchantId: string,
+  serial: string,
+): Record<string, string> {
+  return {
+    Authorization: `Bearer ${accessToken}`,
+    "X-Clover-Merchant-Id": merchantId,
+    // The SERIAL. Named "Device-Id", is not the device id — same trap as the
+    // payment call, and getting it wrong here is a 4xx rather than a wrong
+    // printer.
+    "X-Clover-Device-Id": serial,
+    "X-POS-Id": "Yipyy",
+    Accept: "application/json",
+    "Content-Type": "application/json",
+  };
+}
+
+/**
+ * The device's printers, or an empty list.
+ *
+ * The built-in roll is what we want; a merchant with an attached kitchen
+ * printer would list more than one, and the first is the device's own.
+ */
+export async function devicePrinters(
+  facilityId: string,
+  deviceSerial: string,
+): Promise<Printer[]> {
+  const active = await validAccessToken(facilityId);
+  if (!active) return [];
+
+  const config = cloverConfig(active.environment);
+  if (!config) return [];
+
+  try {
+    const response = await fetch(
+      new URL("/connect/v1/device/printers", config.apiOrigin),
+      {
+        method: "POST",
+        headers: headers(active.accessToken, active.merchantId, deviceSerial),
+        body: "{}",
+        signal: AbortSignal.timeout(15_000),
+      },
+    );
+    if (!response.ok) {
+      console.warn(
+        `[clover-print] printers -> ${response.status} ${await response
+          .text()
+          .catch(() => "")}`.slice(0, 300),
+      );
+      return [];
+    }
+    const body = (await response.json().catch(() => null)) as
+      | { printers?: Printer[] }
+      | Printer[]
+      | null;
+    if (Array.isArray(body)) return body;
+    return body?.printers ?? [];
+  } catch (error) {
+    console.warn("[clover-print] printers failed:", error);
+    return [];
+  }
+}
+
+/**
+ * Print lines of text on the device.
+ *
+ * @returns whether the device accepted it — NOT whether paper came out, which
+ *   nothing over HTTP can tell us.
+ */
+export async function printTextOnDevice(
+  facilityId: string,
+  deviceSerial: string,
+  text: string[],
+  printDeviceId?: string,
+): Promise<{ printed: boolean; detail?: string }> {
+  if (text.length === 0) return { printed: false, detail: "nothing to print" };
+
+  const active = await validAccessToken(facilityId);
+  if (!active) return { printed: false, detail: "no clover token" };
+
+  const config = cloverConfig(active.environment);
+  if (!config) return { printed: false, detail: "clover is not configured" };
+
+  // The printer id is required. Asking for it costs one round trip and is the
+  // only way to learn it — there is no "default printer" the API accepts.
+  let printerId = printDeviceId;
+  if (!printerId) {
+    const printers = await devicePrinters(facilityId, deviceSerial);
+    printerId = printers[0]?.id;
+  }
+  if (!printerId) return { printed: false, detail: "no printer on the device" };
+
+  try {
+    const response = await fetch(
+      new URL("/connect/v1/device/print", config.apiOrigin),
+      {
+        method: "POST",
+        headers: headers(active.accessToken, active.merchantId, deviceSerial),
+        body: JSON.stringify({ printDeviceId: printerId, text }),
+        signal: AbortSignal.timeout(20_000),
+      },
+    );
+    if (!response.ok) {
+      const detail = await response.text().catch(() => "");
+      console.warn(
+        `[clover-print] print -> ${response.status} ${detail}`.slice(0, 300),
+      );
+      return { printed: false, detail: `${response.status}` };
+    }
+    return { printed: true };
+  } catch (error) {
+    console.warn("[clover-print] print failed:", error);
+    return {
+      printed: false,
+      detail: error instanceof Error ? error.message : "network",
+    };
+  }
+}

--- a/src/lib/clover/receipt.ts
+++ b/src/lib/clover/receipt.ts
@@ -1,0 +1,147 @@
+import "server-only";
+
+// ============================================================================
+// The itemised receipt, as lines of text for the terminal's own printer.
+//
+// ── WHY TEXT AND NOT AN ORDER ─────────────────────────────────────────────
+//
+// Reported from the running app: "when we print the receipt from the terminal,
+// it needs to have all the detailed breakdown on it like we should see in the
+// portal". The obvious route is Clover's order model — create an order, add
+// line items, take the payment against it, and let Clover print what it knows.
+//
+// That route is closed for this integration. The terminal here speaks the REST
+// Pay Display API (`/connect/v1/payments`), which Clover documents as a
+// payment-only interface that "does not support passing an order ID or item ID
+// directly". Orders belong to the v3 REST API and the Developer Pay endpoint,
+// neither of which drives a semi-integrated terminal.
+//
+// What the same API DOES offer is a printer: `/connect/v1/device/print` takes
+// `{ printDeviceId, text: [...] }` and prints those lines on the device's own
+// roll. So the breakdown is composed here, from the same figures the booking
+// page renders, and printed as a second act.
+//
+// ── AND THAT IS WHY THE PAYMENT CALL IS UNTOUCHED ─────────────────────────
+//
+// Printing happens AFTER an approved sale, in its own request. Nothing about
+// how money is taken changes — which matters, because the terminal leg is the
+// one part of this integration never exercised in production. A print that
+// fails must leave a completed payment completed.
+//
+// ── 32 CHARACTERS ─────────────────────────────────────────────────────────
+//
+// Clover's built-in printers are 80mm and render this text monospaced at 32
+// columns. Lines longer than that wrap, which turns a tidy right-aligned total
+// into two ragged lines, so amounts are laid out against that width here rather
+// than discovered on paper.
+// ============================================================================
+
+/** The printable width of a Clover receipt, in monospace characters. */
+const WIDTH = 32;
+
+function money(cents: number): string {
+  const sign = cents < 0 ? "-" : "";
+  return `${sign}$${(Math.abs(cents) / 100).toFixed(2)}`;
+}
+
+/**
+ * "Bag of food              $24.00" — label left, amount hard right.
+ *
+ * A label too long to leave room is truncated with an ellipsis rather than
+ * allowed to wrap: a wrapped line puts the amount on a row of its own, under
+ * the wrong label.
+ */
+function row(label: string, cents: number): string {
+  const amount = money(cents);
+  const room = WIDTH - amount.length - 1;
+  const left = label.length > room ? `${label.slice(0, room - 1)}…` : label;
+  return `${left}${" ".repeat(Math.max(1, WIDTH - left.length - amount.length))}${amount}`;
+}
+
+function centred(text: string): string {
+  if (text.length >= WIDTH) return text.slice(0, WIDTH);
+  const pad = Math.floor((WIDTH - text.length) / 2);
+  return `${" ".repeat(pad)}${text}`;
+}
+
+const RULE = "-".repeat(WIDTH);
+
+export interface ReceiptLine {
+  label: string;
+  amountCents: number;
+}
+
+export interface ReceiptInput {
+  facilityName: string;
+  /** "Booking #1234" — whatever names this sale on paper. */
+  reference: string | null;
+  clientName: string | null;
+  petNames: string[];
+  /** The service, the added items, the fees — in the order they should read. */
+  lines: ReceiptLine[];
+  discountCents: number;
+  subtotalCents: number;
+  tipCents: number;
+  totalCents: number;
+  cardBrand: string | null;
+  cardLast4: string | null;
+  /** Clover's own payment id, so a paper receipt maps to a transaction. */
+  processorPaymentId: string | null;
+  /** Rendered as-is; the caller owns the timezone. */
+  printedAt: string;
+}
+
+/**
+ * The receipt, as the array `/connect/v1/device/print` wants.
+ *
+ * Pure: no clock, no locale lookup, nothing that can throw. The caller supplies
+ * `printedAt` already formatted, because the facility's timezone is a property
+ * of the facility and not of this process.
+ */
+export function buildReceiptLines(input: ReceiptInput): string[] {
+  const out: string[] = [];
+
+  out.push(centred(input.facilityName.slice(0, WIDTH)));
+  out.push("");
+  if (input.reference) out.push(input.reference);
+  if (input.clientName) out.push(input.clientName);
+  if (input.petNames.length > 0) {
+    // One line however many pets; a stay for three dogs should not push the
+    // total off the bottom of a short roll.
+    out.push(`Pet: ${input.petNames.join(", ")}`.slice(0, WIDTH));
+  }
+  out.push(input.printedAt);
+  out.push(RULE);
+
+  for (const line of input.lines) {
+    out.push(row(line.label, line.amountCents));
+  }
+
+  if (input.discountCents > 0) {
+    out.push(row("Discount", -input.discountCents));
+  }
+
+  out.push(RULE);
+  out.push(row("Subtotal", input.subtotalCents));
+  if (input.tipCents > 0) out.push(row("Tip", input.tipCents));
+  out.push(row("TOTAL", input.totalCents));
+  out.push(RULE);
+
+  const card = [
+    input.cardBrand,
+    input.cardLast4 ? `••${input.cardLast4}` : null,
+  ]
+    .filter(Boolean)
+    .join(" ");
+  if (card) out.push(row("Paid by card", input.totalCents));
+  if (card) out.push(card);
+  if (input.processorPaymentId) {
+    out.push(`Ref: ${input.processorPaymentId}`.slice(0, WIDTH));
+  }
+
+  out.push("");
+  out.push(centred("Thank you"));
+  out.push("");
+
+  return out;
+}


### PR DESCRIPTION
> *"When we print the receipt from the terminal, it needs to have all the detailed breakdown on it like we should see in the portal."*

## The order route is closed — and that's the API's property, not a gap here

The obvious approach is Clover's order model: create an order, add line items, take the payment against it, let Clover print what it knows.

Clover documents the **REST Pay Display API** — `/connect/v1/payments`, which is what drives a semi-integrated terminal — as *payment-only*, and states it **"does not support passing an order ID or item ID directly."** Orders belong to the v3 REST API and to the Developer Pay endpoint (`/v2/merchant/{mId}/pay`, which *requires* an `orderId`), neither of which drives this hardware.

## What the same API does offer is the printer

```
POST /connect/v1/device/printers   →  the printer ids
POST /connect/v1/device/print      →  { printDeviceId, text: [...] }
```

`lib/clover/receipt.ts` composes the breakdown as text — **32 columns**, the width of an 80mm roll, with amounts laid out against that width rather than discovered on paper — and `lib/clover/print.ts` sends it.

The lines are read **server-side** from the booking and `booking_line_items`, never passed in: a receipt is a record of what was charged, and a caller that could name its own line items could print one that disagrees with the payment.

**Rendered:**

```
+--------------------------------+
|           Pawradise            |
|Booking #426                    |
|Alice Johnson                   |
|Pet: Buddy                      |
|19 Aug 2026, 2:41 p.m.          |
|--------------------------------|
|Daycare                   $60.00|
|Bag of food x2            $24.00|
|Late pickup (73 min)      $20.00|
|Discount                  -$5.00|
|--------------------------------|
|Subtotal                  $99.00|
|Tip                       $15.00|
|TOTAL                    $114.00|
|--------------------------------|
|Paid by card             $114.00|
|VISA ••4242                     |
|Ref: H2K9QF4T7XABC              |
|           Thank you            |
+--------------------------------+
```

## ⚠️ The payment call is byte-identical

Printing happens **after** an approved sale, in its own request, and its failure is reported but **never** changes the payment's outcome. That was the design constraint, not an afterthought:

> a sale that succeeded with no paper is a nuisance; a sale reported as failed because a printer jammed is a **double charge**.

`print.ts` cannot throw, has short timeouts, no retries, and the toast says which happened either way — silence would let staff assume a receipt printed.

The no-charge readiness check (`checkOnly`) now also reports `canPrint`, so a terminal with no printer is discoverable *before* somebody takes money on it.

## Not yet confirmed on hardware — said plainly

The Clover connection belongs to `pawradise`, whose only members are **production** identities (`clover-staff@yipyy.com`, `develop@yipyy.com`), and a local run holds staging keys — the same reason `clover-terminal.spec.ts` skips locally.

So this is written against the documented API and verified as far as a keyboard allows: the receipt renders correctly at 32 columns, `typecheck` / `lint` / `format:check` / `build` are green, six project gates pass, and **62 e2e pass**. It needs **one tap** on the deployed app to be proven on paper. The debt map says so, and this stays 🟡 until then.

**Sources:** [Payments (semi) integration FAQs](https://docs.clover.com/dev/docs/payments-semi-integration-faqs) · [Print a receipt](https://docs.clover.com/dev/docs/printing-a-receipt) · [Payments with Developer Pay API](https://docs.clover.com/dev/docs/developer-pay-api) · [Create custom orders](https://docs.clover.com/dev/docs/creating-custom-orders)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
