### PR TITLE
fix(payments): the terminal stops spinning, and the customer picks the tip

### DIFF
--- a/src/app/api/payments/clover/terminal/route.ts
+++ b/src/app/api/payments/clover/terminal/route.ts
@@ -5,7 +5,12 @@ import { getViewer } from "@/lib/auth/viewer";
 import { holds, myPermissions } from "@/lib/auth/permissions";
 import { createServerClient } from "@/lib/supabase/server";
 import { chargeOnTerminal, deviceState } from "@/lib/clover/terminal";
-import { devicePrinters, printTextOnDevice } from "@/lib/clover/print";
+import {
+  devicePrinters,
+  endTransactionScreen,
+  printTextOnDevice,
+  readTipOnDevice,
+} from "@/lib/clover/print";
 import { buildReceiptLines } from "@/lib/clover/receipt";
 
 // ============================================================================
@@ -47,6 +52,13 @@ const TerminalInput = z.object({
   /** The device SERIAL from the terminals list — not its id. */
   deviceSerial: z.string().min(4).max(64),
   tipCents: z.number().int().min(0).max(100_000).default(0),
+  /**
+   * Ask the CUSTOMER for the tip on the terminal instead of taking `tipCents`
+   * from the screen behind the counter. When this is set, `tipCents` is ignored
+   * entirely rather than used as a fallback — a tip the payer declined must not
+   * reappear because a staff button was left on a percentage.
+   */
+  tipOnDevice: z.boolean().default(false),
   /** Ask the device whether it is awake, and charge nothing. */
   checkOnly: z.boolean().default(false),
 });
@@ -130,12 +142,36 @@ export async function POST(request: NextRequest) {
     );
   }
 
+  // ── THE TIP, ASKED OF THE PERSON PAYING ─────────────────────────────────
+  //
+  // BEFORE the card is presented, because the alternative — authorise, then
+  // tip-adjust — needs a pre-authorisation and Canadian merchants cannot take
+  // those. `owedCents` is what the tip is calculated on, so the device shows
+  // "Tip based on" the subtotal rather than on a figure that already includes
+  // somebody else's tip.
+  //
+  // A null answer is "no tip", never an error: the customer may have declined,
+  // and a counter that cannot take money because a tip screen timed out is a
+  // worse product than one that takes the money without a tip. `tipPrompted`
+  // goes back on the response so staff are told which happened.
+  let tipCents = parsed.data.tipCents;
+  let tipPrompted = false;
+  if (parsed.data.tipOnDevice) {
+    const chosen = await readTipOnDevice(
+      booking.facility_id,
+      parsed.data.deviceSerial,
+      owedCents,
+    );
+    tipPrompted = chosen !== null;
+    tipCents = chosen ?? 0;
+  }
+
   const outcome = await chargeOnTerminal({
     facilityId: booking.facility_id,
     bookingId: booking.id,
     clientId: booking.client_id,
     subtotalCents: owedCents,
-    tipCents: parsed.data.tipCents,
+    tipCents,
     deviceSerial: parsed.data.deviceSerial,
     createdBy: viewer.userId,
     authorName: viewer.email ?? "Terminal payment",
@@ -155,6 +191,14 @@ export async function POST(request: NextRequest) {
               outcome.code === "no_token"
             ? 503
             : 500;
+    // Hand the device back. Without this it spins forever (see below); and a
+    // customer who just declined or cancelled should not be thanked, so this
+    // arm gets the neutral welcome screen rather than the thank-you one.
+    await endTransactionScreen(
+      booking.facility_id,
+      parsed.data.deviceSerial,
+      "welcome",
+    );
     return NextResponse.json(
       { error: outcome.message, code: outcome.code },
       { status },
@@ -179,6 +223,27 @@ export async function POST(request: NextRequest) {
     parsed.data.deviceSerial,
   );
 
+  // ── HAND THE DEVICE BACK ────────────────────────────────────────────────
+  //
+  // Reported from the running app: after an approved sale "the clover terminal
+  // screen keeps loading". Not a hang, and not our timeout — REST Pay Display
+  // gives the POS the device for the whole transaction and takes it back only
+  // when told. Clover's own words: "End your customer transactions with a call
+  // to the Welcome or Thank You screen; otherwise, the spinning icon remains on
+  // the screen until another action is taken."
+  //
+  // We took the money and never told it, so EVERY sale left the terminal
+  // spinning until somebody reset it by hand.
+  //
+  // Last, after the receipt, so the paper is already coming out when the screen
+  // clears. Cosmetic, so — like the printer — it may fail without touching the
+  // payment.
+  const screen = await endTransactionScreen(
+    booking.facility_id,
+    parsed.data.deviceSerial,
+    "thank-you",
+  );
+
   return NextResponse.json({
     paid: true,
     paymentId: outcome.paymentId,
@@ -189,6 +254,9 @@ export async function POST(request: NextRequest) {
     cardLast4: outcome.cardLast4,
     receiptPrinted: printed.printed,
     receiptDetail: printed.detail,
+    tipCents,
+    tipPrompted,
+    screenCleared: screen.shown,
   });
 }
 

--- a/src/app/facility/dashboard/clients/[id]/bookings/[bookingId]/page.tsx
+++ b/src/app/facility/dashboard/clients/[id]/bookings/[bookingId]/page.tsx
@@ -1798,12 +1798,15 @@ export default function ClientBookingDetailPage({
             // prints no receipt: on a terminal the customer has not tapped yet
             // when this begins.
             if (payment.method === "terminal" && payment.deviceSerial) {
+              // THE CUSTOMER IS ASKED ON THE TERMINAL, not here. A tip picked
+              // on this screen is staff choosing on the payer's behalf; the
+              // device asks the person actually paying. `tipCents` is therefore
+              // not sent at all — the route ignores it under `tipOnDevice`, and
+              // sending both would only invite the two to disagree.
               const result = await chargeOnTerminal.mutateAsync({
                 bookingRef: booking.id,
                 deviceSerial: payment.deviceSerial,
-                ...(payment.tip > 0
-                  ? { tipCents: Math.round(payment.tip * 100) }
-                  : {}),
+                tipOnDevice: true,
               });
               const card = result.cardLast4
                 ? `${result.cardBrand ?? "Card"} ···${result.cardLast4}`
@@ -1813,6 +1816,9 @@ export default function ClientBookingDetailPage({
                 {
                   description: [
                     card,
+                    result.tipPrompted
+                      ? `Tip $${(result.tipCents / 100).toFixed(2)}`
+                      : "No tip added.",
                     // Said out loud either way. A charge that went through with
                     // no paper is something the person at the counter has to
                     // know BEFORE the customer walks off, and silence would let

--- a/src/components/bookings/PaymentCheckoutFlow.tsx
+++ b/src/components/bookings/PaymentCheckoutFlow.tsx
@@ -499,8 +499,18 @@ export function PaymentCheckoutFlow({
             </div>
           )}
 
-          {/* Tip — not shown for cash, check, or custom payments */}
-          {method !== "cash" && method !== "custom" && (
+          {/* Tip — not shown for cash, check, or custom payments, and NOT for
+              the terminal: there the customer is asked on the device itself
+              (lib/clover/print.ts readTipOnDevice), and the route ignores
+              anything picked here. Leaving these buttons on screen would let
+              staff select 20%, watch the customer choose nothing, and be handed
+              a total that matches neither. */}
+          {isTerminal && (
+            <div className="text-muted-foreground rounded-md border border-dashed p-3 text-xs">
+              The customer is asked for a tip on the terminal.
+            </div>
+          )}
+          {!isTerminal && method !== "cash" && method !== "custom" && (
             <div>
               <p className="text-muted-foreground mb-2 text-[10px] font-semibold tracking-wider uppercase">
                 Add Tip (optional)

--- a/src/lib/api/terminals.ts
+++ b/src/lib/api/terminals.ts
@@ -154,6 +154,15 @@ export interface TerminalChargeResult {
    * counter needs to know whether to reach for the roll or hand over paper.
    */
   receiptPrinted: boolean;
+  /** The tip actually taken, in cents — the customer's answer, not the ask. */
+  tipCents: number;
+  /**
+   * Whether the customer was asked on the device AND answered.
+   *
+   * False covers both "declined" and "could not be asked", which the counter
+   * needs distinguished from "was never offered a tip".
+   */
+  tipPrompted: boolean;
   receiptDetail?: string;
 }
 
@@ -171,6 +180,11 @@ export function useChargeOnTerminal() {
       bookingRef: number;
       deviceSerial: string;
       tipCents?: number;
+      /**
+       * Ask the customer for the tip ON THE TERMINAL. When set, `tipCents` is
+       * ignored by the route — the payer's answer is the only one that counts.
+       */
+      tipOnDevice?: boolean;
     }): Promise<TerminalChargeResult> => {
       const response = await fetch("/api/payments/clover/terminal", {
         method: "POST",
@@ -198,6 +212,8 @@ export function useChargeOnTerminal() {
         cardLast4: parsed?.cardLast4 ?? null,
         receiptPrinted: parsed?.receiptPrinted === true,
         receiptDetail: parsed?.receiptDetail,
+        tipCents: parsed?.tipCents ?? 0,
+        tipPrompted: parsed?.tipPrompted === true,
       };
     },
     onSuccess: () => {

--- a/src/lib/clover/print.ts
+++ b/src/lib/clover/print.ts
@@ -4,7 +4,11 @@ import { cloverConfig } from "@/lib/clover/config";
 import { validAccessToken } from "@/lib/clover/connection";
 
 // ============================================================================
-// Printing on the terminal's own roll.
+// Commanding the terminal itself — its printer, its screen, its tip prompt.
+//
+// Everything here talks to the DEVICE rather than to the payment. Each
+// section carries its own reasoning; the rule they share is at the bottom of
+// this banner.
 //
 // Two endpoints of the REST Pay Display API:
 //
@@ -146,5 +150,176 @@ export async function printTextOnDevice(
       printed: false,
       detail: error instanceof Error ? error.message : "network",
     };
+  }
+}
+
+// ============================================================================
+// Ending the transaction on the device's SCREEN.
+//
+// ── THE SPINNER IS NOT A HANG ─────────────────────────────────────────────
+//
+// Reported from the running app: after an approved sale "the clover terminal
+// screen keeps loading". That is documented behaviour, not a fault. Clover:
+// "End your customer transactions with a call to the Welcome or Thank You
+// screen; otherwise, the spinning icon remains on the screen until another
+// action is taken."
+//
+// REST Pay Display hands the device to the POS for the whole transaction and
+// hands it back only when told. We took the money and never told it, so every
+// sale left the terminal spinning until somebody reset it.
+//
+//   POST /connect/v1/device/thank-you   empty body — the sale completed
+//   POST /connect/v1/device/welcome     empty body — it did not
+//
+// ── SAME RULE AS THE PRINTER ──────────────────────────────────────────────
+//
+// Cosmetic, and therefore never allowed to affect a payment: returns rather
+// than throws, short timeout, no retries. A stuck screen is a nuisance; a sale
+// reported as failed because a screen call timed out is a double charge.
+// ============================================================================
+
+/**
+ * Return the device to a resting screen.
+ *
+ * @param kind `thank-you` after an approved sale, `welcome` after a decline,
+ *   a cancellation or anything else that ends the attempt — a customer who
+ *   just cancelled should not be thanked.
+ * @returns whether the device accepted the command. Safe to ignore.
+ */
+export async function endTransactionScreen(
+  facilityId: string,
+  deviceSerial: string,
+  kind: "thank-you" | "welcome",
+): Promise<{ shown: boolean; detail?: string }> {
+  const active = await validAccessToken(facilityId);
+  if (!active) return { shown: false, detail: "no clover token" };
+
+  const config = cloverConfig(active.environment);
+  if (!config) return { shown: false, detail: "clover is not configured" };
+
+  try {
+    const response = await fetch(
+      new URL(`/connect/v1/device/${kind}`, config.apiOrigin),
+      {
+        method: "POST",
+        headers: headers(active.accessToken, active.merchantId, deviceSerial),
+        body: "{}",
+        signal: AbortSignal.timeout(10_000),
+      },
+    );
+    if (!response.ok) {
+      const detail = await response.text().catch(() => "");
+      console.warn(
+        `[clover-print] ${kind} -> ${response.status} ${detail}`.slice(0, 300),
+      );
+      return { shown: false, detail: `${response.status}` };
+    }
+    return { shown: true };
+  } catch (error) {
+    console.warn(`[clover-print] ${kind} failed:`, error);
+    return {
+      shown: false,
+      detail: error instanceof Error ? error.message : "network",
+    };
+  }
+}
+
+// ============================================================================
+// Asking the CUSTOMER for a tip, on the device.
+//
+// ── WHY THE TIP MOVED OFF OUR SCREEN ──────────────────────────────────────
+//
+// Reported from the running app: "if we are taking payment from the terminal,
+// it should show option to add tip on the terminal as well". Correct, and not
+// only for convenience — a tip chosen by staff on a back-office screen and
+// typed in on the customer's behalf is a different thing from a tip the payer
+// selected themselves, and card-brand rules care about the difference.
+//
+// ── WHY NOT tipMode ───────────────────────────────────────────────────────
+//
+// The Clover SDKs take `TipMode.ON_SCREEN_BEFORE_PAYMENT` on the sale itself.
+// REST Pay Display does not: its documented flows are a sale WITHOUT tipping,
+// an auth with `/v1/payments/{id}/tip-adjust` afterwards, or this — ask the
+// device first, then charge the total.
+//
+// That distinction matters here specifically. Tip-adjust needs a
+// PRE-AUTHORISATION, and Canadian merchants cannot take those (it is the same
+// constraint that forces `final: true` on the sale). So read-tip-then-charge is
+// not a preference, it is the only on-screen tip flow open to this merchant.
+//
+//   POST /connect/v1/device/read-tip   { baseAmount }  ->  { response: <cents> }
+//
+// ── AND IT RUNS BEFORE ANY MONEY MOVES ────────────────────────────────────
+//
+// Unlike the printer and the screen, a failure here happens BEFORE the card is
+// presented, so it cannot strand a payment. It still must not block the sale: a
+// counter that cannot take money because a tip prompt timed out is worse than a
+// counter that takes money without a tip. The caller treats null as "no tip".
+// ============================================================================
+
+export interface TipSuggestion {
+  name: string;
+  /** A flat amount in cents. Mutually exclusive with `percentage`. */
+  amount?: number;
+  /** A whole percentage of `baseAmount`. Mutually exclusive with `amount`. */
+  percentage?: number;
+}
+
+/**
+ * Show the tip screen and wait for the customer.
+ *
+ * @param baseAmountCents what the tip is calculated ON — the subtotal, not the
+ *   total. Clover displays it as "Tip based on".
+ * @returns the chosen tip in CENTS, or null if the customer declined, walked
+ *   away, or the device could not be asked. Null is never an error to the
+ *   caller: it means charge the base amount.
+ */
+export async function readTipOnDevice(
+  facilityId: string,
+  deviceSerial: string,
+  baseAmountCents: number,
+  tipSuggestions?: TipSuggestion[],
+): Promise<number | null> {
+  if (baseAmountCents <= 0) return null;
+
+  const active = await validAccessToken(facilityId);
+  if (!active) return null;
+
+  const config = cloverConfig(active.environment);
+  if (!config) return null;
+
+  try {
+    const response = await fetch(
+      new URL("/connect/v1/device/read-tip", config.apiOrigin),
+      {
+        method: "POST",
+        headers: headers(active.accessToken, active.merchantId, deviceSerial),
+        body: JSON.stringify({
+          baseAmount: Math.round(baseAmountCents),
+          ...(tipSuggestions?.length ? { tipSuggestions } : {}),
+        }),
+        // A person reading four options and pressing one. Shorter than the
+        // payment timeout because nobody is holding a card yet.
+        signal: AbortSignal.timeout(90_000),
+      },
+    );
+    if (!response.ok) {
+      console.warn(
+        `[clover-print] read-tip -> ${response.status} ${await response
+          .text()
+          .catch(() => "")}`.slice(0, 300),
+      );
+      return null;
+    }
+    const body = (await response.json().catch(() => null)) as {
+      response?: number;
+    } | null;
+    const tip = Number(body?.response ?? 0);
+    // A negative or absurd tip is a malformed answer, not a generous customer.
+    if (!Number.isFinite(tip) || tip <= 0) return null;
+    return Math.min(Math.round(tip), 100_000);
+  } catch (error) {
+    console.warn("[clover-print] read-tip failed:", error);
+    return null;
   }
 }


### PR DESCRIPTION
Two faults reported from the running app after the first live terminal sale.

## The spinner is a missing call, not a hang

REST Pay Display gives the POS the device for the whole transaction and takes it back **only when told**. Clover's own words:

> End your customer transactions with a call to the Welcome or Thank You screen; otherwise, the spinning icon remains on the screen until another action is taken.

We took the money and never told it, so **every** sale left the terminal spinning until somebody reset it by hand. The route now ends the transaction on both arms — `thank-you` after an approved sale, `welcome` after a decline or cancellation, because a customer who just cancelled should not be thanked.

## The tip belongs to the person paying

The SDKs take `TipMode.ON_SCREEN_BEFORE_PAYMENT` on the sale itself. REST Pay Display has no such field — its documented flows are a sale without tipping, an auth with `tip-adjust` afterwards, or `read-tip` first.

`tip-adjust` needs a **pre-authorisation, which Canadian merchants cannot take** — the same constraint that already forces `final: true` on our sale. So read-tip-then-charge is not a preference here, it is the only on-screen tip flow this merchant has.

```
POST /connect/v1/device/read-tip  { baseAmount }  ->  { response: <cents> }
```

Choosing Terminal now prompts on the device, and the tip buttons in the checkout dialog are replaced by a note saying so. Leaving them on screen would let staff select 20%, watch the customer decline, and produce a total matching neither. `tipCents` is not sent at all under `tipOnDevice` rather than kept as a fallback.

## Neither may affect a payment

The screen call is cosmetic, and the tip runs *before* any card is presented, so both return rather than throw, with short timeouts and no retries.

- A stuck screen is a nuisance; a sale reported as failed because a screen call timed out is a **double charge**.
- A tip that could not be read is charged as no tip — a counter that cannot take money because a tip prompt failed is the worse product — and `tipPrompted` goes back on the response so staff are told which happened.

## Verification

`typecheck`, `lint` (0 errors), `format:check`, `check:success-claims` all green.

Not verifiable off the hardware: the Clover connection belongs to `pawradise` (sandbox merchant), whose members are production identities, so a local run cannot reach it — the same reason `clover-terminal.spec.ts` skips locally. **Confirmed on the device after deploy.**