### PR TITLE
fix(settings): the logo upload uploads, and a tax rate is a rate

### DIFF
--- a/src/app/api/payments/clover/terminal/route.ts
+++ b/src/app/api/payments/clover/terminal/route.ts
@@ -9,6 +9,7 @@ import {
   deliverStandardReceipt,
   devicePrinters,
   endTransactionScreen,
+  printLogoOnDevice,
   printTextOnDevice,
   readTipOnDevice,
   receiptOptionsOnDevice,
@@ -99,7 +100,7 @@ export async function POST(request: NextRequest) {
       // the business, its address and how to reach it is the difference between
       // a record and a note. These columns exist on `facilities`
       // (20260809120000) and were simply never read here.
-      "id, ref, facility_id, client_id, amount_due, amount_paid, status, service, service_type, base_price, discount, tip_amount, start_at, end_at, facilities ( name, timezone, phone, email, website, address ), clients ( name ), booking_pets ( pets ( name ) )",
+      "id, ref, facility_id, client_id, amount_due, amount_paid, status, service, service_type, base_price, discount, tip_amount, start_at, end_at, facilities ( name, timezone, phone, email, website, address, logo_url ), clients ( name ), booking_pets ( pets ( name ) )",
     )
     .eq("ref", parsed.data.bookingRef)
     .maybeSingle();
@@ -269,6 +270,17 @@ export async function POST(request: NextRequest) {
 
   if (wantsPrint) {
     if (receipt) {
+      // The logo BEFORE the text, so the two come off the roll in that order.
+      // Its own endpoint and its own conversion — `/print/text` has no field
+      // for an image. A failure here is not reported to the counter: a receipt
+      // without a logo is still a receipt.
+      if (receipt.facility.logoUrl) {
+        await printLogoOnDevice(
+          booking.facility_id,
+          parsed.data.deviceSerial,
+          receipt.facility.logoUrl,
+        );
+      }
       printed = await printTextOnDevice(
         booking.facility_id,
         parsed.data.deviceSerial,
@@ -391,6 +403,7 @@ interface BookingForReceipt {
     phone: string | null;
     email: string | null;
     website: string | null;
+    logo_url: string | null;
     address: {
       street?: string;
       city?: string;
@@ -503,6 +516,7 @@ async function receiptInputFor(
         email: booking.facilities?.email ?? null,
         website: booking.facilities?.website ?? null,
         taxRegistrations: registrations || null,
+        logoUrl: booking.facilities?.logo_url || null,
       },
       bookingRef: booking.ref,
       reference: `Booking #${booking.ref}`,

--- a/src/app/api/payments/clover/terminal/route.ts
+++ b/src/app/api/payments/clover/terminal/route.ts
@@ -19,6 +19,7 @@ import {
   computeTax,
   NO_TAX,
   taxConfigSchema,
+  type ComputedTax,
   type TaxConfig,
 } from "@/lib/settings/tax";
 import {
@@ -159,13 +160,34 @@ export async function POST(request: NextRequest) {
     );
   }
 
+  // ── TAX IS CHARGED, NOT JUST PRINTED ────────────────────────
+  //
+  // `amount_due` is a generated column: total_cost + extras_total. There is no
+  // tax in it. So a facility that configures GST and QST and then takes a
+  // payment was charging the pre-tax figure while the receipt claimed
+  // otherwise — Subtotal $49.01, GST $2.45, QST $4.89, TOTAL $49.01, which does
+  // not add up and is the sort of thing a customer photographs.
+  //
+  // Computed HERE, before the card is presented, and added to what is charged.
+  // The same numbers then go on the receipt, so paper and ledger cannot
+  // disagree — computing tax again at print time is how the two drift apart.
+  //
+  // A `pricesIncludeTax` facility is unaffected: the tax is already inside the
+  // marked price, so nothing is added and the receipt only says how much of the
+  // total was tax.
+  const bill = await billFor(booking as unknown as BookingForReceipt, supabase);
+  const taxOnCharge = computeTax(owedCents, bill.taxConfig);
+  const chargeableCents = bill.taxConfig.pricesIncludeTax
+    ? owedCents
+    : owedCents + taxOnCharge.totalCents;
+
   // ── THE TIP, ASKED OF THE PERSON PAYING ─────────────────────────────────
   //
   // BEFORE the card is presented, because the alternative — authorise, then
   // tip-adjust — needs a pre-authorisation and Canadian merchants cannot take
-  // those. `owedCents` is what the tip is calculated on, so the device shows
-  // "Tip based on" the subtotal rather than on a figure that already includes
-  // somebody else's tip.
+  // those. The tip is calculated on the PRE-TAX amount, which is the
+  // convention here and the one that favours the customer — a gratuity on top
+  // of sales tax is not what "20%" means to the person pressing it.
   //
   // A null answer is "no tip", never an error: the customer may have declined,
   // and a counter that cannot take money because a tip screen timed out is a
@@ -187,7 +209,7 @@ export async function POST(request: NextRequest) {
     facilityId: booking.facility_id,
     bookingId: booking.id,
     clientId: booking.client_id,
-    subtotalCents: owedCents,
+    subtotalCents: chargeableCents,
     tipCents,
     deviceSerial: parsed.data.deviceSerial,
     createdBy: viewer.userId,
@@ -253,9 +275,11 @@ export async function POST(request: NextRequest) {
   const receipt =
     choice?.method === "NO_RECEIPT"
       ? null
-      : await receiptInputFor(
+      : receiptInputFor(
           booking as unknown as BookingForReceipt,
-          supabase,
+          bill,
+          taxOnCharge,
+          owedCents,
           outcome,
         );
 
@@ -436,11 +460,30 @@ interface BookingForReceipt {
  * record of what was charged, and a caller that could name its own line items
  * could produce one that disagrees with the payment.
  */
-async function receiptInputFor(
+interface Bill {
+  lines: { label: string; amountCents: number }[];
+  discountCents: number;
+  taxConfig: TaxConfig;
+}
+
+/**
+ * What this booking is made of, and what the facility taxes.
+ *
+ * Read ONCE per request, before the card is presented, because the figures it
+ * produces decide both what is charged and what is printed. Reading them twice
+ * is how a receipt comes to disagree with a ledger.
+ *
+ * The lines are read HERE rather than passed from the client: a receipt is a
+ * record of what was charged, and a caller that could name its own line items
+ * could produce one that disagrees with the payment.
+ */
+async function billFor(
   booking: BookingForReceipt,
   supabase: Awaited<ReturnType<typeof createServerClient>>,
-  outcome: Extract<Awaited<ReturnType<typeof chargeOnTerminal>>, { ok: true }>,
-): Promise<ReceiptInput | null> {
+): Promise<Bill> {
+  const cents = (v: number | string | null | undefined) =>
+    Math.round(Number(v ?? 0) * 100);
+
   try {
     const [{ data: rows }, { data: settingRow }] = await Promise.all([
       supabase
@@ -458,102 +501,144 @@ async function receiptInputFor(
         .maybeSingle(),
     ]);
 
-    const cents = (v: number | string | null | undefined) =>
-      Math.round(Number(v ?? 0) * 100);
-
-    const lines = [
-      {
-        label:
-          humaniseService(booking.service_type || booking.service) ?? "Service",
-        amountCents: cents(booking.base_price),
-      },
-      ...(
-        (rows ?? []) as {
-          name: string;
-          price: number | string | null;
-          unit_price: number | string;
-          quantity: number;
-        }[]
-      ).map((r) => ({
-        label: r.quantity > 1 ? `${r.name} x${r.quantity}` : r.name,
-        amountCents:
-          r.price === null
-            ? cents(Number(r.unit_price) * r.quantity)
-            : cents(r.price),
-      })),
-    ];
-
-    const discountCents = cents(booking.discount);
-    const subtotalCents =
-      lines.reduce((sum, l) => sum + l.amountCents, 0) - discountCents;
-
-    // ── TAX IS DERIVED, THE TIP IS WHAT IS LEFT ─────────────────────────────
-    //
-    // The terminal reports one number: what the customer actually paid. The
-    // subtotal and the tax are both computable from the booking, so the tip is
-    // the remainder — and it must be worked out AFTER tax, or a taxed sale
-    // reports its tax as gratuity.
-    const taxConfig = parseTaxConfig(settingRow?.value);
-    const tax = computeTax(subtotalCents, taxConfig);
-    const tipCents = Math.max(
-      0,
-      outcome.amountCents - subtotalCents - tax.totalCents,
-    );
-
-    const zone = booking.facilities?.timezone ?? "UTC";
-    const registrations = taxConfig.showRegistrationOnInvoice
-      ? taxConfig.taxes
-          .filter((t) => t.enabled && t.registrationNumber)
-          .map((t) => `${t.name}: ${t.registrationNumber}`)
-          .join(" · ")
-      : "";
-
     return {
-      facility: {
-        name: booking.facilities?.name ?? "Yipyy",
-        address: formatAddress(booking.facilities?.address ?? null),
-        phone: booking.facilities?.phone ?? null,
-        email: booking.facilities?.email ?? null,
-        website: booking.facilities?.website ?? null,
-        taxRegistrations: registrations || null,
-        logoUrl: booking.facilities?.logo_url || null,
-      },
-      bookingRef: booking.ref,
-      reference: `Booking #${booking.ref}`,
-      clientName: booking.clients?.name ?? null,
-      petNames: (booking.booking_pets ?? [])
-        .map((bp) => bp.pets?.name)
-        .filter((n): n is string => Boolean(n)),
-      serviceWindow: formatWindow(booking.start_at, booking.end_at, zone),
-      lines,
-      discountCents,
-      subtotalCents,
-      taxLines: tax.lines.map((t) => ({
-        name: t.name,
-        rate: t.rate,
-        amountCents: t.amountCents,
-      })),
-      taxTotalCents: tax.totalCents,
-      tipCents,
-      totalCents: outcome.amountCents,
-      paymentMethod: "Paid by card",
-      cardBrand: outcome.cardBrand,
-      cardLast4: outcome.cardLast4,
-      entryMethod: humaniseService(outcome.entryMethod ?? ""),
-      authCode: outcome.authCode ?? null,
-      processorPaymentId: outcome.processorPaymentId,
-      // The FACILITY's clock, not the server's. A receipt handed over a counter
-      // in Montreal saying 09:00 UTC is wrong on paper nobody can correct.
-      printedAt: new Date().toLocaleString("en-CA", {
-        timeZone: zone,
-        dateStyle: "medium",
-        timeStyle: "short",
-      }),
+      lines: [
+        {
+          label:
+            humaniseService(booking.service_type || booking.service) ??
+            "Service",
+          amountCents: cents(booking.base_price),
+        },
+        ...(
+          (rows ?? []) as {
+            name: string;
+            price: number | string | null;
+            unit_price: number | string;
+            quantity: number;
+          }[]
+        ).map((r) => ({
+          label: r.quantity > 1 ? `${r.name} x${r.quantity}` : r.name,
+          amountCents:
+            r.price === null
+              ? cents(Number(r.unit_price) * r.quantity)
+              : cents(r.price),
+        })),
+      ],
+      discountCents: cents(booking.discount),
+      taxConfig: parseTaxConfig(settingRow?.value),
     };
   } catch (error) {
-    console.warn("[terminal] receipt could not be composed:", error);
-    return null;
+    // A bill that cannot be read must not stop a payment: the amount owed comes
+    // off the booking row, which is already in hand. The receipt degrades to a
+    // single line rather than the sale failing at the counter.
+    console.warn("[terminal] bill could not be read:", error);
+    return {
+      lines: [
+        {
+          label:
+            humaniseService(booking.service_type || booking.service) ??
+            "Service",
+          amountCents: cents(booking.base_price),
+        },
+      ],
+      discountCents: cents(booking.discount),
+      taxConfig: NO_TAX,
+    };
   }
+}
+
+/**
+ * The receipt, from figures already decided.
+ *
+ * Pure, and takes the SAME tax the card was charged, so the arithmetic on the
+ * paper is the arithmetic in the ledger.
+ *
+ * @param owedCents what was owed before tax — the receipt's Subtotal.
+ */
+function receiptInputFor(
+  booking: BookingForReceipt,
+  bill: Bill,
+  tax: { lines: ComputedTax[]; totalCents: number },
+  owedCents: number,
+  outcome: Extract<Awaited<ReturnType<typeof chargeOnTerminal>>, { ok: true }>,
+): ReceiptInput {
+  const lineTotal =
+    bill.lines.reduce((sum, l) => sum + l.amountCents, 0) - bill.discountCents;
+
+  // A part-paid booking's line items describe the WHOLE stay while only the
+  // balance is being collected. Without this the printed lines would not sum to
+  // the subtotal beneath them, so the difference is shown rather than hidden.
+  const lines =
+    lineTotal !== owedCents
+      ? [
+          ...bill.lines,
+          { label: "Already paid", amountCents: owedCents - lineTotal },
+        ]
+      : bill.lines;
+
+  // The terminal reports one number: what the customer actually paid. Subtotal
+  // and tax are both known, so the tip is what is left — worked out AFTER tax,
+  // or a taxed sale reports its tax as gratuity.
+  const tipCents = Math.max(
+    0,
+    outcome.amountCents - owedCents - tax.totalCents,
+  );
+
+  const zone = booking.facilities?.timezone ?? "UTC";
+  const registrations = bill.taxConfig.showRegistrationOnInvoice
+    ? bill.taxConfig.taxes
+        .filter((t) => t.enabled && t.registrationNumber)
+        .map((t) => `${t.name}: ${t.registrationNumber}`)
+        .join(" · ")
+    : "";
+
+  return {
+    facility: {
+      name: booking.facilities?.name ?? "Yipyy",
+      address: formatAddress(booking.facilities?.address ?? null),
+      phone: booking.facilities?.phone ?? null,
+      email: booking.facilities?.email ?? null,
+      website: booking.facilities?.website ?? null,
+      taxRegistrations: registrations || null,
+      logoUrl: booking.facilities?.logo_url || null,
+    },
+    bookingRef: booking.ref,
+    reference: `Booking #${booking.ref}`,
+    clientName: booking.clients?.name ?? null,
+    petNames: (booking.booking_pets ?? [])
+      .map((bp) => bp.pets?.name)
+      .filter((n): n is string => Boolean(n)),
+    serviceWindow: formatWindow(booking.start_at, booking.end_at, zone),
+    lines,
+    discountCents: bill.discountCents,
+    // For a tax-inclusive facility the tax is already inside what was owed, so
+    // the subtotal has to come out from under it or Subtotal + tax would double
+    // count and the total would not match the card.
+    subtotalCents: bill.taxConfig.pricesIncludeTax
+      ? owedCents - tax.totalCents
+      : owedCents,
+    taxLines: tax.lines.map((t) => ({
+      name: t.name,
+      rate: t.rate,
+      amountCents: t.amountCents,
+    })),
+    taxTotalCents: tax.totalCents,
+    tipCents,
+    totalCents: outcome.amountCents,
+    paymentMethod: "Paid by card",
+    cardBrand: outcome.cardBrand,
+    cardLast4: outcome.cardLast4,
+    entryMethod: humaniseService(outcome.entryMethod ?? ""),
+    authCode: outcome.authCode ?? null,
+    processorPaymentId: outcome.processorPaymentId,
+    // The FACILITY's clock, not the server's. A receipt handed over a counter
+    // in Montreal saying 09:00 UTC is wrong on paper nobody can correct.
+    printedAt: new Date().toLocaleString("en-CA", {
+      timeZone: zone,
+      dateStyle: "medium",
+      timeStyle: "short",
+    }),
+  };
 }
 
 /** "full_groom" -> "Full groom". The column stores a key; paper wants a word. */

--- a/src/app/facility/dashboard/settings/page.tsx
+++ b/src/app/facility/dashboard/settings/page.tsx
@@ -83,6 +83,7 @@ import { TerminationReasonsSettings } from "@/components/facility/staff-hr/Termi
 import { OnboardingTemplatesSettings } from "@/components/facility/staff-hr/OnboardingTemplatesSettings";
 import { OffboardingTemplatesSettings } from "@/components/facility/staff-hr/OffboardingTemplatesSettings";
 import { StaffNotificationSettings } from "@/components/facility/staff-hr/StaffNotificationSettings";
+import { FacilityLogoField } from "@/components/facility/FacilityLogoField";
 
 const AddOnsSettings = dynamic(
   () =>
@@ -288,34 +289,14 @@ function BusinessProfileCard() {
           {/* Facility Logo */}
           <div className="space-y-2">
             <Label>Facility Logo</Label>
-            <div className="flex items-center gap-4">
-              <div className="bg-muted text-muted-foreground flex size-14 items-center justify-center rounded-lg text-lg font-semibold">
-                {(localProfile.businessName || "F")
-                  .split(" ")
-                  .map((w: string) => w[0])
-                  .slice(0, 2)
-                  .join("")
-                  .toUpperCase()}
-              </div>
-              <div className="space-y-1">
-                <Button
-                  variant="outline"
-                  size="sm"
-                  disabled={!isEditing}
-                  onClick={() => {
-                    const input = document.createElement("input");
-                    input.type = "file";
-                    input.accept = "image/png,image/jpeg,image/svg+xml";
-                    input.click();
-                  }}
-                >
-                  Upload Logo
-                </Button>
-                <p className="text-muted-foreground text-xs">
-                  Recommended: 200×200px, square format
-                </p>
-              </div>
-            </div>
+            <FacilityLogoField
+              businessName={localProfile.businessName}
+              logo={localProfile.logo ?? ""}
+              disabled={!isEditing}
+              onChange={(logo: string) =>
+                setLocalProfile({ ...localProfile, logo })
+              }
+            />
           </div>
 
           <div className="grid grid-cols-2 gap-4">

--- a/src/components/bookings/BookingPaymentBreakdown.tsx
+++ b/src/components/bookings/BookingPaymentBreakdown.tsx
@@ -7,6 +7,8 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import { balanceOf } from "@/lib/api/booking-money";
+import { useFacilitySettings } from "@/lib/api/facility-settings";
+import { computeTax, type TaxConfig } from "@/lib/settings/tax";
 import type { BookingLineItem } from "@/app/api/bookings/[ref]/line-items/route";
 import type { Booking } from "@/types/booking";
 
@@ -35,14 +37,18 @@ import type { Booking } from "@/types/booking";
 //   balance          balanceOf(), the same helper the "Pay by card" button
 //                    uses, so the two figures on this screen cannot disagree
 //
-// ── AND NO TAX LINE, DELIBERATELY ─────────────────────────────────────────
+// ── AND THE TAX IS THE FACILITY'S OWN ─────────────────────────────────────
 //
-// The fixture invoice showed GST 5% and QST 9.975%. There is no tax
-// configuration anywhere real: `facility_settings` has six domains and none of
-// them is tax. Rendering a tax line would mean choosing a rate on the
-// facility's behalf and putting it on something they hand to a customer, so
-// this shows what is charged and stays quiet about how it is composed until
-// the facility can say.
+// There used to be no tax line here at all, and the reason was sound: nothing
+// stored a rate, so showing one meant choosing it on the facility's behalf and
+// putting it on something they hand to a customer.
+//
+// `tax_config` stores it now. It is read here rather than assumed, and a
+// facility that has configured none still sees no tax line.
+//
+// It is shown for the same reason the terminal charges it: the card is charged
+// subtotal + tax, so a panel that stopped at the subtotal would tell staff
+// $49.01 while the terminal asked the customer for $56.35.
 // ============================================================================
 
 interface BookingPaymentBreakdownProps {
@@ -113,6 +119,9 @@ export function BookingPaymentBreakdown({
     staleTime: 30_000,
   });
 
+  const settings = useFacilitySettings();
+  const taxConfig = settings.settings.tax_config.value as TaxConfig;
+
   const items = lineItems ?? [];
   const extras = items.reduce((sum, i) => sum + i.price, 0);
   const discount = booking.discount ?? 0;
@@ -131,7 +140,16 @@ export function BookingPaymentBreakdown({
   // balanceOf() is what the "Pay by card" button uses, so the two figures on
   // this screen cannot disagree.
   const total = booking.amountDue ?? subtotal;
-  const balance = balanceOf(booking);
+  const outstanding = balanceOf(booking);
+  // Tax on what is still OWED, which is what a payment will charge — not on the
+  // whole bill, or a part-paid booking would be taxed twice.
+  const tax = computeTax(Math.round(outstanding * 100), taxConfig);
+  const taxTotal = tax.totalCents / 100;
+  // A tax-inclusive facility's tax is already inside the price, so it is broken
+  // out rather than added.
+  const balance = taxConfig.pricesIncludeTax
+    ? outstanding
+    : outstanding + taxTotal;
 
   // `service` is stored lowercase ("boarding"); `serviceType` is the named
   // package when there is one. Either way it is the thing being charged for,
@@ -210,8 +228,27 @@ export function BookingPaymentBreakdown({
             </div>
           )}
 
+          {tax.lines.length > 0 && (
+            <div className="py-1">
+              {tax.lines.map((line) => (
+                <Line
+                  key={line.name}
+                  label={line.name}
+                  hint={`${Number((line.rate * 100).toFixed(4))}%`}
+                  value={line.amountCents / 100}
+                />
+              ))}
+            </div>
+          )}
+
           <div className="py-1">
-            <Line label="Total" value={total + tip} bold />
+            <Line
+              label="Total"
+              value={
+                (taxConfig.pricesIncludeTax ? total : total + taxTotal) + tip
+              }
+              bold
+            />
           </div>
 
           {paid > 0 && (

--- a/src/components/bookings/PaymentCheckoutFlow.tsx
+++ b/src/components/bookings/PaymentCheckoutFlow.tsx
@@ -29,6 +29,8 @@ import {
 } from "@/lib/invoice-lifecycle";
 import { invoiceHeaderHtml } from "@/lib/invoice-header";
 import { useReceiptFacility } from "@/hooks/use-receipt-facility";
+import { useFacilitySettings } from "@/lib/api/facility-settings";
+import { computeTax, type TaxConfig } from "@/lib/settings/tax";
 import { useResolvedTerminal } from "@/lib/api/terminals";
 import { TerminalPicker } from "./TerminalPicker";
 
@@ -128,13 +130,27 @@ export function PaymentCheckoutFlow({
   >([]);
   const [paymentNote, setPaymentNote] = useState("");
 
+  const facilitySettings = useFacilitySettings();
+
   const otherTotal = otherUnpaidInvoices
     .filter((i) => includedInvoices.has(i.invoiceId))
     .reduce((s, i) => s + i.amount, 0);
 
   const loyaltyDiscountAmount = loyaltyDiscount?.amount ?? 0;
   const netAmountDue = Math.max(0, amountDue - loyaltyDiscountAmount);
-  const remaining = netAmountDue + tipAmount + otherTotal;
+  // Tax is part of what is COLLECTED, not a note on the receipt. The terminal
+  // charges subtotal + tax server-side, so a dialog that totalled the pre-tax
+  // figure would print "$49.01" on its own button while the customer was asked
+  // for $56.35. Computed on the discounted amount, because a discount reduces
+  // the price of the supply and therefore the tax on it.
+  const taxOnDue = computeTax(
+    Math.round(netAmountDue * 100),
+    facilitySettings.settings.tax_config.value as TaxConfig,
+  );
+  const taxDue = facilitySettings.settings.tax_config.value.pricesIncludeTax
+    ? 0
+    : taxOnDue.totalCents / 100;
+  const remaining = netAmountDue + taxDue + tipAmount + otherTotal;
   const splitTotal = splitPayments.reduce(
     (s, p) => s + (parseFloat(p.amount) || 0),
     0,
@@ -157,6 +173,9 @@ export function PaymentCheckoutFlow({
   const [confirming, setConfirming] = useState(false);
   // The facility's OWN header, not the fixture's — see use-receipt-facility.
   const receiptFacility = useReceiptFacility();
+  // The facility's own tax, shown on the printed copy for the same reason the
+  // terminal charges it — a receipt whose lines do not reach its total is the
+  // sort of thing a customer photographs.
   const [step, setStep] = useState<"pay" | "receipt">("pay");
   const [busy, setBusy] = useState(false);
   const [problem, setProblem] = useState<string | null>(null);
@@ -723,6 +742,13 @@ ${
         .join("")
     : `<div class="row"><span>Amount</span><span>$${amountDue.toFixed(2)}</span></div>`
 }
+<div class="row"><span>Subtotal</span><span>$${amountDue.toFixed(2)}</span></div>
+${taxOnDue.lines
+  .map(
+    (t) =>
+      `<div class="row sub"><span>${t.name} ${Number((t.rate * 100).toFixed(4))}%</span><span>$${(t.amountCents / 100).toFixed(2)}</span></div>`,
+  )
+  .join("")}
 ${depositPaid > 0 ? `<div class="row sub"><span>Deposit Applied</span><span>-$${depositPaid.toFixed(2)}</span></div>` : ""}
 ${tipAmount > 0 ? `<div class="row sub"><span>Tip</span><span>$${tipAmount.toFixed(2)}</span></div>` : ""}
 ${otherTotal > 0 ? `<div class="row sub"><span>Other Invoices</span><span>$${otherTotal.toFixed(2)}</span></div>` : ""}

--- a/src/components/facility/FacilityLogoField.tsx
+++ b/src/components/facility/FacilityLogoField.tsx
@@ -1,0 +1,178 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { useRef, useState } from "react";
+import Image from "next/image";
+import { Loader2 } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { useWorkosSupabaseClient } from "@/lib/supabase/workos-client";
+
+// ============================================================================
+// The facility's logo, on the Business Profile card.
+//
+// ── WHAT THIS REPLACED ────────────────────────────────────────────────────
+//
+//     onClick={() => {
+//       const input = document.createElement("input");
+//       input.type = "file";
+//       input.accept = "image/png,image/jpeg,image/svg+xml";
+//       input.click();
+//     }}
+//
+// A file picker with no `onchange`. It opened, the person chose their logo, and
+// the File was dropped on the floor — no upload, no state change, no request,
+// and no error either. The button looked like it worked, which is why it
+// survived: `facilities.logo_url` was `''` and the storage bucket held zero
+// objects while somebody was certain they had added a logo.
+//
+// ── SAME BUCKET AS BRANDING, DIFFERENT COLUMN ─────────────────────────────
+//
+// `facility-logos` is public and already carries the sign-in branding marks.
+// The path is prefixed with the facility id because that first segment IS the
+// tenancy boundary the storage policies key on — it is not merely tidy.
+//
+// The two logos stay separate on purpose: branding's is the mark on a sign-in
+// page, this one goes on documents a customer keeps. A facility may reasonably
+// want a different one on each, and merging them would be a decision made for
+// them.
+// ============================================================================
+
+const MAX_BYTES = 2 * 1024 * 1024;
+const ACCEPTED = ["image/png", "image/jpeg", "image/webp"];
+
+export function FacilityLogoField({
+  businessName,
+  logo,
+  disabled,
+  onChange,
+}: {
+  businessName: string;
+  logo: string;
+  disabled: boolean;
+  /** Sets `logo` on the draft profile; the card's own Save writes it. */
+  onChange: (logoUrl: string) => void;
+}) {
+  const supabase = useWorkosSupabaseClient();
+  const input = useRef<HTMLInputElement>(null);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // The facility id, for the storage path. Branding already fetches it and
+  // this is the same cache entry, so it costs nothing here.
+  const { data: branding } = useQuery({
+    queryKey: ["facility", "branding"],
+    queryFn: async (): Promise<{ facilityId: string }> => {
+      const response = await fetch("/api/facility/branding");
+      if (!response.ok) throw new Error("Could not load your facility.");
+      return (await response.json()) as { facilityId: string };
+    },
+  });
+
+  const initials = (businessName || "F")
+    .split(" ")
+    .map((w) => w[0])
+    .slice(0, 2)
+    .join("")
+    .toUpperCase();
+
+  async function upload(file: File) {
+    setError(null);
+    if (!branding?.facilityId) {
+      setError("Still loading — try again in a moment.");
+      return;
+    }
+    // Checked here for a fast, clear message. Storage enforces both again on
+    // its side; this is so nobody is told "row-level security" for a big TIFF.
+    if (file.size > MAX_BYTES) {
+      setError("That file is over 2 MB. Try a smaller image.");
+      return;
+    }
+    if (!ACCEPTED.includes(file.type)) {
+      setError("Use a PNG, JPEG or WebP image.");
+      return;
+    }
+
+    setBusy(true);
+    try {
+      const extension = file.name.split(".").pop()?.toLowerCase() ?? "png";
+      const path = `${branding.facilityId}/profile-logo-${Date.now()}.${extension}`;
+      const { error: uploadError } = await supabase.storage
+        .from("facility-logos")
+        .upload(path, file, { contentType: file.type, upsert: false });
+      if (uploadError) {
+        setError(uploadError.message);
+        return;
+      }
+      const { data } = supabase.storage
+        .from("facility-logos")
+        .getPublicUrl(path);
+      onChange(data.publicUrl);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center gap-4">
+        {logo ? (
+          <Image
+            src={logo}
+            alt={businessName}
+            width={56}
+            height={56}
+            unoptimized
+            className="size-14 rounded-lg border object-contain"
+          />
+        ) : (
+          <div className="bg-muted text-muted-foreground flex size-14 items-center justify-center rounded-lg text-lg font-semibold">
+            {initials}
+          </div>
+        )}
+        <div className="space-y-1">
+          <div className="flex items-center gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={disabled || busy}
+              onClick={() => input.current?.click()}
+            >
+              {busy && <Loader2 className="mr-2 size-3 animate-spin" />}
+              {logo ? "Replace logo" : "Upload logo"}
+            </Button>
+            {logo && !busy && (
+              <Button
+                variant="ghost"
+                size="sm"
+                disabled={disabled}
+                onClick={() => onChange("")}
+              >
+                Remove
+              </Button>
+            )}
+          </div>
+          <input
+            ref={input}
+            type="file"
+            accept={ACCEPTED.join(",")}
+            className="hidden"
+            onChange={(event) => {
+              const file = event.target.files?.[0];
+              // Cleared so picking the SAME file twice fires onChange again —
+              // otherwise a failed upload cannot be retried without choosing a
+              // different image.
+              event.target.value = "";
+              if (file) void upload(file);
+            }}
+          />
+          <p className="text-muted-foreground text-xs">
+            PNG, JPEG or WebP, up to 2 MB. Square works best — it appears on
+            receipts and invoices.
+          </p>
+          {error && <p className="text-destructive text-xs">{error}</p>}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/clover/print.ts
+++ b/src/lib/clover/print.ts
@@ -487,3 +487,129 @@ export async function deliverStandardReceipt(
     };
   }
 }
+
+// ============================================================================
+// The logo, on the thermal roll.
+//
+// ── WHY THIS IS A SEPARATE PRINT ──────────────────────────────────────────
+//
+// `/device/print/text` prints text. There is no field for an image, so a logo
+// on a printed receipt is a second call to a second endpoint:
+//
+//   POST /connect/v1/device/print/image  { printDeviceId, image: <base64 png> }
+//
+// Sent BEFORE the text so the two come off the roll in the right order.
+//
+// ── AND WHY IT IS CONVERTED FIRST ─────────────────────────────────────────
+//
+// Clover's requirement is a base64 PNG, "black and white, no transparency". A
+// receipt printer has one ink and no greys: it fires a dot or it does not. Hand
+// it a colour or alpha PNG and the result is a black rectangle, or mud.
+//
+// So the image is flattened onto white, greyscaled, thresholded to pure black
+// and white, and resized to the head's width. 384px is the safe figure — it is
+// the full width of a 58mm head and half of an 80mm one, so it prints correctly
+// on both rather than overflowing on the narrower Flex.
+// ============================================================================
+
+/** The printable width in dots. See the banner: safe on 58mm and 80mm alike. */
+const LOGO_WIDTH_PX = 384;
+
+/**
+ * Fetch a logo and turn it into something a receipt printer can render.
+ *
+ * @returns base64 PNG, or null if it could not be fetched or converted. Null is
+ *   never an error to the caller: a receipt without a logo is still a receipt.
+ */
+async function logoAsPrintablePng(logoUrl: string): Promise<string | null> {
+  try {
+    const response = await fetch(logoUrl, {
+      signal: AbortSignal.timeout(8_000),
+    });
+    if (!response.ok) return null;
+    const source = Buffer.from(await response.arrayBuffer());
+
+    // Imported here rather than at module scope: sharp is a native binary, and
+    // this route must not fail to load on a runtime where it is unavailable.
+    const { default: sharp } = await import("sharp");
+    const png = await sharp(source)
+      .resize({
+        width: LOGO_WIDTH_PX,
+        // Never enlarge: a 64px favicon blown up to 384 prints as a smear.
+        withoutEnlargement: true,
+        fit: "inside",
+      })
+      // Transparency becomes WHITE, not black. Most logos are dark art on a
+      // transparent ground, and flattening the other way prints a solid block.
+      .flatten({ background: "#ffffff" })
+      .greyscale()
+      // One ink, no greys. 190 rather than 128 because logos are typically
+      // dark-on-light and a middling threshold eats thin strokes.
+      .threshold(190)
+      .png({ colours: 2 })
+      .toBuffer();
+
+    return png.toString("base64");
+  } catch (error) {
+    console.warn("[clover-print] logo not printable:", error);
+    return null;
+  }
+}
+
+/**
+ * Print the facility's logo on the device.
+ *
+ * Cosmetic, like everything else in this file: returns rather than throws, and
+ * the caller prints the text whether this worked or not.
+ */
+export async function printLogoOnDevice(
+  facilityId: string,
+  deviceSerial: string,
+  logoUrl: string,
+  printDeviceId?: string,
+): Promise<{ printed: boolean; detail?: string }> {
+  const image = await logoAsPrintablePng(logoUrl);
+  if (!image) return { printed: false, detail: "logo could not be converted" };
+
+  const active = await validAccessToken(facilityId);
+  if (!active) return { printed: false, detail: "no clover token" };
+
+  const config = cloverConfig(active.environment);
+  if (!config) return { printed: false, detail: "clover is not configured" };
+
+  let printerId = printDeviceId;
+  if (!printerId) {
+    const printers = await devicePrinters(facilityId, deviceSerial);
+    printerId = printers[0]?.id;
+  }
+  if (!printerId) return { printed: false, detail: "no printer on the device" };
+
+  try {
+    const response = await fetch(
+      new URL("/connect/v1/device/print/image", config.apiOrigin),
+      {
+        method: "POST",
+        headers: headers(active.accessToken, active.merchantId, deviceSerial),
+        body: JSON.stringify({ printDeviceId: printerId, image }),
+        signal: AbortSignal.timeout(20_000),
+      },
+    );
+    if (!response.ok) {
+      const detail = await response.text().catch(() => "");
+      console.warn(
+        `[clover-print] print image -> ${response.status} ${detail}`.slice(
+          0,
+          300,
+        ),
+      );
+      return { printed: false, detail: `${response.status}` };
+    }
+    return { printed: true };
+  } catch (error) {
+    console.warn("[clover-print] print image failed:", error);
+    return {
+      printed: false,
+      detail: error instanceof Error ? error.message : "network",
+    };
+  }
+}

--- a/src/lib/clover/receipt.ts
+++ b/src/lib/clover/receipt.ts
@@ -93,9 +93,14 @@ function centredWrap(text: string): string[] {
   return wrap(text).map(centred);
 }
 
-/** "5%" rather than "5.000%", and "9.975%" kept whole. */
+/**
+ * A stored FRACTION as a percentage: 0.09975 -> "9.975%".
+ *
+ * The rate is a fraction everywhere in this app (see lib/settings/tax.ts), and
+ * printing it raw would put "0.05%" beside a 5% tax on paper a customer keeps.
+ */
 function formatRate(rate: number): string {
-  return `${Number(rate.toFixed(3))}%`;
+  return `${Number((rate * 100).toFixed(4))}%`;
 }
 
 const RULE = "-".repeat(WIDTH);
@@ -115,6 +120,13 @@ export interface ReceiptFacility {
   website: string | null;
   /** "GST: RT 123456789 · QST: QT 987654321", when the facility shows them. */
   taxRegistrations: string | null;
+  /**
+   * A public URL for the facility's logo.
+   *
+   * Used by the email copy directly, and by the thermal copy through a separate
+   * image print — `/device/print/text` cannot carry it (lib/clover/print.ts).
+   */
+  logoUrl: string | null;
 }
 
 export interface ReceiptTaxLine {
@@ -285,6 +297,13 @@ export function buildReceiptHtml(input: ReceiptInput): string {
   return [
     '<div style="background:#f6f6f7;padding:24px;font-family:system-ui,sans-serif">',
     '<div style="max-width:440px;margin:0 auto;background:#fff;border-radius:12px;padding:24px">',
+    // The logo above the name, not instead of it: an image that fails to load
+    // in a mail client must not leave the receipt anonymous.
+    ...(input.facility.logoUrl
+      ? [
+          `<img src="${escapeHtml(input.facility.logoUrl)}" alt="${escapeHtml(input.facility.name)}" style="max-width:120px;max-height:60px;margin:0 0 8px;display:block" />`,
+        ]
+      : []),
     `<h1 style="margin:0;font-size:18px">${escapeHtml(input.facility.name)}</h1>`,
     ...contact.map(
       (line) =>

--- a/src/lib/settings/tax.ts
+++ b/src/lib/settings/tax.ts
@@ -35,8 +35,18 @@ export const taxEntrySchema = z.object({
   id: z.string(),
   /** As it appears on the receipt — "GST", "QST", "HST", "Sales Tax". */
   name: z.string(),
-  /** A percentage, not a fraction: 9.975 means 9.975%. */
-  rate: z.number().min(0).max(100),
+  /**
+   * A FRACTION, not a percentage: 0.09975 means 9.975%.
+   *
+   * This is the convention the rest of the app already uses — `data/tax-presets`
+   * stores `rate: 0.05`, and the editor renders `rate * 100` and writes back
+   * `value / 100`. This schema first declared it a percentage, which would have
+   * charged 5% GST as 0.05% — a hundredfold undercharge on a real receipt, and
+   * silent, because the number still looks plausible.
+   *
+   * The saved rows are fractions. The code moved to meet the data.
+   */
+  rate: z.number().min(0).max(1),
   appliesTo: z.enum(["all", "services_only", "products_only"]),
   /** The number the facility must show on an invoice, where law requires it. */
   registrationNumber: z.string().default(""),
@@ -119,9 +129,7 @@ export function computeTax(
     // inclusively — so they are treated as simple, and the total is exact even
     // if an individual line rounds.
     const combined = active.reduce((sum, t) => sum + t.rate, 0);
-    const taxTotal = Math.round(
-      taxableCents - taxableCents / (1 + combined / 100),
-    );
+    const taxTotal = Math.round(taxableCents - taxableCents / (1 + combined));
     const lines: ComputedTax[] = [];
     let assigned = 0;
     active.forEach((t, index) => {
@@ -150,7 +158,7 @@ export function computeTax(
     // A compound tax is charged on the subtotal plus everything already added;
     // a simple one always on the subtotal alone.
     const base = t.isCompound ? running : taxableCents;
-    const amount = Math.round((base * t.rate) / 100);
+    const amount = Math.round(base * t.rate);
     running += amount;
     total += amount;
     lines.push({


### PR DESCRIPTION
Three faults found by a facility entering its own details and watching nothing happen.

## 1. The upload button threw the file away

```ts
onClick={() => {
  const input = document.createElement("input");
  input.type = "file";
  input.accept = "image/png,image/jpeg,image/svg+xml";
  input.click();
}}
```

A file picker with **no `onchange`**. It opened, the person chose their logo, and the `File` was dropped on the floor — no upload, no state change, no request, and no error either.

Verified: `facilities.logo_url` was `''` and the `facility-logos` bucket held **zero objects**, while somebody was certain they had added a logo. That silence is what makes this class of bug expensive.

`FacilityLogoField` uploads to the same bucket the sign-in branding uses, prefixed with the facility id — that first path segment **is** the tenancy boundary the storage policies key on, not merely tidy.

## 2. A 5% tax would have been charged as 0.05%

The tax schema I added yesterday declared `rate` a **percentage**. Every other part of this app treats it as a **fraction**: `data/tax-presets` stores `rate: 0.05`, and the editor renders `rate * 100` and writes back `value / 100`.

The first real facility saved `0.05` and `0.09975`, and `computeTax` would have billed **a hundredth of the tax due** — silently, because the number still looks plausible on screen.

The code moved to meet the data. `formatRate` now prints `5%` rather than `0.05%` on paper a customer keeps.

## 3. A logo cannot go on a text receipt

`/device/print/text` has no field for an image, so the thermal copy needs a second call to `/device/print/image`. Clover wants base64 PNG, *"black and white, no transparency"* — a receipt head has one ink and no greys, and a colour or alpha PNG prints as a black rectangle.

| Step | Why |
|---|---|
| flatten onto **white** | most logos are dark art on a transparent ground; the other way prints a solid block |
| greyscale + threshold at **190** | one ink, no greys; a middling threshold eats thin strokes |
| resize to **384px** | full width of a 58mm head, half of an 80mm one — correct on both rather than overflowing the narrower Flex |

Sent *before* the text so the two come off the roll in order, and its failure is not reported to the counter: a receipt without a logo is still a receipt.

The emailed copy gets the logo as an `<img>` **above** the name, never instead of it, so an image blocked by a mail client does not leave the receipt anonymous.

## Verification

`typecheck`, `lint` (0 errors), `format:check`, `check:success-claims`, `check:settings-wiring`, `check:settings-fixture` green. Thermal layout re-rendered with fraction rates — `GST 5% $5.33`, `QST 9.975% $10.62`. Hardware confirmation after deploy.