### PR TITLE
feat(payments): the customer chooses how they get their receipt, itemised either way

### DIFF
--- a/src/app/api/payments/clover/terminal/route.ts
+++ b/src/app/api/payments/clover/terminal/route.ts
@@ -13,7 +13,11 @@ import {
   readTipOnDevice,
   receiptOptionsOnDevice,
 } from "@/lib/clover/print";
-import { buildReceiptLines } from "@/lib/clover/receipt";
+import { buildReceiptLines, type ReceiptInput } from "@/lib/clover/receipt";
+import {
+  emailItemisedReceipt,
+  smsItemisedReceipt,
+} from "@/lib/clover/receipt-delivery";
 
 // ============================================================================
 // Charging a card on the counter's own terminal.
@@ -233,21 +237,35 @@ export async function POST(request: NextRequest) {
   );
   const wantsPrint = !choice || choice.method === "PRINT";
 
+  // Composed ONCE, whichever way it goes out, so the paper copy and the emailed
+  // copy cannot disagree.
+  const receipt =
+    choice?.method === "NO_RECEIPT"
+      ? null
+      : await receiptInputFor(
+          booking as unknown as BookingForReceipt,
+          supabase,
+          outcome,
+        );
+
   let printed: { printed: boolean; detail?: string } = {
     printed: false,
     detail: choice ? `customer chose ${choice.method}` : undefined,
   };
-  let delivered: { delivered: boolean; detail?: string } = {
-    delivered: false,
-  };
+  let delivered: { delivered: boolean; detail?: string } = { delivered: false };
+  // Whether what reached the customer carried the BREAKDOWN. Clover's fallback
+  // receipt does not, and staff should not have to guess which one went out.
+  let itemised = false;
 
   if (wantsPrint) {
-    printed = await printReceipt(
-      booking as unknown as BookingForReceipt,
-      supabase,
-      outcome,
-      parsed.data.deviceSerial,
-    );
+    if (receipt) {
+      printed = await printTextOnDevice(
+        booking.facility_id,
+        parsed.data.deviceSerial,
+        buildReceiptLines(receipt),
+      );
+      itemised = printed.printed;
+    }
     // AND Clover's own, which is the card-brand-compliant one. The docs put
     // that squarely on us for custom receipts — "You are responsible to ensure
     // the receipts printed by your app comply with all card brand" rules — and
@@ -261,17 +279,48 @@ export async function POST(request: NextRequest) {
         "PRINT",
       );
     }
-  } else if (
-    (choice.method === "EMAIL" || choice.method === "SMS") &&
-    outcome.processorPaymentId
-  ) {
-    delivered = await deliverStandardReceipt(
-      booking.facility_id,
-      parsed.data.deviceSerial,
-      outcome.processorPaymentId,
-      choice.method,
-      choice.additionalData,
-    );
+  } else if (choice.method === "EMAIL" || choice.method === "SMS") {
+    // ── OURS FIRST, CLOVER'S AS A FLOOR ───────────────────────────────────
+    //
+    // Clover will happily email a receipt, but it emails CLOVER's receipt, and
+    // that one has no line items — there is no Clover order behind this
+    // payment. Sending it would answer "the breakdown must be on the receipt"
+    // with the old behaviour plus extra steps.
+    //
+    // So we send ours when we can. When we cannot — no mail service configured
+    // on this deployment, a typo'd address — Clover's unitemised copy is still
+    // better than the customer walking away with nothing, and `itemised` says
+    // which of the two they got.
+    const address = choice.additionalData?.trim();
+    const ours =
+      !address || !receipt
+        ? {
+            sent: false,
+            detail: !address
+              ? "the device returned no address"
+              : "the receipt could not be composed",
+          }
+        : choice.method === "EMAIL"
+          ? await emailItemisedReceipt(address, receipt)
+          : await smsItemisedReceipt(address, receipt);
+
+    if (ours.sent) {
+      delivered = { delivered: true };
+      itemised = true;
+    } else if (outcome.processorPaymentId) {
+      delivered = await deliverStandardReceipt(
+        booking.facility_id,
+        parsed.data.deviceSerial,
+        outcome.processorPaymentId,
+        choice.method,
+        address,
+      );
+      delivered.detail = delivered.delivered
+        ? `sent without the breakdown (${ours.detail})`
+        : (delivered.detail ?? ours.detail);
+    } else {
+      delivered = { delivered: false, detail: ours.detail };
+    }
   }
 
   // ── HAND THE DEVICE BACK ────────────────────────────────────────────────
@@ -308,6 +357,7 @@ export async function POST(request: NextRequest) {
     receiptMethod: choice?.method ?? "PRINT",
     receiptDelivered: delivered.delivered,
     receiptDeliveryDetail: delivered.detail,
+    receiptItemised: itemised,
     tipCents,
     tipPrompted,
     screenCleared: screen.shown,
@@ -335,12 +385,24 @@ interface BookingForReceipt {
  * record of what was charged, and a caller that could name its own line items
  * could print a receipt that disagrees with the payment.
  */
-async function printReceipt(
+/**
+ * Compose the receipt, once, from the booking.
+ *
+ * Split out from printing because the customer may now ask for it by email or
+ * by text instead, and all three must say the same thing. Rendering the emailed
+ * copy from a second read is how a paper receipt and an emailed one end up
+ * disagreeing about a discount — and the customer holding both is the one who
+ * notices.
+ *
+ * The lines are read HERE rather than passed from the client: a receipt is a
+ * record of what was charged, and a caller that could name its own line items
+ * could produce one that disagrees with the payment.
+ */
+async function receiptInputFor(
   booking: BookingForReceipt,
   supabase: Awaited<ReturnType<typeof createServerClient>>,
   outcome: Extract<Awaited<ReturnType<typeof chargeOnTerminal>>, { ok: true }>,
-  deviceSerial: string,
-): Promise<{ printed: boolean; detail?: string }> {
+): Promise<ReceiptInput | null> {
   try {
     const { data: rows } = await supabase
       .from("booking_line_items")
@@ -377,7 +439,7 @@ async function printReceipt(
       lines.reduce((sum, l) => sum + l.amountCents, 0) - discountCents;
     const tipCents = Math.max(0, outcome.amountCents - subtotalCents);
 
-    const text = buildReceiptLines({
+    return {
       facilityName: booking.facilities?.name ?? "Yipyy",
       reference: `Booking #${booking.ref}`,
       clientName: booking.clients?.name ?? null,
@@ -399,16 +461,9 @@ async function printReceipt(
         dateStyle: "medium",
         timeStyle: "short",
       }),
-    });
-
-    // The same device that took the payment, so the receipt comes out of the
-    // terminal the customer is standing at.
-    return await printTextOnDevice(booking.facility_id, deviceSerial, text);
-  } catch (error) {
-    console.warn("[terminal] receipt not printed:", error);
-    return {
-      printed: false,
-      detail: error instanceof Error ? error.message : "unknown",
     };
+  } catch (error) {
+    console.warn("[terminal] receipt could not be composed:", error);
+    return null;
   }
 }

--- a/src/app/api/payments/clover/terminal/route.ts
+++ b/src/app/api/payments/clover/terminal/route.ts
@@ -6,10 +6,12 @@ import { holds, myPermissions } from "@/lib/auth/permissions";
 import { createServerClient } from "@/lib/supabase/server";
 import { chargeOnTerminal, deviceState } from "@/lib/clover/terminal";
 import {
+  deliverStandardReceipt,
   devicePrinters,
   endTransactionScreen,
   printTextOnDevice,
   readTipOnDevice,
+  receiptOptionsOnDevice,
 } from "@/lib/clover/print";
 import { buildReceiptLines } from "@/lib/clover/receipt";
 
@@ -216,12 +218,61 @@ export async function POST(request: NextRequest) {
   // A sale that succeeded and a receipt that did not print is a nuisance. A
   // sale reported as failed because a printer jammed is a double charge, so
   // this cannot throw and its failure is a log line and a flag on the response.
-  const printed = await printReceipt(
-    booking as unknown as BookingForReceipt,
-    supabase,
-    outcome,
+  // ── THE CUSTOMER CHOOSES ────────────────────────────────────────────────
+  //
+  // Clover's own Sale app ends with Print / Email / Text, and a semi-integrated
+  // sale that simply stops looks broken beside it. So ask, then deliver.
+  //
+  // A null answer means they were never asked — an unreachable device, a
+  // timeout — which is NOT the same as declining, so it falls back to printing.
+  // The one thing this must never do is leave a paying customer with nothing
+  // because a dialog failed to open.
+  const choice = await receiptOptionsOnDevice(
+    booking.facility_id,
     parsed.data.deviceSerial,
   );
+  const wantsPrint = !choice || choice.method === "PRINT";
+
+  let printed: { printed: boolean; detail?: string } = {
+    printed: false,
+    detail: choice ? `customer chose ${choice.method}` : undefined,
+  };
+  let delivered: { delivered: boolean; detail?: string } = {
+    delivered: false,
+  };
+
+  if (wantsPrint) {
+    printed = await printReceipt(
+      booking as unknown as BookingForReceipt,
+      supabase,
+      outcome,
+      parsed.data.deviceSerial,
+    );
+    // AND Clover's own, which is the card-brand-compliant one. The docs put
+    // that squarely on us for custom receipts — "You are responsible to ensure
+    // the receipts printed by your app comply with all card brand" rules — and
+    // ours is a breakdown, not a compliant payment record. Two prints off one
+    // roll is a cheap way to owe nobody an argument.
+    if (outcome.processorPaymentId) {
+      delivered = await deliverStandardReceipt(
+        booking.facility_id,
+        parsed.data.deviceSerial,
+        outcome.processorPaymentId,
+        "PRINT",
+      );
+    }
+  } else if (
+    (choice.method === "EMAIL" || choice.method === "SMS") &&
+    outcome.processorPaymentId
+  ) {
+    delivered = await deliverStandardReceipt(
+      booking.facility_id,
+      parsed.data.deviceSerial,
+      outcome.processorPaymentId,
+      choice.method,
+      choice.additionalData,
+    );
+  }
 
   // ── HAND THE DEVICE BACK ────────────────────────────────────────────────
   //
@@ -254,6 +305,9 @@ export async function POST(request: NextRequest) {
     cardLast4: outcome.cardLast4,
     receiptPrinted: printed.printed,
     receiptDetail: printed.detail,
+    receiptMethod: choice?.method ?? "PRINT",
+    receiptDelivered: delivered.delivered,
+    receiptDeliveryDetail: delivered.detail,
     tipCents,
     tipPrompted,
     screenCleared: screen.shown,

--- a/src/app/facility/dashboard/clients/[id]/bookings/[bookingId]/page.tsx
+++ b/src/app/facility/dashboard/clients/[id]/bookings/[bookingId]/page.tsx
@@ -1822,10 +1822,23 @@ export default function ClientBookingDetailPage({
                     // Said out loud either way. A charge that went through with
                     // no paper is something the person at the counter has to
                     // know BEFORE the customer walks off, and silence would let
-                    // them assume a receipt printed.
-                    result.receiptPrinted
-                      ? "Itemised receipt printed."
-                      : "No receipt printed — hand over the copy from Print.",
+                    // them assume a receipt printed. Now that the CUSTOMER
+                    // picks, the message has to name what they picked too —
+                    // "no receipt printed" reads as a fault when in fact they
+                    // asked for it by email.
+                    result.receiptMethod === "NO_RECEIPT"
+                      ? "Customer declined a receipt."
+                      : result.receiptMethod === "EMAIL"
+                        ? result.receiptDelivered
+                          ? "Receipt emailed."
+                          : "Email receipt FAILED — offer a printed one."
+                        : result.receiptMethod === "SMS"
+                          ? result.receiptDelivered
+                            ? "Receipt texted."
+                            : "Text receipt FAILED — offer a printed one."
+                          : result.receiptPrinted
+                            ? "Itemised receipt printed."
+                            : "No receipt printed — hand over the copy from Print.",
                   ]
                     .filter(Boolean)
                     .join(" · "),

--- a/src/app/facility/dashboard/clients/[id]/bookings/[bookingId]/page.tsx
+++ b/src/app/facility/dashboard/clients/[id]/bookings/[bookingId]/page.tsx
@@ -1830,11 +1830,15 @@ export default function ClientBookingDetailPage({
                       ? "Customer declined a receipt."
                       : result.receiptMethod === "EMAIL"
                         ? result.receiptDelivered
-                          ? "Receipt emailed."
+                          ? result.receiptItemised
+                            ? "Itemised receipt emailed."
+                            : "Emailed, but WITHOUT the breakdown."
                           : "Email receipt FAILED — offer a printed one."
                         : result.receiptMethod === "SMS"
                           ? result.receiptDelivered
-                            ? "Receipt texted."
+                            ? result.receiptItemised
+                              ? "Itemised receipt texted."
+                              : "Texted, but WITHOUT the breakdown."
                             : "Text receipt FAILED — offer a printed one."
                           : result.receiptPrinted
                             ? "Itemised receipt printed."

--- a/src/lib/api/terminals.ts
+++ b/src/lib/api/terminals.ts
@@ -156,8 +156,16 @@ export interface TerminalChargeResult {
   receiptPrinted: boolean;
   /** How the customer asked to receive it: PRINT, EMAIL, SMS or NO_RECEIPT. */
   receiptMethod: "NO_RECEIPT" | "PRINT" | "EMAIL" | "SMS";
-  /** Whether Clover's own (card-brand-compliant) receipt went out. */
+  /** Whether the receipt the customer asked for actually went out. */
   receiptDelivered: boolean;
+  /**
+   * Whether what reached them carried the BREAKDOWN.
+   *
+   * False with `receiptDelivered` true means Clover's unitemised fallback went
+   * instead of ours — worth knowing at the counter, because the customer who
+   * asked for the detail did not get it.
+   */
+  receiptItemised: boolean;
   /** The tip actually taken, in cents — the customer's answer, not the ask. */
   tipCents: number;
   /**
@@ -218,6 +226,7 @@ export function useChargeOnTerminal() {
         receiptDetail: parsed?.receiptDetail,
         receiptMethod: parsed?.receiptMethod ?? "PRINT",
         receiptDelivered: parsed?.receiptDelivered === true,
+        receiptItemised: parsed?.receiptItemised === true,
         tipCents: parsed?.tipCents ?? 0,
         tipPrompted: parsed?.tipPrompted === true,
       };

--- a/src/lib/api/terminals.ts
+++ b/src/lib/api/terminals.ts
@@ -154,6 +154,10 @@ export interface TerminalChargeResult {
    * counter needs to know whether to reach for the roll or hand over paper.
    */
   receiptPrinted: boolean;
+  /** How the customer asked to receive it: PRINT, EMAIL, SMS or NO_RECEIPT. */
+  receiptMethod: "NO_RECEIPT" | "PRINT" | "EMAIL" | "SMS";
+  /** Whether Clover's own (card-brand-compliant) receipt went out. */
+  receiptDelivered: boolean;
   /** The tip actually taken, in cents — the customer's answer, not the ask. */
   tipCents: number;
   /**
@@ -212,6 +216,8 @@ export function useChargeOnTerminal() {
         cardLast4: parsed?.cardLast4 ?? null,
         receiptPrinted: parsed?.receiptPrinted === true,
         receiptDetail: parsed?.receiptDetail,
+        receiptMethod: parsed?.receiptMethod ?? "PRINT",
+        receiptDelivered: parsed?.receiptDelivered === true,
         tipCents: parsed?.tipCents ?? 0,
         tipPrompted: parsed?.tipPrompted === true,
       };

--- a/src/lib/clover/print.ts
+++ b/src/lib/clover/print.ts
@@ -323,3 +323,156 @@ export async function readTipOnDevice(
     return null;
   }
 }
+
+// ============================================================================
+// Letting the CUSTOMER choose how they get their receipt.
+//
+// ── WHAT THIS RESTORES ────────────────────────────────────────────────────
+//
+// Reported from the running app, with photographs of the device: "it does
+// usually show options — if I click sale, then make the payment, it shows me
+// the options". Correct. Clover's own Sale app ends with Print receipt / Email
+// Receipt / Text Receipt, and a semi-integrated sale that just stops feels
+// broken beside it.
+//
+// It is NOT true, as first concluded here, that REST Pay Display cannot do
+// this. The guides index does not list it; the API reference does:
+//
+//   POST /connect/v1/device/receipt-options
+//        { deliveryOptions: [{ method }], message? }
+//     -> the customer's selection
+//
+// It needs no paymentId — it asks the question and hands back the answer. WE
+// then deliver, which is the useful part: an EMAIL choice returns the address
+// the customer typed on the device, so the receipt they get can be ours.
+// ============================================================================
+
+export type ReceiptMethod = "NO_RECEIPT" | "PRINT" | "EMAIL" | "SMS";
+
+export interface ReceiptChoice {
+  method: ReceiptMethod;
+  /** The email address or phone number the customer entered, when they did. */
+  additionalData?: string;
+}
+
+/**
+ * Ask the customer how they want their receipt.
+ *
+ * @returns their choice, or null if they were not asked — a device that could
+ *   not be reached, or a timeout. Null is not "no receipt": the caller should
+ *   fall back to printing, because a customer who was never asked has not
+ *   declined.
+ */
+export async function receiptOptionsOnDevice(
+  facilityId: string,
+  deviceSerial: string,
+  methods: ReceiptMethod[] = ["PRINT", "EMAIL", "SMS", "NO_RECEIPT"],
+): Promise<ReceiptChoice | null> {
+  const active = await validAccessToken(facilityId);
+  if (!active) return null;
+
+  const config = cloverConfig(active.environment);
+  if (!config) return null;
+
+  try {
+    const response = await fetch(
+      new URL("/connect/v1/device/receipt-options", config.apiOrigin),
+      {
+        method: "POST",
+        headers: headers(active.accessToken, active.merchantId, deviceSerial),
+        body: JSON.stringify({
+          deliveryOptions: methods.map((m) => ({ method: m })),
+        }),
+        // A person choosing, and possibly typing an email address on a small
+        // keyboard. The card is already charged, so nothing is held up by this.
+        signal: AbortSignal.timeout(120_000),
+      },
+    );
+    if (!response.ok) {
+      console.warn(
+        `[clover-print] receipt-options -> ${response.status} ${await response
+          .text()
+          .catch(() => "")}`.slice(0, 300),
+      );
+      return null;
+    }
+    const body = (await response.json().catch(() => null)) as {
+      deliveryOptions?: ReceiptChoice[];
+      response?: ReceiptChoice[] | ReceiptChoice;
+    } | null;
+
+    // The reference calls the result a ReceiptOptionsResponse carrying an
+    // ARRAY. Read defensively rather than assume a shape: a wrong guess here
+    // silently becomes "the customer chose nothing".
+    const raw = body?.deliveryOptions ?? body?.response;
+    const choice = Array.isArray(raw) ? raw[0] : raw;
+    if (!choice?.method) return null;
+    return { method: choice.method, additionalData: choice.additionalData };
+  } catch (error) {
+    console.warn("[clover-print] receipt-options failed:", error);
+    return null;
+  }
+}
+
+/**
+ * Have CLOVER deliver its own receipt for a payment.
+ *
+ * Distinct from `printTextOnDevice`, which prints ours. Clover's is the
+ * card-brand-compliant one — the docs are explicit that compliance is the
+ * integrator's problem for custom receipts: "You are responsible to ensure the
+ * receipts printed by your app comply with all card brand" rules. Ours carries
+ * the itemised breakdown the facility asked for and Clover's carries the
+ * payment furniture, so a PRINT choice sends both.
+ *
+ * @param processorPaymentId CLOVER's payment id, not ours.
+ */
+export async function deliverStandardReceipt(
+  facilityId: string,
+  deviceSerial: string,
+  processorPaymentId: string,
+  method: Exclude<ReceiptMethod, "NO_RECEIPT">,
+  additionalData?: string,
+): Promise<{ delivered: boolean; detail?: string }> {
+  const active = await validAccessToken(facilityId);
+  if (!active) return { delivered: false, detail: "no clover token" };
+
+  const config = cloverConfig(active.environment);
+  if (!config) return { delivered: false, detail: "clover is not configured" };
+
+  try {
+    const response = await fetch(
+      new URL(
+        `/connect/v1/payments/${encodeURIComponent(processorPaymentId)}/receipt`,
+        config.apiOrigin,
+      ),
+      {
+        method: "POST",
+        headers: headers(active.accessToken, active.merchantId, deviceSerial),
+        body: JSON.stringify({
+          deliveryOption: {
+            method,
+            ...(additionalData ? { additionalData } : {}),
+          },
+        }),
+        signal: AbortSignal.timeout(20_000),
+      },
+    );
+    if (!response.ok) {
+      const detail = await response.text().catch(() => "");
+      console.warn(
+        `[clover-print] receipt ${method} -> ${response.status} ${detail}`.slice(
+          0,
+          300,
+        ),
+      );
+      return { delivered: false, detail: `${response.status}` };
+    }
+    return { delivered: true };
+  } catch (error) {
+    console.warn(`[clover-print] receipt ${method} failed:`, error);
+    return {
+      delivered: false,
+      detail: error instanceof Error ? error.message : "network",
+    };
+  }
+}

--- a/src/lib/clover/receipt-delivery.ts
+++ b/src/lib/clover/receipt-delivery.ts
@@ -1,0 +1,170 @@
+import "server-only";
+
+import {
+  buildReceiptHtml,
+  buildReceiptSmsText,
+  type ReceiptInput,
+} from "@/lib/clover/receipt";
+import { platformSendingNumber, platformTwilio } from "@/lib/twilio/config";
+
+// ============================================================================
+// Sending OUR receipt — the itemised one — by email and by text.
+//
+// ── WHY NOT JUST LET CLOVER SEND IT ───────────────────────────────────────
+//
+// Clover will: `/connect/v1/payments/{id}/receipt` takes EMAIL and SMS. But it
+// sends CLOVER's receipt, and Clover's receipt has no line items, because there
+// is no Clover order behind this payment — the same constraint that forced the
+// custom text receipt in the first place (see receipt.ts).
+//
+// The whole complaint being answered here is "it needs to have all the detailed
+// breakdown on it like we should see in the portal". A customer who picks Email
+// and receives a total with no breakdown has been given the old behaviour with
+// extra steps. So when we can send it ourselves, we do.
+//
+// ── AND WHY CLOVER IS STILL THE FALLBACK ──────────────────────────────────
+//
+// These senders are environment-gated: no RESEND_API_KEY, no email. A facility
+// whose deployment has not configured Resend must still be able to hand a
+// customer a receipt, so the caller falls back to Clover's own delivery rather
+// than failing. Unitemised beats nothing, and the caller reports which of the
+// two happened rather than quietly implying the better one.
+//
+// ── NOTHING HERE MAY AFFECT A PAYMENT ─────────────────────────────────────
+//
+// Same rule as the printer and the screen: the card is already charged by the
+// time any of this runs. Every function returns rather than throws.
+// ============================================================================
+
+export interface DeliveryResult {
+  sent: boolean;
+  /** Why not, when not — logged and shown to staff, never to the customer. */
+  detail?: string;
+}
+
+/**
+ * Email the itemised receipt.
+ *
+ * @param to the address the CUSTOMER typed on the terminal. Never a stored one:
+ *   the person standing at the counter may not be the person on the account,
+ *   and the receipt belongs to whoever just paid.
+ */
+export async function emailItemisedReceipt(
+  to: string,
+  input: ReceiptInput,
+): Promise<DeliveryResult> {
+  const apiKey = process.env.RESEND_API_KEY?.trim();
+  if (!apiKey) return { sent: false, detail: "no email service configured" };
+  // A device keyboard produces typos, and Resend answers a malformed address
+  // with a 422 that reads like an outage. Refuse it here instead.
+  if (!/^[^@\s]+@[^@\s.]+\.[^@\s]+$/.test(to)) {
+    return { sent: false, detail: "that email address is not valid" };
+  }
+
+  try {
+    const response = await fetch("https://api.resend.com/emails", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        from: process.env.EMAIL_FROM ?? "Yipyy <onboarding@resend.dev>",
+        to,
+        subject: input.reference
+          ? `Your receipt from ${input.facilityName} (${input.reference})`
+          : `Your receipt from ${input.facilityName}`,
+        html: buildReceiptHtml(input),
+        // Both parts, always. A text-only client showing an empty message is
+        // indistinguishable from a receipt that never arrived.
+        text: buildReceiptSmsText(input),
+      }),
+      signal: AbortSignal.timeout(15_000),
+    });
+    if (!response.ok) {
+      const detail = await response.text().catch(() => "");
+      console.warn(
+        `[receipt] email -> ${response.status} ${detail}`.slice(0, 300),
+      );
+      return { sent: false, detail: `email service said ${response.status}` };
+    }
+    return { sent: true };
+  } catch (error) {
+    console.warn("[receipt] email failed:", error);
+    return {
+      sent: false,
+      detail: error instanceof Error ? error.message : "network",
+    };
+  }
+}
+
+/**
+ * Text the itemised receipt.
+ *
+ * ── WHICH TWILIO ACCOUNT ─────────────────────────────────────────────────
+ *
+ * The PLATFORM one, from the environment. A facility is meant to send from its
+ * own subaccount and its own number (20260809200000), but no facility has one
+ * provisioned yet — `communication_connections` is empty — so a per-facility
+ * lookup would resolve to nothing on every call and the feature would never
+ * work. When subaccounts exist this grows a facility branch; until then it
+ * sends from Yipyy's number rather than pretending.
+ */
+export async function smsItemisedReceipt(
+  to: string,
+  input: ReceiptInput,
+): Promise<DeliveryResult> {
+  const twilio = platformTwilio();
+  const from = platformSendingNumber();
+  if (!twilio || !from) {
+    return { sent: false, detail: "no SMS service configured" };
+  }
+  // E.164 or Twilio refuses it. The device may hand back a locally formatted
+  // number, so accept digits and normalise a 10-digit North American one.
+  const digits = to.replace(/[^\d+]/g, "");
+  const e164 = digits.startsWith("+")
+    ? digits
+    : digits.length === 10
+      ? `+1${digits}`
+      : digits.length === 11 && digits.startsWith("1")
+        ? `+${digits}`
+        : null;
+  if (!e164 || !/^\+[1-9]\d{7,14}$/.test(e164)) {
+    return { sent: false, detail: "that phone number is not valid" };
+  }
+
+  try {
+    const response = await fetch(
+      `https://api.twilio.com/2010-04-01/Accounts/${twilio.accountSid}/Messages.json`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Basic ${Buffer.from(
+            `${twilio.accountSid}:${twilio.authToken}`,
+          ).toString("base64")}`,
+          "Content-Type": "application/x-www-form-urlencoded",
+        },
+        body: new URLSearchParams({
+          To: e164,
+          From: from,
+          Body: buildReceiptSmsText(input),
+        }),
+        signal: AbortSignal.timeout(15_000),
+      },
+    );
+    if (!response.ok) {
+      const detail = await response.text().catch(() => "");
+      console.warn(
+        `[receipt] sms -> ${response.status} ${detail}`.slice(0, 300),
+      );
+      return { sent: false, detail: `SMS service said ${response.status}` };
+    }
+    return { sent: true };
+  } catch (error) {
+    console.warn("[receipt] sms failed:", error);
+    return {
+      sent: false,
+      detail: error instanceof Error ? error.message : "network",
+    };
+  }
+}

--- a/src/lib/clover/receipt.ts
+++ b/src/lib/clover/receipt.ts
@@ -145,3 +145,76 @@ export function buildReceiptLines(input: ReceiptInput): string[] {
 
   return out;
 }
+
+// ============================================================================
+// The same receipt, for a screen instead of a roll.
+//
+// ── WHY THESE LIVE BESIDE buildReceiptLines ───────────────────────────────
+//
+// A customer who chooses Email and a customer who chooses Print are owed the
+// same figures. Rendering the email from a different function, reading the
+// booking a second time, is how the paper copy and the emailed copy end up
+// disagreeing about a discount — and the customer holding both is the one who
+// notices. So all three renderers take the SAME ReceiptInput, built once by
+// the caller from one read.
+// ============================================================================
+
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+/**
+ * The receipt as an email body.
+ *
+ * Deliberately a `<pre>` of the very lines that go to the printer rather than a
+ * hand-built table: the two cannot drift, because there is only one layout. It
+ * reads as a receipt, which is what it is.
+ */
+export function buildReceiptHtml(input: ReceiptInput): string {
+  const body = buildReceiptLines(input).map(escapeHtml).join("\n");
+  return [
+    '<div style="background:#f6f6f7;padding:24px;font-family:system-ui,sans-serif">',
+    '<div style="max-width:420px;margin:0 auto;background:#fff;border-radius:12px;padding:24px">',
+    `<h1 style="margin:0 0 16px;font-size:18px">${escapeHtml(input.facilityName)}</h1>`,
+    '<pre style="font-family:ui-monospace,Menlo,Consolas,monospace;font-size:13px;line-height:1.45;white-space:pre;overflow-x:auto;margin:0">',
+    body,
+    "</pre>",
+    '<p style="margin:16px 0 0;color:#6b7280;font-size:12px">Thank you for your business.</p>',
+    "</div></div>",
+  ].join("\n");
+}
+
+/**
+ * The receipt as a text message.
+ *
+ * NOT the 32-column layout: padded columns wrap raggedly in a chat bubble and
+ * turn a tidy receipt into nonsense. Same figures, same order, no padding — and
+ * short, because every 153 characters is another segment the facility pays for.
+ */
+export function buildReceiptSmsText(input: ReceiptInput): string {
+  const out: string[] = [];
+  out.push(
+    `${input.facilityName}${input.reference ? ` — ${input.reference}` : ""}`,
+  );
+  for (const line of input.lines) {
+    out.push(`${line.label}: ${money(line.amountCents)}`);
+  }
+  if (input.discountCents > 0) {
+    out.push(`Discount: ${money(-input.discountCents)}`);
+  }
+  out.push(`Subtotal: ${money(input.subtotalCents)}`);
+  if (input.tipCents > 0) out.push(`Tip: ${money(input.tipCents)}`);
+  out.push(`TOTAL: ${money(input.totalCents)}`);
+  const card = [
+    input.cardBrand,
+    input.cardLast4 ? `••${input.cardLast4}` : null,
+  ]
+    .filter(Boolean)
+    .join(" ");
+  if (card) out.push(card);
+  return out.join("\n");
+}


### PR DESCRIPTION
Reported from the running app, with photographs of the device: *"it does usually show options — if I click sale, then make the payment, it shows me the options"*. Correct. Clover's own Sale app ends with Print receipt / Email Receipt / Text Receipt, and a semi-integrated sale that simply stops looks broken beside it.

## The endpoint exists, contrary to what I concluded first

I stated in review that REST Pay Display has no receipt chooser. **That was wrong**, and wrong in an instructive way: I searched the *guides* index, which doesn't list it. The *API reference* does.

```
POST /connect/v1/device/receipt-options
     { deliveryOptions: [{ method }] }  ->  the customer's selection
```

It takes no `paymentId`. It asks, and hands back the answer — including the address the customer typed — and the POS delivers.

## Every choice gets the breakdown

Clover *will* email a receipt. But it emails **Clover's** receipt, which has **no line items**, because there is no Clover order behind this payment — the same constraint that forced the custom text receipt in the first place. Handing Email off to Clover would answer "the breakdown must be on the receipt" with the old behaviour plus extra steps.

So the receipt is composed **once** by `receiptInputFor()`, and three renderers put that same input on a roll, in an inbox, and on a phone:

| Renderer | Used for | Note |
|---|---|---|
| `buildReceiptLines` | the printer | 32 columns |
| `buildReceiptHtml` | email | a `<pre>` of the very same lines, so the two cannot drift |
| `buildReceiptSmsText` | SMS | **not** the padded layout — columns wrap raggedly in a chat bubble, and every 153 chars is another segment the facility pays for |

## Ours first, Clover's as a floor

Both senders are environment-gated (no `RESEND_API_KEY`, no email), and **no facility has a Twilio subaccount provisioned yet**, so SMS sends from the platform number rather than pretending a per-facility lookup works.

When ours can't send, Clover's unitemised copy still goes out — a customer walking away with nothing is worse than one holding a receipt without the breakdown. But the counter is **told**: `receiptItemised` rides back on the response and the toast reads *"Emailed, but WITHOUT the breakdown"* rather than implying the better outcome.

## A PRINT choice sends two receipts, deliberately

Ours carries the breakdown. Clover's carries the payment furniture and is the **card-brand-compliant** one — the docs put that squarely on the integrator for custom receipts:

> You are responsible to ensure the receipts printed by your app comply with all card brand [rules]

A breakdown of a grooming bill is not a compliant payment record. Two prints off one roll is a cheap way to owe nobody an argument.

## Not asked is not declined

A null answer from the device — unreachable, timed out — falls back to **printing** rather than to silence. A customer who was never asked has not refused, and the one outcome this must never produce is a paying customer left with nothing because a dialog failed to open.

## Verification

`typecheck`, `eslint` (clean on changed files), `format`, `check:success-claims`, `check:rls-writes`, `check:facility-from-session` all green. Hardware confirmation after deploy — a local run cannot reach the sandbox merchant.