### PR TITLE
feat(payments): every receipt names the facility and shows the breakdown

### DIFF
--- a/src/app/api/payments/clover/terminal/route.ts
+++ b/src/app/api/payments/clover/terminal/route.ts
@@ -15,6 +15,12 @@ import {
 } from "@/lib/clover/print";
 import { buildReceiptLines, type ReceiptInput } from "@/lib/clover/receipt";
 import {
+  computeTax,
+  NO_TAX,
+  taxConfigSchema,
+  type TaxConfig,
+} from "@/lib/settings/tax";
+import {
   emailItemisedReceipt,
   smsItemisedReceipt,
 } from "@/lib/clover/receipt-delivery";
@@ -89,7 +95,11 @@ export async function POST(request: NextRequest) {
   const { data: booking } = await supabase
     .from("bookings")
     .select(
-      "id, ref, facility_id, client_id, amount_due, amount_paid, status, service, service_type, base_price, discount, tip_amount, facilities ( name, timezone ), clients ( name ), booking_pets ( pets ( name ) )",
+      // The facility's OWN identity travels with the booking: a receipt naming
+      // the business, its address and how to reach it is the difference between
+      // a record and a note. These columns exist on `facilities`
+      // (20260809120000) and were simply never read here.
+      "id, ref, facility_id, client_id, amount_due, amount_paid, status, service, service_type, base_price, discount, tip_amount, start_at, end_at, facilities ( name, timezone, phone, email, website, address ), clients ( name ), booking_pets ( pets ( name ) )",
     )
     .eq("ref", parsed.data.bookingRef)
     .maybeSingle();
@@ -373,7 +383,22 @@ interface BookingForReceipt {
   base_price: number | string;
   discount: number | string | null;
   tip_amount: number | string | null;
-  facilities: { name: string; timezone: string | null } | null;
+  start_at: string | null;
+  end_at: string | null;
+  facilities: {
+    name: string;
+    timezone: string | null;
+    phone: string | null;
+    email: string | null;
+    website: string | null;
+    address: {
+      street?: string;
+      city?: string;
+      state?: string;
+      zipCode?: string;
+      country?: string;
+    } | null;
+  } | null;
   clients: { name: string } | null;
   booking_pets: { pets: { name: string } | null }[] | null;
 }
@@ -404,18 +429,29 @@ async function receiptInputFor(
   outcome: Extract<Awaited<ReturnType<typeof chargeOnTerminal>>, { ok: true }>,
 ): Promise<ReceiptInput | null> {
   try {
-    const { data: rows } = await supabase
-      .from("booking_line_items")
-      .select("name, price, unit_price, quantity")
-      .eq("booking_id", booking.id)
-      .order("created_at", { ascending: true });
+    const [{ data: rows }, { data: settingRow }] = await Promise.all([
+      supabase
+        .from("booking_line_items")
+        .select("name, price, unit_price, quantity")
+        .eq("booking_id", booking.id)
+        .order("created_at", { ascending: true }),
+      // The FACILITY's tax, not a fixture's. Nothing is added when they have
+      // not configured any — see the banner in lib/settings/tax.ts.
+      supabase
+        .from("facility_settings")
+        .select("value")
+        .eq("facility_id", booking.facility_id)
+        .eq("domain", "tax_config")
+        .maybeSingle(),
+    ]);
 
     const cents = (v: number | string | null | undefined) =>
       Math.round(Number(v ?? 0) * 100);
 
     const lines = [
       {
-        label: booking.service_type || booking.service,
+        label:
+          humaniseService(booking.service_type || booking.service) ?? "Service",
         amountCents: cents(booking.base_price),
       },
       ...(
@@ -437,27 +473,65 @@ async function receiptInputFor(
     const discountCents = cents(booking.discount);
     const subtotalCents =
       lines.reduce((sum, l) => sum + l.amountCents, 0) - discountCents;
-    const tipCents = Math.max(0, outcome.amountCents - subtotalCents);
+
+    // ── TAX IS DERIVED, THE TIP IS WHAT IS LEFT ─────────────────────────────
+    //
+    // The terminal reports one number: what the customer actually paid. The
+    // subtotal and the tax are both computable from the booking, so the tip is
+    // the remainder — and it must be worked out AFTER tax, or a taxed sale
+    // reports its tax as gratuity.
+    const taxConfig = parseTaxConfig(settingRow?.value);
+    const tax = computeTax(subtotalCents, taxConfig);
+    const tipCents = Math.max(
+      0,
+      outcome.amountCents - subtotalCents - tax.totalCents,
+    );
+
+    const zone = booking.facilities?.timezone ?? "UTC";
+    const registrations = taxConfig.showRegistrationOnInvoice
+      ? taxConfig.taxes
+          .filter((t) => t.enabled && t.registrationNumber)
+          .map((t) => `${t.name}: ${t.registrationNumber}`)
+          .join(" · ")
+      : "";
 
     return {
-      facilityName: booking.facilities?.name ?? "Yipyy",
+      facility: {
+        name: booking.facilities?.name ?? "Yipyy",
+        address: formatAddress(booking.facilities?.address ?? null),
+        phone: booking.facilities?.phone ?? null,
+        email: booking.facilities?.email ?? null,
+        website: booking.facilities?.website ?? null,
+        taxRegistrations: registrations || null,
+      },
+      bookingRef: booking.ref,
       reference: `Booking #${booking.ref}`,
       clientName: booking.clients?.name ?? null,
       petNames: (booking.booking_pets ?? [])
         .map((bp) => bp.pets?.name)
         .filter((n): n is string => Boolean(n)),
+      serviceWindow: formatWindow(booking.start_at, booking.end_at, zone),
       lines,
       discountCents,
       subtotalCents,
+      taxLines: tax.lines.map((t) => ({
+        name: t.name,
+        rate: t.rate,
+        amountCents: t.amountCents,
+      })),
+      taxTotalCents: tax.totalCents,
       tipCents,
       totalCents: outcome.amountCents,
+      paymentMethod: "Paid by card",
       cardBrand: outcome.cardBrand,
       cardLast4: outcome.cardLast4,
+      entryMethod: humaniseService(outcome.entryMethod ?? ""),
+      authCode: outcome.authCode ?? null,
       processorPaymentId: outcome.processorPaymentId,
       // The FACILITY's clock, not the server's. A receipt handed over a counter
       // in Montreal saying 09:00 UTC is wrong on paper nobody can correct.
       printedAt: new Date().toLocaleString("en-CA", {
-        timeZone: booking.facilities?.timezone ?? "UTC",
+        timeZone: zone,
         dateStyle: "medium",
         timeStyle: "short",
       }),
@@ -466,4 +540,76 @@ async function receiptInputFor(
     console.warn("[terminal] receipt could not be composed:", error);
     return null;
   }
+}
+
+/** "full_groom" -> "Full groom". The column stores a key; paper wants a word. */
+function humaniseService(raw: string): string | null {
+  if (!raw) return null;
+  const words = raw.replace(/[_-]+/g, " ").trim();
+  return words ? words.charAt(0).toUpperCase() + words.slice(1) : null;
+}
+
+/** The address jsonb as one line, or null when the facility has not set one. */
+function formatAddress(
+  address: {
+    street?: string;
+    city?: string;
+    state?: string;
+    zipCode?: string;
+    country?: string;
+  } | null,
+): string | null {
+  if (!address) return null;
+  const line = [
+    address.street,
+    address.city,
+    [address.state, address.zipCode].filter(Boolean).join(" "),
+  ]
+    .map((part) => part?.trim())
+    .filter(Boolean)
+    .join(", ");
+  return line || null;
+}
+
+/**
+ * "19 Aug 2026, 8:00 a.m. - 6:00 p.m." for a same-day service, or the two dates
+ * in full for a stay.
+ *
+ * A receipt for a day of daycare that does not say WHICH day is not a record of
+ * anything, and a boarding receipt that shows only the drop-off hides half of
+ * what was bought.
+ */
+function formatWindow(
+  startAt: string | null,
+  endAt: string | null,
+  zone: string,
+): string | null {
+  if (!startAt) return null;
+  const start = new Date(startAt);
+  if (Number.isNaN(start.getTime())) return null;
+  const date = (d: Date) =>
+    d.toLocaleDateString("en-CA", { timeZone: zone, dateStyle: "medium" });
+  const time = (d: Date) =>
+    d.toLocaleTimeString("en-CA", { timeZone: zone, timeStyle: "short" });
+
+  if (!endAt) return `${date(start)} ${time(start)}`;
+  const end = new Date(endAt);
+  if (Number.isNaN(end.getTime())) return `${date(start)} ${time(start)}`;
+
+  return date(start) === date(end)
+    ? `${date(start)}, ${time(start)} - ${time(end)}`
+    : `${date(start)} ${time(start)} - ${date(end)} ${time(end)}`;
+}
+
+/**
+ * The stored tax setting, or none.
+ *
+ * Parsed rather than cast: `facility_settings.value` is jsonb and a row written
+ * by an older shape would otherwise reach the arithmetic. A receipt is the
+ * wrong place to discover that a config is malformed, so a bad row means no tax
+ * line rather than a thrown request.
+ */
+function parseTaxConfig(value: unknown): TaxConfig {
+  const parsed = taxConfigSchema.safeParse(value);
+  return parsed.success ? parsed.data : NO_TAX;
 }

--- a/src/app/facility/dashboard/clients/[id]/bookings/[bookingId]/page.tsx
+++ b/src/app/facility/dashboard/clients/[id]/bookings/[bookingId]/page.tsx
@@ -64,6 +64,7 @@ import {
 } from "@/lib/bookings/care-instructions";
 import { careLogKeys, careLogQueries, logCare } from "@/lib/api/care-log";
 import { BookingNotes } from "@/components/bookings/BookingNotes";
+import type { BookingLineItem } from "@/app/api/bookings/[ref]/line-items/route";
 import { BookingModal } from "@/components/bookings/modals/BookingModal";
 import { ProcessPaymentModal } from "@/components/bookings/modals/ProcessPaymentModal";
 import { CancelBookingModal } from "@/components/bookings/modals/CancelBookingModal";
@@ -570,6 +571,39 @@ export default function ClientBookingDetailPage({
 
   const invoice = booking.invoice;
   const addedSubtotal = booking.extrasTotal ?? 0;
+
+  // ── WHAT GOES ON A PRINTED RECEIPT ──────────────────────────────────────
+  //
+  // The same rows the Payment Summary panel shows, so the paper a customer
+  // takes away and the screen the counter is reading cannot disagree. Same
+  // query key as BookingPaymentBreakdown, so this is the cache, not a second
+  // request.
+  const { data: bookingLineItemsData } = useQuery({
+    queryKey: ["bookings", booking.id, "line-items"],
+    queryFn: async (): Promise<BookingLineItem[]> => {
+      const response = await fetch(`/api/bookings/${booking.id}/line-items`);
+      if (!response.ok) throw new Error("Could not read the bill.");
+      return (await response.json()) as BookingLineItem[];
+    },
+    staleTime: 30_000,
+  });
+  const bookingLineItems = bookingLineItemsData ?? [];
+
+  // "Aug 19, 2026, 8:00 AM - 6:00 PM". A receipt for a day of daycare that does
+  // not say which day is not a record of anything.
+  const serviceWindowLabel = (() => {
+    if (!booking.startDate) return null;
+    const day = (value: string) =>
+      new Date(`${value}T00:00:00`).toLocaleDateString("en-CA", {
+        dateStyle: "medium",
+      });
+    const times = [booking.checkInTime, booking.checkOutTime]
+      .filter(Boolean)
+      .join(" - ");
+    return booking.endDate && booking.endDate !== booking.startDate
+      ? `${day(booking.startDate)} - ${day(booking.endDate)}`
+      : `${day(booking.startDate)}${times ? `, ${times}` : ""}`;
+  })();
   // Incident-medication charges (2B.3) — gated by the med's chargeFee + the
   // facility toggle (2G.1); per_admin lines recompute as care logs accrue.
   const incidentCareItems = getIncidentCareCharges(booking.id);
@@ -1760,6 +1794,29 @@ export default function ClientBookingDetailPage({
         <PaymentCheckoutFlow
           open={checkoutOpen}
           onOpenChange={setCheckoutOpen}
+          // What the customer is being charged FOR. The printed receipt used to
+          // show a single "Amount" line — a total with no evidence behind it.
+          receiptReference={bookingRef}
+          receiptServiceWindow={serviceWindowLabel}
+          receiptLines={[
+            {
+              label: booking.serviceType || booking.service,
+              amount: booking.basePrice,
+            },
+            ...bookingLineItems.map((item) => ({
+              label:
+                item.quantity > 1
+                  ? `${item.name} x${item.quantity}`
+                  : item.name,
+              amount: item.price,
+            })),
+            ...(incidentCareTotal > 0
+              ? [{ label: "Incident care", amount: incidentCareTotal }]
+              : []),
+            ...(pendingLateFee
+              ? [{ label: "Late pickup fee", amount: pendingLateFee.amount }]
+              : []),
+          ]}
           amountDue={
             (invoice?.remainingDue ?? booking.totalCost) +
             addedSubtotal +

--- a/src/app/facility/dashboard/clients/[id]/bookings/[bookingId]/page.tsx
+++ b/src/app/facility/dashboard/clients/[id]/bookings/[bookingId]/page.tsx
@@ -536,6 +536,29 @@ export default function ClientBookingDetailPage({
   }, [isBoarding, booking, pet, client, nights]);
 
   const bookingRef = formatBookingRef(booking?.id ?? bookingId);
+  // ── WHAT GOES ON A PRINTED RECEIPT ──────────────────────────────────────
+  //
+  // The same rows the Payment Summary panel shows, so the paper a customer
+  // takes away and the screen the counter is reading cannot disagree. Same
+  // query key as BookingPaymentBreakdown, so this is the cache, not a second
+  // request.
+  //
+  // ABOVE the early returns below, and keyed on `bookingId` rather than
+  // `booking.id`: a hook after a conditional return is called in a different
+  // order on the render where the booking is still loading.
+  const { data: bookingLineItemsData } = useQuery({
+    queryKey: ["bookings", booking?.id ?? bookingId, "line-items"],
+    queryFn: async (): Promise<BookingLineItem[]> => {
+      const response = await fetch(
+        `/api/bookings/${booking?.id ?? bookingId}/line-items`,
+      );
+      if (!response.ok) throw new Error("Could not read the bill.");
+      return (await response.json()) as BookingLineItem[];
+    },
+    enabled: Boolean(booking?.id ?? bookingId),
+    staleTime: 30_000,
+  });
+  const bookingLineItems = bookingLineItemsData ?? [];
 
   const [tasks, setTasks] = useState<GeneratedTask[]>([]);
   useEffect(() => {
@@ -571,23 +594,6 @@ export default function ClientBookingDetailPage({
 
   const invoice = booking.invoice;
   const addedSubtotal = booking.extrasTotal ?? 0;
-
-  // ── WHAT GOES ON A PRINTED RECEIPT ──────────────────────────────────────
-  //
-  // The same rows the Payment Summary panel shows, so the paper a customer
-  // takes away and the screen the counter is reading cannot disagree. Same
-  // query key as BookingPaymentBreakdown, so this is the cache, not a second
-  // request.
-  const { data: bookingLineItemsData } = useQuery({
-    queryKey: ["bookings", booking.id, "line-items"],
-    queryFn: async (): Promise<BookingLineItem[]> => {
-      const response = await fetch(`/api/bookings/${booking.id}/line-items`);
-      if (!response.ok) throw new Error("Could not read the bill.");
-      return (await response.json()) as BookingLineItem[];
-    },
-    staleTime: 30_000,
-  });
-  const bookingLineItems = bookingLineItemsData ?? [];
 
   // "Aug 19, 2026, 8:00 AM - 6:00 PM". A receipt for a day of daycare that does
   // not say which day is not a record of anything.

--- a/src/app/facility/dashboard/services/retail/page.tsx
+++ b/src/app/facility/dashboard/services/retail/page.tsx
@@ -5,7 +5,6 @@ import dynamic from "next/dynamic";
 import { useSearchParams } from "next/navigation";
 import { cn } from "@/lib/utils";
 import { toast } from "sonner";
-import { facilities } from "@/data/facilities";
 import {
   Popover,
   PopoverContent,

--- a/src/app/facility/dashboard/services/retail/page.tsx
+++ b/src/app/facility/dashboard/services/retail/page.tsx
@@ -12,6 +12,7 @@ import {
   PopoverTrigger,
 } from "@/components/ui/popover";
 import { invoiceHeaderHtml } from "@/lib/invoice-header";
+import { useReceiptFacility } from "@/hooks/use-receipt-facility";
 import { VariantSelector } from "@/components/retail/VariantSelector";
 import { useHardwareBarcodeScanner } from "@/hooks/use-hardware-barcode-scanner";
 
@@ -161,6 +162,8 @@ interface CartItemWithId extends CartItem {
 }
 
 export default function POSPage() {
+  // The facility's OWN header, not the fixture's — see use-receipt-facility.
+  const receiptFacility = useReceiptFacility();
   const searchParams = useSearchParams();
   const { role: facilityRole } = useFacilityRole();
   const currentUserId = getCurrentUserId();
@@ -2891,9 +2894,11 @@ export default function POSPage() {
                       className="w-full gap-2"
                       disabled={cart.length === 0}
                       onClick={() => {
-                        const facility = facilities.find(
-                          (f: { id: number }) => f.id === 11,
-                        );
+                        // The facility's OWN header. This was the fixture,
+                        // so a retail receipt handed across the counter named
+                        // "Example Pet Care Facility" and carried somebody
+                        // else's tax registration numbers.
+                        const facility = receiptFacility;
                         const w = window.open(
                           "",
                           "_blank",

--- a/src/components/bookings/BulkPaymentModal.tsx
+++ b/src/components/bookings/BulkPaymentModal.tsx
@@ -22,10 +22,8 @@ import {
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { toast } from "sonner";
-import { facilities } from "@/data/facilities";
 import { invoiceHeaderHtml } from "@/lib/invoice-header";
-
-const defaultFacility = facilities.find((f) => f.id === 11);
+import { useReceiptFacility } from "@/hooks/use-receipt-facility";
 
 interface UnpaidInvoice {
   bookingId: number;
@@ -80,6 +78,8 @@ export function BulkPaymentModal({
   invoices,
   onConfirm,
 }: BulkPaymentModalProps) {
+  // The facility's OWN header, not the fixture's — see use-receipt-facility.
+  const receiptFacility = useReceiptFacility();
   // ── The state is what the user UNTICKED, not what is ticked ──────────────
   //
   // The obvious shape — a set of selected ids seeded from `invoices` — needs
@@ -188,7 +188,7 @@ h1{font-size:18px;margin:0}h2{font-size:12px;color:#666;margin:4px 0 20px}
 .footer{margin-top:24px;text-align:center;font-size:10px;color:#999}
 .badge{background:#ecfdf5;color:#059669;padding:6px 14px;border-radius:8px;text-align:center;margin-top:14px;font-weight:600;font-size:13px}
 </style></head><body>
-${invoiceHeaderHtml(defaultFacility)}
+${invoiceHeaderHtml(receiptFacility)}
 <h1>Bulk Payment Receipt</h1>
 <h2>${clientName} · ${new Date().toLocaleDateString("en-US", { month: "long", day: "numeric", year: "numeric" })}</h2>
 <div class="section">Bookings Paid (${lines.length})</div>

--- a/src/components/bookings/PaymentCheckoutFlow.tsx
+++ b/src/components/bookings/PaymentCheckoutFlow.tsx
@@ -27,13 +27,16 @@ import {
   calculateChange,
   type PaymentMethod,
 } from "@/lib/invoice-lifecycle";
-import { facilities } from "@/data/facilities";
 import { invoiceHeaderHtml } from "@/lib/invoice-header";
+import { useReceiptFacility } from "@/hooks/use-receipt-facility";
 import { useResolvedTerminal } from "@/lib/api/terminals";
 import { TerminalPicker } from "./TerminalPicker";
 
-// Default facility for receipt header
-const defaultFacility = facilities.find((f) => f.id === 11);
+/** One priced line on the printed receipt — the service, an item, a fee. */
+export interface ReceiptDetailLine {
+  label: string;
+  amount: number;
+}
 
 interface OtherUnpaidInvoice {
   invoiceId: string;
@@ -47,6 +50,19 @@ interface PaymentCheckoutFlowProps {
   amountDue: number;
   depositPaid: number;
   invoiceTotal: number;
+  /**
+   * What the customer is actually being charged FOR.
+   *
+   * Optional so the other callers of this dialog are unaffected, but a printed
+   * receipt without it is the bug being fixed: this window used to show
+   * "Amount / Total Charged" and nothing else, which is a total with no
+   * evidence behind it.
+   */
+  receiptLines?: ReceiptDetailLine[];
+  /** The booking's ref, so a printed receipt can be traced back from a counter. */
+  receiptReference?: string | null;
+  /** "19 Aug 2026, 8:00 a.m. - 6:00 p.m." — already in the facility's clock. */
+  receiptServiceWindow?: string | null;
   clientStoreCreditBalance?: number;
   otherUnpaidInvoices?: OtherUnpaidInvoice[];
   /** Auto-applied loyalty discount voucher — shown as a line and netted off the
@@ -90,6 +106,9 @@ export function PaymentCheckoutFlow({
   amountDue,
   depositPaid,
   invoiceTotal,
+  receiptLines,
+  receiptReference,
+  receiptServiceWindow,
   clientStoreCreditBalance = 0,
   otherUnpaidInvoices = [],
   loyaltyDiscount,
@@ -136,6 +155,8 @@ export function PaymentCheckoutFlow({
   };
 
   const [confirming, setConfirming] = useState(false);
+  // The facility's OWN header, not the fixture's — see use-receipt-facility.
+  const receiptFacility = useReceiptFacility();
   const [step, setStep] = useState<"pay" | "receipt">("pay");
   const [busy, setBusy] = useState(false);
   const [problem, setProblem] = useState<string | null>(null);
@@ -687,10 +708,21 @@ h1{font-size:18px;margin:0}h2{font-size:12px;color:#666;margin:4px 0 20px}
 .badge{background:#ecfdf5;color:#059669;padding:8px 16px;border-radius:8px;text-align:center;margin-top:16px;font-weight:600;font-size:13px}
 .footer{margin-top:24px;text-align:center;font-size:10px;color:#999}
 @media print{body{padding:20px}}</style></head><body>
-${invoiceHeaderHtml(defaultFacility)}
+${invoiceHeaderHtml(receiptFacility)}
 <h1>Payment Receipt</h1>
 <h2>${new Date().toLocaleDateString("en-US", { month: "long", day: "numeric", year: "numeric" })}</h2>
-<div class="row"><span>Amount</span><span>$${amountDue.toFixed(2)}</span></div>
+${receiptReference ? `<div class="row sub"><span>Reference</span><span>${receiptReference}</span></div>` : ""}
+${receiptServiceWindow ? `<div class="row sub"><span>Service</span><span>${receiptServiceWindow}</span></div>` : ""}
+${
+  receiptLines && receiptLines.length > 0
+    ? receiptLines
+        .map(
+          (l) =>
+            `<div class="row"><span>${l.label}</span><span>$${l.amount.toFixed(2)}</span></div>`,
+        )
+        .join("")
+    : `<div class="row"><span>Amount</span><span>$${amountDue.toFixed(2)}</span></div>`
+}
 ${depositPaid > 0 ? `<div class="row sub"><span>Deposit Applied</span><span>-$${depositPaid.toFixed(2)}</span></div>` : ""}
 ${tipAmount > 0 ? `<div class="row sub"><span>Tip</span><span>$${tipAmount.toFixed(2)}</span></div>` : ""}
 ${otherTotal > 0 ? `<div class="row sub"><span>Other Invoices</span><span>$${otherTotal.toFixed(2)}</span></div>` : ""}
@@ -698,7 +730,7 @@ ${otherTotal > 0 ? `<div class="row sub"><span>Other Invoices</span><span>$${oth
 <div class="row sub"><span>Payment Method</span><span>${methodLabel}</span></div>
 ${paymentNote ? `<div class="row sub"><span>Note</span><span>${paymentNote}</span></div>` : ""}
 <div class="badge">PAYMENT COMPLETE</div>
-<div class="footer">Thank you for your business!<br>${defaultFacility?.name ?? ""}</div>
+<div class="footer">Thank you for your business!<br>${receiptFacility?.name ?? ""}</div>
 </body></html>`);
                   w.document.close();
                   w.print();

--- a/src/components/bookings/RefundModal.tsx
+++ b/src/components/bookings/RefundModal.tsx
@@ -21,10 +21,8 @@ import {
   Loader2,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { facilities } from "@/data/facilities";
 import { invoiceHeaderHtml } from "@/lib/invoice-header";
-
-const defaultFacility = facilities.find((f) => f.id === 11);
+import { useReceiptFacility } from "@/hooks/use-receipt-facility";
 
 interface RefundModalProps {
   open: boolean;
@@ -54,6 +52,8 @@ export function RefundModal({
   items,
   onConfirm,
 }: RefundModalProps) {
+  // The facility's OWN header, not the fixture's — see use-receipt-facility.
+  const receiptFacility = useReceiptFacility();
   const [step, setStep] = useState<"select" | "confirm">("select");
   const [refundType, setRefundType] = useState<RefundType>("full");
   const [partialAmount, setPartialAmount] = useState("");
@@ -136,7 +136,7 @@ h1{font-size:18px;margin:0;color:#dc2626}h2{font-size:12px;color:#666;margin:4px
 .badge{background:#fef2f2;color:#dc2626;padding:6px 14px;border-radius:8px;text-align:center;margin-top:14px;font-weight:600;font-size:13px}
 .note{background:#f8fafc;border:1px solid #e2e8f0;border-radius:8px;padding:10px;margin-top:14px;font-size:11px;color:#64748b}
 </style></head><body>
-${invoiceHeaderHtml(defaultFacility)}
+${invoiceHeaderHtml(receiptFacility)}
 <h1>Refund Receipt</h1>
 <h2>Processed ${new Date().toLocaleDateString("en-US", { month: "long", day: "numeric", year: "numeric" })}</h2>
 <div class="section">Refund Details</div>

--- a/src/components/customer/billing/InvoicesTab.tsx
+++ b/src/components/customer/billing/InvoicesTab.tsx
@@ -25,7 +25,6 @@ import {
 import { FileText, Download, Search, Calendar, DollarSign } from "lucide-react";
 import { toast } from "sonner";
 import { InvoiceLoyaltySection } from "@/components/loyalty/InvoiceLoyaltySection";
-import { facilities } from "@/data/facilities";
 import { invoiceHeaderHtml } from "@/lib/invoice-header";
 import { useReceiptFacility } from "@/hooks/use-receipt-facility";
 

--- a/src/components/customer/billing/InvoicesTab.tsx
+++ b/src/components/customer/billing/InvoicesTab.tsx
@@ -27,8 +27,11 @@ import { toast } from "sonner";
 import { InvoiceLoyaltySection } from "@/components/loyalty/InvoiceLoyaltySection";
 import { facilities } from "@/data/facilities";
 import { invoiceHeaderHtml } from "@/lib/invoice-header";
+import { useReceiptFacility } from "@/hooks/use-receipt-facility";
 
 export function InvoicesTab() {
+  // The facility's OWN header, not the fixture's — see use-receipt-facility.
+  const receiptFacility = useReceiptFacility();
   const { client: customer } = useCurrentCustomer();
   const customerId = customer?.id;
 
@@ -263,7 +266,7 @@ export function InvoicesTab() {
       </head>
       <body>
         <div class="invoice-wrapper">
-          ${invoiceHeaderHtml(facilities.find((f) => f.id === (selectedFacility?.id ?? 11)))}
+          ${invoiceHeaderHtml(receiptFacility)}
           <div class="header">
             <div></div>
             <div class="meta">

--- a/src/components/facility/TaxSettings.tsx
+++ b/src/components/facility/TaxSettings.tsx
@@ -18,8 +18,28 @@ import { Receipt, Plus, Trash2, Shield, Globe, Percent } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { toast } from "sonner";
 import { TAX_PRESETS, getPreset } from "@/data/tax-presets";
-import { facilities } from "@/data/facilities";
 import { useFacilityRole } from "@/hooks/use-facility-role";
+import {
+  useFacilitySettings,
+  useSaveFacilitySetting,
+} from "@/lib/api/facility-settings";
+import type { TaxConfig } from "@/lib/settings/tax";
+
+// ============================================================================
+// ── THIS SCREEN USED TO SAVE NOTHING ──────────────────────────────────────
+//
+// Its Save button mutated the shared FIXTURE and announced success:
+//
+//     (defaultFacility as Record<string, unknown>).taxConfig = { ... };
+//     toast.success("Tax settings saved");
+//
+// One object, shared by every facility on the platform, discarded on reload,
+// never sent anywhere. A facility could enter its GST and QST registration
+// numbers, be told they were saved, and find them on no document ever.
+//
+// It now reads and writes the `tax_config` setting domain, which is what makes
+// a tax line appear on a receipt at all.
+// ============================================================================
 
 interface TaxEntry {
   id: string;
@@ -32,13 +52,13 @@ interface TaxEntry {
   enabled: boolean;
 }
 
-const defaultFacility = facilities.find((f) => f.id === 11);
-const defaultConfig = defaultFacility?.taxConfig;
-
 let _taxId = 500;
 
 export function TaxSettings() {
   const { role } = useFacilityRole();
+  const settings = useFacilitySettings();
+  const saveSetting = useSaveFacilitySetting();
+  const defaultConfig = settings.settings.tax_config.value as TaxConfig;
 
   const [country, setCountry] = useState(defaultConfig?.country ?? "CA");
   const [province, setProvince] = useState(defaultConfig?.province ?? "QC");
@@ -133,23 +153,36 @@ export function TaxSettings() {
     );
   };
 
-  const handleSave = () => {
-    if (defaultFacility) {
-      (defaultFacility as Record<string, unknown>).taxConfig = {
-        country,
-        province,
-        taxes,
-        pricesIncludeTax,
-        showTaxesSeparately: showSeparately,
-        showRegistrationOnInvoice: showRegistration,
-        exemptions: {
-          tips: true,
-          giftCards: exemptGiftCards,
-          storeCredit: exemptStoreCredit,
-        },
-      };
+  const handleSave = async () => {
+    // Awaited, and the failure reported. RLS refuses this write for anyone
+    // without `manage_settings`, and an unawaited mutation would show the same
+    // "saved" toast for a refusal as for a success — which is the bug this
+    // screen shipped with, in a subtler form.
+    try {
+      await saveSetting.mutateAsync({
+        domain: "tax_config",
+        value: {
+          country,
+          province,
+          taxes,
+          pricesIncludeTax,
+          showTaxesSeparately: showSeparately,
+          showRegistrationOnInvoice: showRegistration,
+          exemptions: {
+            // Never configurable here: a gratuity is not a supply, and no
+            // jurisdiction this ships in taxes one.
+            tips: true,
+            giftCards: exemptGiftCards,
+            storeCredit: exemptStoreCredit,
+          },
+        } satisfies TaxConfig,
+      });
+      toast.success("Tax settings saved");
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : "Tax settings were not saved.",
+      );
     }
-    toast.success("Tax settings saved");
   };
 
   if (role !== "owner" && role !== "manager") {

--- a/src/hooks/use-receipt-facility.ts
+++ b/src/hooks/use-receipt-facility.ts
@@ -1,0 +1,38 @@
+"use client";
+
+import { useFacilityProfile } from "@/lib/api/facility-profile";
+import { useFacilitySettings } from "@/lib/api/facility-settings";
+import {
+  facilityInfoFromProfile,
+  type FacilityInfo,
+} from "@/lib/invoice-header";
+import type { TaxConfig } from "@/lib/settings/tax";
+
+// ============================================================================
+// The facility that a printed document is FROM.
+//
+// Five screens print something a customer keeps — a payment receipt, a bulk
+// payment receipt, a refund slip, a retail receipt, a customer invoice — and
+// all five headed it with `facilities.find((f) => f.id === 11)`. That is the
+// fixture: "Example Pet Care Facility, 123 Example St, Example City", carrying
+// the fixture's GST and QST registration numbers.
+//
+// One hook so there is one answer, and so the next screen that prints something
+// cannot quietly reintroduce the fixture.
+// ============================================================================
+
+/**
+ * The current facility's own name, address, contact and tax registrations.
+ *
+ * @returns `null` until the profile has loaded — callers pass it straight to
+ *   `invoiceHeaderHtml`, which renders nothing for null. An empty header beats
+ *   a header naming the wrong business.
+ */
+export function useReceiptFacility(): FacilityInfo | null {
+  const { profile, isPending } = useFacilityProfile();
+  const settings = useFacilitySettings();
+  const tax = settings.settings.tax_config.value as TaxConfig;
+
+  if (isPending || !profile.businessName) return null;
+  return facilityInfoFromProfile(profile, tax);
+}

--- a/src/lib/api/facility-settings.ts
+++ b/src/lib/api/facility-settings.ts
@@ -21,6 +21,7 @@ import type {
   ModuleConfig,
   TipConfig,
 } from "@/types/facility";
+import type { TaxConfig } from "@/lib/settings/tax";
 
 // ============================================================================
 // A facility's own settings, per domain.
@@ -47,6 +48,7 @@ export interface FacilitySettings {
   business_hours: SettingState<BusinessHours>;
   booking_rules: SettingState<BookingRules>;
   tip_config: SettingState<TipConfig>;
+  tax_config: SettingState<TaxConfig>;
   booking_flow: SettingState<FacilityBookingFlowConfig>;
   daycare_config: SettingState<ModuleConfig>;
   boarding_config: SettingState<ModuleConfig>;

--- a/src/lib/clover/print.ts
+++ b/src/lib/clover/print.ts
@@ -12,8 +12,19 @@ import { validAccessToken } from "@/lib/clover/connection";
 //
 // Two endpoints of the REST Pay Display API:
 //
-//   POST /connect/v1/device/printers   empty body, answers with the printers
-//   POST /connect/v1/device/print      { printDeviceId, text: [...] }
+//   POST /connect/v1/device/printers    empty body, answers with the printers
+//   POST /connect/v1/device/print/text  { printDeviceId, text: [...] }
+//
+// ── /print/text, NOT /print ───────────────────────────────────────────────
+//
+// The guide prose says "the /v1/device/print endpoints require the printer's
+// identifier", and building from that sentence produced /v1/device/print,
+// which answers 404 {"message":"Invalid URI"}. The reference gives the literal
+// path: /v1/device/print/text (and /v1/device/print/image for the other kind).
+//
+// It cost a live terminal test to find, because the failure is invisible from
+// the outside: the payment succeeds, the response says receiptPrinted false,
+// and the only place the 404 appears is the server log.
 //
 // ── NOTHING HERE MAY AFFECT A PAYMENT ─────────────────────────────────────
 //
@@ -128,7 +139,7 @@ export async function printTextOnDevice(
 
   try {
     const response = await fetch(
-      new URL("/connect/v1/device/print", config.apiOrigin),
+      new URL("/connect/v1/device/print/text", config.apiOrigin),
       {
         method: "POST",
         headers: headers(active.accessToken, active.merchantId, deviceSerial),

--- a/src/lib/clover/receipt-delivery.ts
+++ b/src/lib/clover/receipt-delivery.ts
@@ -72,8 +72,8 @@ export async function emailItemisedReceipt(
         from: process.env.EMAIL_FROM ?? "Yipyy <onboarding@resend.dev>",
         to,
         subject: input.reference
-          ? `Your receipt from ${input.facilityName} (${input.reference})`
-          : `Your receipt from ${input.facilityName}`,
+          ? `Your receipt from ${input.facility.name} (${input.reference})`
+          : `Your receipt from ${input.facility.name}`,
         html: buildReceiptHtml(input),
         // Both parts, always. A text-only client showing an empty message is
         // indistinguishable from a receipt that never arrived.

--- a/src/lib/clover/receipt.ts
+++ b/src/lib/clover/receipt.ts
@@ -64,6 +64,40 @@ function centred(text: string): string {
   return `${" ".repeat(pad)}${text}`;
 }
 
+/**
+ * Break a long value across lines instead of cutting it.
+ *
+ * `row()` truncates a LABEL because the amount beside it must stay on the same
+ * line. Free text has no such constraint, and an address or a payment reference
+ * loses its meaning when the tail is dropped.
+ */
+function wrap(text: string): string[] {
+  const words = text.split(" ");
+  const lines: string[] = [];
+  let current = "";
+  for (const word of words) {
+    if (current.length === 0) {
+      current = word.slice(0, WIDTH);
+    } else if (current.length + 1 + word.length <= WIDTH) {
+      current += ` ${word}`;
+    } else {
+      lines.push(current);
+      current = word.slice(0, WIDTH);
+    }
+  }
+  if (current) lines.push(current);
+  return lines.length > 0 ? lines : [""];
+}
+
+function centredWrap(text: string): string[] {
+  return wrap(text).map(centred);
+}
+
+/** "5%" rather than "5.000%", and "9.975%" kept whole. */
+function formatRate(rate: number): string {
+  return `${Number(rate.toFixed(3))}%`;
+}
+
 const RULE = "-".repeat(WIDTH);
 
 export interface ReceiptLine {
@@ -71,20 +105,55 @@ export interface ReceiptLine {
   amountCents: number;
 }
 
+/** Who the receipt is FROM. Every field is the facility's own, never a fixture. */
+export interface ReceiptFacility {
+  name: string;
+  /** One line, already assembled: "3824 Saint Patrick St, Montreal, QC H4E 1A4". */
+  address: string | null;
+  phone: string | null;
+  email: string | null;
+  website: string | null;
+  /** "GST: RT 123456789 · QST: QT 987654321", when the facility shows them. */
+  taxRegistrations: string | null;
+}
+
+export interface ReceiptTaxLine {
+  name: string;
+  rate: number;
+  amountCents: number;
+}
+
 export interface ReceiptInput {
-  facilityName: string;
+  facility: ReceiptFacility;
+  /** The booking's own ref — what Yipyy is asked to trace this sale by. */
+  bookingRef: number | null;
   /** "Booking #1234" — whatever names this sale on paper. */
   reference: string | null;
   clientName: string | null;
   petNames: string[];
+  /**
+   * When the service was, in the facility's clock and already formatted —
+   * "19 Aug 2026, 8:00 a.m. – 6:00 p.m." A receipt for a day of daycare that
+   * does not say which day is not a record of anything.
+   */
+  serviceWindow: string | null;
   /** The service, the added items, the fees — in the order they should read. */
   lines: ReceiptLine[];
   discountCents: number;
+  /** Net of discount, before tax and tip. */
   subtotalCents: number;
+  taxLines: ReceiptTaxLine[];
+  taxTotalCents: number;
   tipCents: number;
   totalCents: number;
+  /** "Terminal", "Cash", "Card on file" — how it was actually paid. */
+  paymentMethod: string | null;
   cardBrand: string | null;
   cardLast4: string | null;
+  /** "Contactless", "Chip", "Swiped" — a card-brand receipt names the entry. */
+  entryMethod: string | null;
+  /** The acquirer's approval code. */
+  authCode: string | null;
   /** Clover's own payment id, so a paper receipt maps to a transaction. */
   processorPaymentId: string | null;
   /** Rendered as-is; the caller owns the timezone. */
@@ -101,15 +170,37 @@ export interface ReceiptInput {
 export function buildReceiptLines(input: ReceiptInput): string[] {
   const out: string[] = [];
 
-  out.push(centred(input.facilityName.slice(0, WIDTH)));
-  out.push("");
-  if (input.reference) out.push(input.reference);
-  if (input.clientName) out.push(input.clientName);
-  if (input.petNames.length > 0) {
-    // One line however many pets; a stay for three dogs should not push the
-    // total off the bottom of a short roll.
-    out.push(`Pet: ${input.petNames.join(", ")}`.slice(0, WIDTH));
+  // ── WHO THIS IS FROM ────────────────────────────────────────────────────
+  //
+  // Name, address, phone, email. A receipt that says only "Pawradise" is not
+  // something a customer can act on: they cannot phone about it, and in most
+  // jurisdictions a supplier's address is what makes it a receipt rather than a
+  // note. Each is skipped when the facility has not set it, rather than
+  // printing a blank line or a fixture's.
+  out.push(...centredWrap(input.facility.name));
+  if (input.facility.address) out.push(...centredWrap(input.facility.address));
+  // Phone and email on their OWN lines rather than joined with a separator:
+  // at 32 columns the pair almost always wraps, and it wraps mid-separator —
+  // "514 690 8911 ·" sitting alone above the address looks like a fault.
+  if (input.facility.phone) out.push(...centredWrap(input.facility.phone));
+  if (input.facility.email) out.push(...centredWrap(input.facility.email));
+  if (input.facility.taxRegistrations) {
+    out.push(...centredWrap(input.facility.taxRegistrations));
   }
+  out.push("");
+
+  // ── WHAT IT IS FOR ──────────────────────────────────────────────────────
+  //
+  // The booking ref first, and deliberately: it is what Yipyy is asked to trace
+  // a printed receipt by when a customer brings one back to a counter.
+  if (input.reference) out.push(input.reference);
+  if (input.clientName) out.push(...wrap(input.clientName));
+  if (input.petNames.length > 0) {
+    out.push(...wrap(`Pet: ${input.petNames.join(", ")}`));
+  }
+  // The service window wraps rather than truncates — a date cut in half is
+  // worse than a date on two lines.
+  if (input.serviceWindow) out.push(...wrap(input.serviceWindow));
   out.push(input.printedAt);
   out.push(RULE);
 
@@ -123,20 +214,32 @@ export function buildReceiptLines(input: ReceiptInput): string[] {
 
   out.push(RULE);
   out.push(row("Subtotal", input.subtotalCents));
+  for (const tax of input.taxLines) {
+    out.push(row(`${tax.name} ${formatRate(tax.rate)}`, tax.amountCents));
+  }
   if (input.tipCents > 0) out.push(row("Tip", input.tipCents));
   out.push(row("TOTAL", input.totalCents));
   out.push(RULE);
 
+  // ── HOW IT WAS PAID ─────────────────────────────────────────────────────
+  //
+  // Brand, masked pan, entry method and approval code. These are the fields a
+  // card-brand-compliant receipt is expected to carry, and the payments row
+  // already stores every one of them — printing a total and a last-4 while
+  // `auth_code` and `entry_method` sat unused was leaving the compliant version
+  // of this receipt one join away.
   const card = [
     input.cardBrand,
     input.cardLast4 ? `••${input.cardLast4}` : null,
   ]
     .filter(Boolean)
     .join(" ");
-  if (card) out.push(row("Paid by card", input.totalCents));
+  out.push(row(input.paymentMethod ?? "Paid", input.totalCents));
   if (card) out.push(card);
+  if (input.entryMethod) out.push(`Entry: ${input.entryMethod}`);
+  if (input.authCode) out.push(`Auth: ${input.authCode}`);
   if (input.processorPaymentId) {
-    out.push(`Ref: ${input.processorPaymentId}`.slice(0, WIDTH));
+    out.push(...wrap(`Ref: ${input.processorPaymentId}`));
   }
 
   out.push("");
@@ -145,7 +248,6 @@ export function buildReceiptLines(input: ReceiptInput): string[] {
 
   return out;
 }
-
 // ============================================================================
 // The same receipt, for a screen instead of a roll.
 //
@@ -176,10 +278,19 @@ function escapeHtml(text: string): string {
  */
 export function buildReceiptHtml(input: ReceiptInput): string {
   const body = buildReceiptLines(input).map(escapeHtml).join("\n");
+  const contact = [
+    input.facility.address,
+    [input.facility.phone, input.facility.email].filter(Boolean).join(" · "),
+  ].filter((line): line is string => Boolean(line));
   return [
     '<div style="background:#f6f6f7;padding:24px;font-family:system-ui,sans-serif">',
-    '<div style="max-width:420px;margin:0 auto;background:#fff;border-radius:12px;padding:24px">',
-    `<h1 style="margin:0 0 16px;font-size:18px">${escapeHtml(input.facilityName)}</h1>`,
+    '<div style="max-width:440px;margin:0 auto;background:#fff;border-radius:12px;padding:24px">',
+    `<h1 style="margin:0;font-size:18px">${escapeHtml(input.facility.name)}</h1>`,
+    ...contact.map(
+      (line) =>
+        `<p style="margin:2px 0 0;color:#6b7280;font-size:12px">${escapeHtml(line)}</p>`,
+    ),
+    '<hr style="border:none;border-top:1px solid #e5e7eb;margin:16px 0" />',
     '<pre style="font-family:ui-monospace,Menlo,Consolas,monospace;font-size:13px;line-height:1.45;white-space:pre;overflow-x:auto;margin:0">',
     body,
     "</pre>",
@@ -198,8 +309,9 @@ export function buildReceiptHtml(input: ReceiptInput): string {
 export function buildReceiptSmsText(input: ReceiptInput): string {
   const out: string[] = [];
   out.push(
-    `${input.facilityName}${input.reference ? ` — ${input.reference}` : ""}`,
+    `${input.facility.name}${input.reference ? ` — ${input.reference}` : ""}`,
   );
+  if (input.serviceWindow) out.push(input.serviceWindow);
   for (const line of input.lines) {
     out.push(`${line.label}: ${money(line.amountCents)}`);
   }
@@ -207,6 +319,9 @@ export function buildReceiptSmsText(input: ReceiptInput): string {
     out.push(`Discount: ${money(-input.discountCents)}`);
   }
   out.push(`Subtotal: ${money(input.subtotalCents)}`);
+  for (const tax of input.taxLines) {
+    out.push(`${tax.name}: ${money(tax.amountCents)}`);
+  }
   if (input.tipCents > 0) out.push(`Tip: ${money(input.tipCents)}`);
   out.push(`TOTAL: ${money(input.totalCents)}`);
   const card = [
@@ -216,5 +331,6 @@ export function buildReceiptSmsText(input: ReceiptInput): string {
     .filter(Boolean)
     .join(" ");
   if (card) out.push(card);
+  if (input.facility.phone) out.push(input.facility.phone);
   return out.join("\n");
 }

--- a/src/lib/clover/terminal.ts
+++ b/src/lib/clover/terminal.ts
@@ -163,6 +163,10 @@ export type TerminalOutcome =
       amountCents: number;
       currency: string;
       cardBrand: string | null;
+      /** "Contactless", "Chip", "Swiped" — what a compliant receipt names. */
+      entryMethod: string | null;
+      /** The acquirer's approval code, for the same reason. */
+      authCode: string | null;
       cardLast4: string | null;
     }
   | { ok: false; intentId: string | null; code: string; message: string };
@@ -443,6 +447,10 @@ export async function chargeOnTerminal(
     amountCents: (payment.amount ?? amountCents) + (payment.tipAmount ?? 0),
     currency: connection.currency,
     cardBrand: payment.cardTransaction?.cardType ?? null,
+    // Already recorded on the payments row above; returned as well so the
+    // receipt can carry them without a second read.
+    entryMethod: entryMethod(payment.cardTransaction?.entryType),
+    authCode: payment.cardTransaction?.authCode ?? null,
     cardLast4: payment.cardTransaction?.last4 ?? null,
   };
 }

--- a/src/lib/invoice-header.ts
+++ b/src/lib/invoice-header.ts
@@ -3,7 +3,7 @@
  * Shows the facility logo (if available), name, address, and contact.
  */
 
-interface FacilityInfo {
+export interface FacilityInfo {
   name: string;
   logo?: string;
   contact?: { email?: string; phone?: string };
@@ -68,3 +68,61 @@ td{padding:4px 0}
 .total td{font-weight:700;font-size:16px;padding-top:8px}
 @media print{body{margin:0;padding:20px}}
 `;
+
+// ============================================================================
+// The REAL facility, in the shape this header wants.
+//
+// Every caller of `invoiceHeaderHtml` passed the same thing:
+//
+//     const defaultFacility = facilities.find((f) => f.id === 11);
+//
+// — the FIXTURE. So every printed receipt, invoice, estimate and refund slip
+// this product produces was headed "Example Pet Care Facility, 123 Example St,
+// Example City", with the fixture's GST and QST registration numbers on it.
+// A customer of Pawradise holding one was reading another business's tax
+// numbers, which is worse than a cosmetic bug.
+//
+// `useFacilityProfile()` has returned the facility's own row since
+// 20260809120000. This is the adapter nobody wrote.
+// ============================================================================
+
+/** Turn the facility's own profile and tax setting into a printable header. */
+export function facilityInfoFromProfile(
+  profile: {
+    businessName: string;
+    email?: string;
+    phone?: string;
+    logo?: string;
+    address?: {
+      street?: string;
+      city?: string;
+      state?: string;
+      zipCode?: string;
+      country?: string;
+    };
+  },
+  tax?: {
+    showRegistrationOnInvoice?: boolean;
+    taxes?: { name: string; registrationNumber?: string; enabled: boolean }[];
+  },
+): FacilityInfo {
+  const a = profile.address;
+  const address = [
+    a?.street,
+    a?.city,
+    [a?.state, a?.zipCode].filter(Boolean).join(" "),
+  ]
+    .map((part) => part?.trim())
+    .filter(Boolean)
+    .join(", ");
+
+  return {
+    name: profile.businessName,
+    logo: profile.logo || undefined,
+    contact: { email: profile.email, phone: profile.phone },
+    // `locationsList` is how the header reads an address; one entry, the
+    // facility's own, rather than the fixture's list of branches.
+    locationsList: address ? [{ address }] : [],
+    taxConfig: tax,
+  };
+}

--- a/src/lib/settings/domains.ts
+++ b/src/lib/settings/domains.ts
@@ -1,5 +1,7 @@
 import { z } from "zod";
 
+import { NO_TAX, taxConfigSchema } from "@/lib/settings/tax";
+
 import {
   bookingRulesSchema,
   dropOffPickUpOverrideSchema,
@@ -128,6 +130,14 @@ export const SETTING_DOMAINS = {
   // set of tip tiers while the payment screen offers another is not a display
   // bug.
   tip_config: { schema: tipConfigSchema, fallback: DEFAULT_TIPS },
+  // Money, and the most consequential entry here: it decides what a customer
+  // is CHARGED and what the facility owes a revenue authority.
+  //
+  // The fallback is NO_TAX — an empty list — and not the fixture's Quebec
+  // GST + QST. Carrying the fixture over would have every facility that never
+  // opened the screen quietly adding 14.975% to its receipts, in Ontario, in
+  // Alberta, in the United States. See the banner in lib/settings/tax.ts.
+  tax_config: { schema: taxConfigSchema, fallback: NO_TAX },
 
   // ── WHAT A CUSTOMER MAY BOOK ───────────────────────────────────────────
   //

--- a/src/lib/settings/tax.ts
+++ b/src/lib/settings/tax.ts
@@ -1,0 +1,164 @@
+import { z } from "zod";
+
+// ============================================================================
+// What a facility charges in tax, and what it puts on a receipt.
+//
+// ── WHY THIS EXISTS ───────────────────────────────────────────────────────
+//
+// `TaxSettings.tsx` has been on the settings page all along, and its Save
+// button did this:
+//
+//     (defaultFacility as Record<string, unknown>).taxConfig = { ... };
+//     toast.success("Tax settings saved");
+//
+// It mutated the in-memory FIXTURE — facility 11, the one every deployment
+// shares — and announced success. The values survived until the next reload,
+// were never sent anywhere, and were the same object for every facility on the
+// platform. So a facility could enter its GST and QST registration numbers,
+// be told they were saved, and have nothing on any document ever show them.
+//
+// ── THE DEFAULT IS NO TAX, DELIBERATELY ───────────────────────────────────
+//
+// The fixture defaulted to Quebec GST 5% + QST 9.975%. Carrying that over as
+// the fallback would mean every facility that has never opened this screen
+// starts adding 14.975% to its receipts — in Ontario, in Alberta, in the
+// United States. A default that changes what a customer is charged is not a
+// default, it is a decision made on the facility's behalf about their tax
+// liability.
+//
+// So the fallback is an empty list: no tax line appears on any receipt until
+// somebody chooses one. `configured: false` travels with it, so a screen can
+// still tell "nobody has set this" from "they chose nothing".
+// ============================================================================
+
+export const taxEntrySchema = z.object({
+  id: z.string(),
+  /** As it appears on the receipt — "GST", "QST", "HST", "Sales Tax". */
+  name: z.string(),
+  /** A percentage, not a fraction: 9.975 means 9.975%. */
+  rate: z.number().min(0).max(100),
+  appliesTo: z.enum(["all", "services_only", "products_only"]),
+  /** The number the facility must show on an invoice, where law requires it. */
+  registrationNumber: z.string().default(""),
+  description: z.string().default(""),
+  /** Charged on subtotal PLUS the taxes above it, as some jurisdictions do. */
+  isCompound: z.boolean().default(false),
+  enabled: z.boolean(),
+});
+
+export const taxConfigSchema = z.object({
+  country: z.string().default("CA"),
+  province: z.string().default(""),
+  taxes: z.array(taxEntrySchema).default([]),
+  /** Prices already contain the tax; the receipt breaks it out rather than adding. */
+  pricesIncludeTax: z.boolean().default(false),
+  showTaxesSeparately: z.boolean().default(true),
+  showRegistrationOnInvoice: z.boolean().default(true),
+  exemptions: z
+    .object({
+      // A tip is a gratuity, not a supply, and is not taxable anywhere this
+      // ships. It is a field rather than a constant so the one jurisdiction
+      // that disagrees does not need a code change.
+      tips: z.boolean().default(true),
+      giftCards: z.boolean().default(true),
+      storeCredit: z.boolean().default(true),
+    })
+    .default({ tips: true, giftCards: true, storeCredit: true }),
+});
+
+export type TaxEntry = z.infer<typeof taxEntrySchema>;
+export type TaxConfig = z.infer<typeof taxConfigSchema>;
+
+/** No tax, until a facility says otherwise. See the banner above. */
+export const NO_TAX: TaxConfig = {
+  country: "CA",
+  province: "",
+  taxes: [],
+  pricesIncludeTax: false,
+  showTaxesSeparately: true,
+  showRegistrationOnInvoice: true,
+  exemptions: { tips: true, giftCards: true, storeCredit: true },
+};
+
+export interface ComputedTax {
+  name: string;
+  rate: number;
+  registrationNumber: string;
+  amountCents: number;
+}
+
+/**
+ * The tax on a sale, line by line.
+ *
+ * @param taxableCents the subtotal AFTER any discount and BEFORE the tip. A
+ *   discount reduces the price of the supply, so it reduces the tax; a tip is
+ *   not part of the supply at all.
+ *
+ * ── PRICES-INCLUDE-TAX IS EXTRACTION, NOT ADDITION ───────────────────────
+ *
+ * When a facility prices inclusively, the tax is already inside `taxableCents`
+ * and the receipt only has to say how much of it was tax. Adding it again would
+ * overcharge every customer, which is why the two branches are separate rather
+ * than one formula with a flag.
+ */
+export function computeTax(
+  taxableCents: number,
+  config: TaxConfig,
+): { lines: ComputedTax[]; totalCents: number } {
+  const active = config.taxes.filter(
+    (t) => t.enabled && t.rate > 0 && t.appliesTo !== "products_only",
+  );
+  if (active.length === 0 || taxableCents <= 0) {
+    return { lines: [], totalCents: 0 };
+  }
+
+  if (config.pricesIncludeTax) {
+    // The combined rate is what was baked in, so each tax's share is its own
+    // rate over that combined total. Compound taxes cannot be unpicked this
+    // way, and no jurisdiction that ships here prices compound taxes
+    // inclusively — so they are treated as simple, and the total is exact even
+    // if an individual line rounds.
+    const combined = active.reduce((sum, t) => sum + t.rate, 0);
+    const taxTotal = Math.round(
+      taxableCents - taxableCents / (1 + combined / 100),
+    );
+    const lines: ComputedTax[] = [];
+    let assigned = 0;
+    active.forEach((t, index) => {
+      const amount =
+        index === active.length - 1
+          ? // The last line absorbs the rounding so the parts always sum to the
+            // whole. A receipt whose tax lines do not add up to its tax total is
+            // a receipt somebody will query.
+            taxTotal - assigned
+          : Math.round((taxTotal * t.rate) / combined);
+      assigned += amount;
+      lines.push({
+        name: t.name,
+        rate: t.rate,
+        registrationNumber: t.registrationNumber,
+        amountCents: amount,
+      });
+    });
+    return { lines, totalCents: taxTotal };
+  }
+
+  const lines: ComputedTax[] = [];
+  let running = taxableCents;
+  let total = 0;
+  for (const t of active) {
+    // A compound tax is charged on the subtotal plus everything already added;
+    // a simple one always on the subtotal alone.
+    const base = t.isCompound ? running : taxableCents;
+    const amount = Math.round((base * t.rate) / 100);
+    running += amount;
+    total += amount;
+    lines.push({
+      name: t.name,
+      rate: t.rate,
+      registrationNumber: t.registrationNumber,
+      amountCents: amount,
+    });
+  }
+  return { lines, totalCents: total };
+}


### PR DESCRIPTION
Three faults, found by printing one on a real terminal.

## 1. The print endpoint was wrong, and failed silently

```
[clover-print] print -> 404 {"message":"Invalid URI"}
```

The guide prose says *"the `/v1/device/print` endpoints require the printer's identifier"*, and I built from that sentence. The **reference** gives the literal path: **`/v1/device/print/text`**.

So the itemised receipt has never printed. The failure is invisible from outside — the payment succeeds, the response says `receiptPrinted: false`, and the 404 appears only in the server log. It cost a live terminal test to find.

## 2. Every printed document was headed with the fixture

Five screens print something a customer keeps — payment receipt, bulk payment receipt, refund slip, retail receipt, customer invoice — and **all five** did:

```ts
const defaultFacility = facilities.find((f) => f.id === 11);
```

That is *"Example Pet Care Facility, 123 Example St, Example City"*, carrying **the fixture's GST and QST registration numbers**. A customer of Pawradise holding one was reading another business's tax numbers — worse than a cosmetic bug.

`useFacilityProfile()` has returned the facility's own row since `20260809120000`. `useReceiptFacility()` is the adapter nobody wrote.

## 3. Tax settings saved nothing

```ts
(defaultFacility as Record<string, unknown>).taxConfig = { ... };
toast.success("Tax settings saved");
```

It mutated the **shared fixture** and announced success: one object for every facility on the platform, discarded on reload, never sent anywhere. A facility could enter its GST and QST registration numbers, be told they were saved, and find them on no document ever.

It is now the `tax_config` setting domain — awaited, with a refusal reported.

**The fallback is NO TAX**, not the fixture's Quebec GST + QST. A default that changes what a customer is charged is not a default, it is a decision made on a facility's behalf about their tax liability — and carrying the fixture over would have added 14.975% to receipts in Ontario, in Alberta, in the United States.

## What a receipt says now

```
+--------------------------------+
|           Pawradise            |
|3824 Saint Patrick St, Montreal,|
|           QC H4E 1A4           |
|          514 690 8911          |
|      hello@pawradise.com       |
|  GST: RT 123456789 · QST: QT   |
|           987654321            |
|                                |
|Booking #897                    |
|Clover Test Customer            |
|Pet: Buddy                      |
|19 Aug 2026, 8:00 a.m. - 6:00   |
|p.m.                            |
|19 Aug 2026, 11:51 a.m.         |
|--------------------------------|
|Full groom                $62.50|
|Nail trim add-on          $15.00|
|Bag of food x2            $24.00|
|Late pickup (73 min)      $10.00|
|Discount                  -$5.00|
|--------------------------------|
|Subtotal                 $106.50|
|GST 5%                     $5.33|
|QST 9.975%                $10.62|
|Tip                       $15.00|
|TOTAL                    $137.45|
|--------------------------------|
|Paid by card             $137.45|
|VISA ••5556                     |
|Entry: Contactless              |
|Auth: OK0561                    |
|Ref: WJ7SFEVER5RR8              |
+--------------------------------+
```

`entry_method` and `auth_code` were **already stored** on the payments row — one join from being printed, and the two fields a card-brand-compliant receipt is expected to carry.

One `ReceiptInput` renders to the roll, to an inbox and to a phone, so the copy a customer keeps and the copy they are emailed cannot disagree.

The in-app printed receipt showed "Amount" and "Total Charged" and nothing else — a total with no evidence behind it. It now takes the same lines, plus the booking reference and the service window.

## Verification

`typecheck`, `eslint` (clean on changed files), `format`, `check:success-claims`, `check:settings-fixture`, `check:settings-wiring` green. Thermal layout rendered and inspected at 32 columns (above). Hardware confirmation after deploy.