### PR TITLE
fix(payments): the amounts line up, and the logo stops feeding blank paper

### DIFF
--- a/src/app/api/payments/clover/terminal/route.ts
+++ b/src/app/api/payments/clover/terminal/route.ts
@@ -9,12 +9,14 @@ import {
   deliverStandardReceipt,
   devicePrinters,
   endTransactionScreen,
-  printLogoOnDevice,
+  logoAsPrintablePng,
+  printImageOnDevice,
   printTextOnDevice,
   readTipOnDevice,
   receiptOptionsOnDevice,
 } from "@/lib/clover/print";
 import { buildReceiptLines, type ReceiptInput } from "@/lib/clover/receipt";
+import { renderReceiptPng } from "@/lib/clover/receipt-image";
 import {
   computeTax,
   NO_TAX,
@@ -294,22 +296,27 @@ export async function POST(request: NextRequest) {
 
   if (wantsPrint) {
     if (receipt) {
-      // The logo BEFORE the text, so the two come off the roll in that order.
-      // Its own endpoint and its own conversion — `/print/text` has no field
-      // for an image. A failure here is not reported to the counter: a receipt
-      // without a logo is still a receipt.
-      if (receipt.facility.logoUrl) {
-        await printLogoOnDevice(
-          booking.facility_id,
-          parsed.data.deviceSerial,
-          receipt.facility.logoUrl,
-        );
-      }
-      printed = await printTextOnDevice(
+      // ── PRINTED AS AN IMAGE, LOGO INCLUDED ────────────────────────────
+      //
+      // `/print/text` renders in a proportional font, so padding to a column
+      // width put every amount at a different place down the right-hand side
+      // (lib/clover/receipt-image.ts). One image gives a straight column, and
+      // carries the logo in the same job rather than a second call that can
+      // half-fail — which is what left 48mm of blank roll above the last one.
+      printed = await printReceiptAsImage(
         booking.facility_id,
         parsed.data.deviceSerial,
-        buildReceiptLines(receipt),
+        receipt,
       );
+      // FALLBACK. SVG text needs a font in the runtime; without one the render
+      // is valid and entirely blank. Ragged columns beat blank paper.
+      if (!printed.printed) {
+        printed = await printTextOnDevice(
+          booking.facility_id,
+          parsed.data.deviceSerial,
+          buildReceiptLines(receipt),
+        );
+      }
       itemised = printed.printed;
     }
     // AND Clover's own, which is the card-brand-compliant one. The docs put
@@ -711,4 +718,46 @@ function formatWindow(
 function parseTaxConfig(value: unknown): TaxConfig {
   const parsed = taxConfigSchema.safeParse(value);
   return parsed.success ? parsed.data : NO_TAX;
+}
+
+/**
+ * Print the receipt as one image — logo, lines and a straight column of
+ * amounts.
+ *
+ * Returns `printed: false` when the render came back blank, so the caller can
+ * fall back to text rather than hand somebody an empty receipt.
+ */
+async function printReceiptAsImage(
+  facilityId: string,
+  deviceSerial: string,
+  receipt: ReceiptInput,
+): Promise<{ printed: boolean; detail?: string }> {
+  const logo = receipt.facility.logoUrl
+    ? await logoAsPrintablePng(receipt.facility.logoUrl)
+    : null;
+
+  const rendered = await renderReceiptPng(
+    receipt,
+    logo
+      ? {
+          dataUri: `data:image/png;base64,${logo.image}`,
+          width: logo.width,
+          height: logo.height,
+        }
+      : undefined,
+  );
+  if (!rendered)
+    return { printed: false, detail: "receipt could not be rendered" };
+
+  // A receipt this size is comfortably over 1% ink. Anything under it means the
+  // glyphs did not render — a runtime with no font produces a blank page rather
+  // than an error.
+  if (rendered.ink < 0.01) {
+    return {
+      printed: false,
+      detail: "rendered blank — no font in the runtime",
+    };
+  }
+
+  return printImageOnDevice(facilityId, deviceSerial, rendered.image);
 }

--- a/src/lib/clover/print.ts
+++ b/src/lib/clover/print.ts
@@ -513,15 +513,20 @@ export async function deliverStandardReceipt(
 // ============================================================================
 
 /** The printable width in dots. See the banner: safe on 58mm and 80mm alike. */
-const LOGO_WIDTH_PX = 384;
+const LOGO_WIDTH_PX = 320;
+/** A logo may not take more roll than this, whatever its aspect ratio. */
+const LOGO_MAX_HEIGHT_PX = 160;
 
 /**
  * Fetch a logo and turn it into something a receipt printer can render.
  *
- * @returns base64 PNG, or null if it could not be fetched or converted. Null is
- *   never an error to the caller: a receipt without a logo is still a receipt.
+ * @returns the base64 PNG and its final dimensions — the caller needs them to
+ *   place it — or null if it could not be fetched or converted. Null is never an
+ *   error: a receipt without a logo is still a receipt.
  */
-async function logoAsPrintablePng(logoUrl: string): Promise<string | null> {
+export async function logoAsPrintablePng(
+  logoUrl: string,
+): Promise<{ image: string; width: number; height: number } | null> {
   try {
     const response = await fetch(logoUrl, {
       signal: AbortSignal.timeout(8_000),
@@ -532,9 +537,21 @@ async function logoAsPrintablePng(logoUrl: string): Promise<string | null> {
     // Imported here rather than at module scope: sharp is a native binary, and
     // this route must not fail to load on a runtime where it is unavailable.
     const { default: sharp } = await import("sharp");
-    const png = await sharp(source)
+    // TRIM FIRST. The logo uploaded on 2026-08-19 was 1024x1024 with the art in
+    // the middle and transparent padding all round, so resizing it to 384 wide
+    // produced a 384x384 square that was 96.7% white — about 48mm of blank roll
+    // above the receipt, which is exactly what came out of the printer.
+    const trimmed = await sharp(source)
+      .trim({ threshold: 10 })
+      .toBuffer()
+      .catch(() => source);
+
+    const png = await sharp(trimmed)
       .resize({
         width: LOGO_WIDTH_PX,
+        // Capped, so a tall logo cannot push the bill off the bottom of a short
+        // roll — the receipt is the thing the customer needs.
+        height: LOGO_MAX_HEIGHT_PX,
         // Never enlarge: a 64px favicon blown up to 384 prints as a smear.
         withoutEnlargement: true,
         fit: "inside",
@@ -549,7 +566,25 @@ async function logoAsPrintablePng(logoUrl: string): Promise<string | null> {
       .png({ colours: 2 })
       .toBuffer();
 
-    return png.toString("base64");
+    const meta = await sharp(png).metadata();
+
+    // A logo that thresholds to almost nothing is a light mark meant for a dark
+    // background, and a thermal head has no white ink. Printing it would feed
+    // blank paper, so it is skipped — the same failure that put 48mm of nothing
+    // above the last receipt, for the other reason.
+    const raw = await sharp(png).greyscale().raw().toBuffer();
+    let dark = 0;
+    for (const value of raw) if (value < 128) dark += 1;
+    if (dark / Math.max(1, raw.length) < 0.01) {
+      console.warn("[clover-print] logo is blank once thresholded — skipping");
+      return null;
+    }
+
+    return {
+      image: png.toString("base64"),
+      width: meta.width ?? LOGO_WIDTH_PX,
+      height: meta.height ?? LOGO_MAX_HEIGHT_PX,
+    };
   } catch (error) {
     console.warn("[clover-print] logo not printable:", error);
     return null;
@@ -557,20 +592,18 @@ async function logoAsPrintablePng(logoUrl: string): Promise<string | null> {
 }
 
 /**
- * Print the facility's logo on the device.
+ * Print a prepared image on the device.
  *
  * Cosmetic, like everything else in this file: returns rather than throws, and
- * the caller prints the text whether this worked or not.
+ * the caller carries on whether this worked or not.
  */
-export async function printLogoOnDevice(
+export async function printImageOnDevice(
   facilityId: string,
   deviceSerial: string,
-  logoUrl: string,
+  /** Base64 PNG, already black and white. */
+  image: string,
   printDeviceId?: string,
 ): Promise<{ printed: boolean; detail?: string }> {
-  const image = await logoAsPrintablePng(logoUrl);
-  if (!image) return { printed: false, detail: "logo could not be converted" };
-
   const active = await validAccessToken(facilityId);
   if (!active) return { printed: false, detail: "no clover token" };
 

--- a/src/lib/clover/receipt-image.ts
+++ b/src/lib/clover/receipt-image.ts
@@ -1,0 +1,313 @@
+import "server-only";
+
+import type { ReceiptInput } from "@/lib/clover/receipt";
+
+// ============================================================================
+// The receipt as an IMAGE, because text printing cannot align a column.
+//
+// ── WHAT THE PAPER SHOWED ─────────────────────────────────────────────────
+//
+// Reported from the running app, with a photograph: "its not organized, the
+// alignment and spaces — all the amounts in one straight line".
+//
+// `/device/print/text` renders in a PROPORTIONAL font. The receipt was laid out
+// by padding to 32 characters, which only aligns in a monospace one, so:
+//
+//   Full day        $45.00              <- 8 + 18 spaces + 6 = 32 chars
+//   Daycare add-on: nail trim $15.00    <- 25 + 1 space + 6  = 32 chars
+//
+// are the same number of CHARACTERS and visibly different WIDTHS on paper,
+// because a space is about half the width of a digit. Every amount landed at a
+// different position down the right-hand side.
+//
+// No character-based padding can fix that: two labels of equal length still
+// render at different pixel widths. The only way to put the amounts in one
+// straight line is to control the pixels, which means printing an image.
+//
+// ── SO THE LOGO GOES IN THE SAME IMAGE ────────────────────────────────────
+//
+// It used to be its own print job before the text. One image means one job,
+// guaranteed ordering, and no second call that can half-fail.
+//
+// ── AND THE CALLER KEEPS THE TEXT PATH ────────────────────────────────────
+//
+// SVG text needs a font in the runtime. If the deployment has none the render
+// comes back blank, so `renderReceiptPng` reports its ink coverage and the
+// caller falls back to text printing rather than handing somebody a blank
+// receipt. Ragged columns beat no receipt.
+// ============================================================================
+
+/** Dots across. Full width of a 58mm head, half of an 80mm one — safe on both. */
+const WIDTH = 384;
+const PADDING = 8;
+const FONT = 17;
+/** Monospace advance is ~0.6em; used only to decide where to wrap and truncate. */
+const CHAR = FONT * 0.6;
+const COLS = Math.floor((WIDTH - PADDING * 2) / CHAR);
+const FAMILY =
+  "DejaVu Sans Mono, Liberation Mono, Menlo, Consolas, Courier New, monospace";
+
+type Row =
+  | { kind: "centre"; text: string; size?: number; bold?: boolean }
+  | { kind: "left"; text: string; size?: number }
+  | {
+      kind: "pair";
+      label: string;
+      amount: string;
+      bold?: boolean;
+      size?: number;
+    }
+  | { kind: "rule" }
+  | { kind: "gap"; height: number };
+
+function escapeXml(text: string): string {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}
+
+function money(cents: number): string {
+  const sign = cents < 0 ? "-" : "";
+  return `${sign}$${(Math.abs(cents) / 100).toFixed(2)}`;
+}
+
+/** Break on words so an address never loses its tail. */
+function wrap(text: string, cols = COLS): string[] {
+  const out: string[] = [];
+  let line = "";
+  for (const word of text.split(" ")) {
+    if (!line) line = word.slice(0, cols);
+    else if (line.length + 1 + word.length <= cols) line += ` ${word}`;
+    else {
+      out.push(line);
+      line = word.slice(0, cols);
+    }
+  }
+  if (line) out.push(line);
+  return out.length ? out : [""];
+}
+
+function rowsFor(input: ReceiptInput): Row[] {
+  const rows: Row[] = [];
+  const f = input.facility;
+
+  rows.push({ kind: "centre", text: f.name, size: 22, bold: true });
+  if (f.address) {
+    for (const line of wrap(f.address))
+      rows.push({ kind: "centre", text: line });
+  }
+  if (f.phone) rows.push({ kind: "centre", text: f.phone });
+  if (f.email) rows.push({ kind: "centre", text: f.email });
+  if (f.taxRegistrations) {
+    for (const line of wrap(f.taxRegistrations, COLS + 6)) {
+      rows.push({ kind: "centre", text: line, size: 14 });
+    }
+  }
+
+  rows.push({ kind: "gap", height: 10 });
+  if (input.reference) rows.push({ kind: "left", text: input.reference });
+  if (input.clientName) {
+    for (const line of wrap(input.clientName))
+      rows.push({ kind: "left", text: line });
+  }
+  if (input.petNames.length > 0) {
+    for (const line of wrap(`Pet: ${input.petNames.join(", ")}`)) {
+      rows.push({ kind: "left", text: line });
+    }
+  }
+  if (input.serviceWindow) {
+    for (const line of wrap(input.serviceWindow))
+      rows.push({ kind: "left", text: line });
+  }
+  rows.push({ kind: "left", text: input.printedAt, size: 14 });
+  rows.push({ kind: "rule" });
+
+  for (const line of input.lines) {
+    rows.push({
+      kind: "pair",
+      label: line.label,
+      amount: money(line.amountCents),
+    });
+  }
+  if (input.discountCents > 0) {
+    rows.push({
+      kind: "pair",
+      label: "Discount",
+      amount: money(-input.discountCents),
+    });
+  }
+
+  rows.push({ kind: "rule" });
+  rows.push({
+    kind: "pair",
+    label: "Subtotal",
+    amount: money(input.subtotalCents),
+  });
+  for (const tax of input.taxLines) {
+    rows.push({
+      kind: "pair",
+      // The stored rate is a fraction; trailing zeros trimmed so Quebec's
+      // 9.975% keeps its decimals and a flat 5% does not gain any.
+      label: `${tax.name} ${Number((tax.rate * 100).toFixed(4))}%`,
+      amount: money(tax.amountCents),
+    });
+  }
+  if (input.tipCents > 0) {
+    rows.push({ kind: "pair", label: "Tip", amount: money(input.tipCents) });
+  }
+  rows.push({
+    kind: "pair",
+    label: "TOTAL",
+    amount: money(input.totalCents),
+    bold: true,
+  });
+  rows.push({ kind: "rule" });
+
+  rows.push({
+    kind: "pair",
+    label: input.paymentMethod ?? "Paid",
+    amount: money(input.totalCents),
+  });
+  const card = [
+    input.cardBrand,
+    input.cardLast4 ? `••${input.cardLast4}` : null,
+  ]
+    .filter(Boolean)
+    .join(" ");
+  if (card) rows.push({ kind: "left", text: card });
+  if (input.entryMethod)
+    rows.push({ kind: "left", text: `Entry: ${input.entryMethod}` });
+  if (input.authCode)
+    rows.push({ kind: "left", text: `Auth: ${input.authCode}` });
+  if (input.processorPaymentId) {
+    for (const line of wrap(`Ref: ${input.processorPaymentId}`)) {
+      rows.push({ kind: "left", text: line });
+    }
+  }
+
+  rows.push({ kind: "gap", height: 12 });
+  rows.push({ kind: "centre", text: "Thank you" });
+  return rows;
+}
+
+export interface ReceiptSvg {
+  svg: string;
+  height: number;
+}
+
+/**
+ * Lay the receipt out as SVG.
+ *
+ * @param logo an already-converted logo as a data URI, composited at the top.
+ *   Optional: a facility without one gets a receipt that starts at its name.
+ */
+export function buildReceiptSvg(
+  input: ReceiptInput,
+  logo?: { dataUri: string; width: number; height: number },
+): ReceiptSvg {
+  const rows = rowsFor(input);
+  const logoBlock = logo ? logo.height + 12 : 0;
+
+  let y = PADDING + logoBlock;
+  const parts: string[] = [];
+
+  if (logo) {
+    const x = Math.round((WIDTH - logo.width) / 2);
+    parts.push(
+      `<image x="${x}" y="${PADDING}" width="${logo.width}" height="${logo.height}" href="${logo.dataUri}"/>`,
+    );
+  }
+
+  for (const row of rows) {
+    if (row.kind === "gap") {
+      y += row.height;
+      continue;
+    }
+    if (row.kind === "rule") {
+      y += 6;
+      parts.push(
+        `<rect x="${PADDING}" y="${y}" width="${WIDTH - PADDING * 2}" height="2" fill="#000"/>`,
+      );
+      y += 12;
+      continue;
+    }
+
+    const size = row.size ?? FONT;
+    y += size + 4;
+
+    if (row.kind === "centre") {
+      parts.push(
+        `<text x="${WIDTH / 2}" y="${y}" text-anchor="middle" font-family="${FAMILY}" font-size="${size}"${row.bold ? ' font-weight="bold"' : ""} fill="#000">${escapeXml(row.text)}</text>`,
+      );
+    } else if (row.kind === "left") {
+      parts.push(
+        `<text x="${PADDING}" y="${y}" font-family="${FAMILY}" font-size="${size}" fill="#000">${escapeXml(row.text)}</text>`,
+      );
+    } else {
+      // THE POINT OF THIS FILE. The amount is anchored to the right edge, so
+      // every amount lands on the same vertical line whatever its label.
+      const room = COLS - row.amount.length - 1;
+      const label =
+        row.label.length > room
+          ? `${row.label.slice(0, room - 1)}…`
+          : row.label;
+      const weight = row.bold ? ' font-weight="bold"' : "";
+      parts.push(
+        `<text x="${PADDING}" y="${y}" font-family="${FAMILY}" font-size="${size}"${weight} fill="#000">${escapeXml(label)}</text>`,
+        `<text x="${WIDTH - PADDING}" y="${y}" text-anchor="end" font-family="${FAMILY}" font-size="${size}"${weight} fill="#000">${escapeXml(row.amount)}</text>`,
+      );
+    }
+    y += 4;
+  }
+
+  const height = y + PADDING;
+  return {
+    height,
+    svg: `<svg xmlns="http://www.w3.org/2000/svg" width="${WIDTH}" height="${height}"><rect width="${WIDTH}" height="${height}" fill="#fff"/>${parts.join("")}</svg>`,
+  };
+}
+
+/**
+ * Render the receipt to a black-and-white PNG the device can print.
+ *
+ * @returns base64 PNG and the fraction of it that is ink. The caller uses the
+ *   coverage to decide whether the render worked: a runtime with no font
+ *   produces a page that is technically valid and entirely blank, and handing
+ *   somebody that is worse than a ragged text receipt.
+ */
+export async function renderReceiptPng(
+  input: ReceiptInput,
+  logo?: { dataUri: string; width: number; height: number },
+): Promise<{ image: string; ink: number } | null> {
+  try {
+    const { svg } = buildReceiptSvg(input, logo);
+    // Imported here rather than at module scope: sharp is a native binary and
+    // this route must not fail to load on a runtime where it is unavailable.
+    const { default: sharp } = await import("sharp");
+
+    const png = await sharp(Buffer.from(svg))
+      .flatten({ background: "#ffffff" })
+      .greyscale()
+      // One ink, no greys — the head fires a dot or it does not. High, because
+      // anti-aliased text is mostly mid-grey at the edges and a low threshold
+      // eats the strokes.
+      .threshold(200)
+      .png({ colours: 2 })
+      .toBuffer();
+
+    const raw = await sharp(png).greyscale().raw().toBuffer();
+    let dark = 0;
+    for (const value of raw) if (value < 128) dark += 1;
+
+    return {
+      image: png.toString("base64"),
+      ink: dark / Math.max(1, raw.length),
+    };
+  } catch (error) {
+    console.warn("[clover-print] receipt image failed:", error);
+    return null;
+  }
+}


### PR DESCRIPTION
Two faults on the first receipt that actually printed.

## A proportional font cannot be aligned with spaces

`/device/print/text` renders in a **proportional** font. The layout padded to 32 characters, which only aligns in a monospace one:

```
Full day        $45.00              <- 8 + 18 spaces + 6 = 32 chars
Daycare add-on: nail trim $15.00    <- 25 + 1 space  + 6 = 32 chars
```

Same character count, visibly different width on paper, because a space is about half the width of a digit. Every amount landed somewhere different down the right-hand side.

**No character-based padding fixes that** — two labels of equal *length* still render at different *widths*. The only way to put the amounts in one straight line is to control the pixels, so the receipt is composed as SVG and printed through `/device/print/image`. Amounts are anchored to the right edge, so they line up whatever the label.

The logo is composited into the **same image**: one job, guaranteed order, and no second call that can half-fail.

## Fallback, because SVG text needs a font

A runtime with no font renders a page that is valid and **entirely blank**. So the renderer reports its ink coverage and anything under 1% falls back to text printing. Ragged columns beat blank paper.

## 48mm of blank roll

The logo printed as a 384x384 square that was **96.7% white**. The uploaded file is 1024x1024 with the art in the middle and transparent padding all round, and resizing that to 384 wide keeps the padding.

Trimmed first now, and capped at 160px tall so a tall logo cannot push the bill off the end of a short roll. Measured on the real file:

```
1024x1024  ->  trim  ->  447x328  ->  printed 218x160 at 24.6% ink
```

A logo that thresholds to almost nothing is also **skipped** rather than printed: a light mark meant for a dark background has no representation on a thermal head - there is no white ink - so it would feed blank paper for the other reason.

## Verification

Rendered end to end against the facility's real logo and real tax config: **384x888, 7.9% ink, 111mm of paper, every amount on one vertical line.** `typecheck`, `eslint` (0 errors), `format:check`, `check:success-claims` green. Hardware confirmation after deploy.