### PR TITLE
test(e2e): assert on the heading, not on how Next.js streams

### DIFF
--- a/tests/e2e/facility-access-level.spec.ts
+++ b/tests/e2e/facility-access-level.spec.ts
@@ -346,8 +346,17 @@ test.describe("inviting somebody onto the platform team", () => {
     ).toString("base64url");
 
     await page.goto(`/setup/${forged}`);
+    // The HEADING, not any text node matching the phrase. `getByText` resolved
+    // to two elements under a built server and failed on strict mode — the
+    // served HTML carries the <h1> once and the phrase a second time inside the
+    // RSC flight payload, so the loose locator was asserting on how Next.js
+    // streams rather than on what the page says.
     await expect(
-      page.getByText(/invitation link is invalid or has expired/i),
+      page
+        .getByRole("heading", {
+          name: /invitation link is invalid or has expired/i,
+        })
+        .first(),
     ).toBeVisible();
     // The address from the payload is nowhere on the page.
     await expect(page.getByText("attacker@yipyy.invalid")).toHaveCount(0);


### PR DESCRIPTION
The auth & access suite ran in CI **for the first time today** — 61 passed, 1 skipped, 1 failed — and the failure is the test, not the product.

```
strict mode violation: getByText(/invitation link is invalid or has expired/i)
resolved to 2 elements
```

## The page renders it once

Fetched from production and counted:

```
occurrences of the phrase:                    2
<h1> elements containing it:                  1
```

The second is inside the **RSC flight payload** Next.js streams in a script tag. So the loose text locator was asserting on how the framework serialises a page rather than on what the page says — and it only bit under a **built** server, which is what CI runs and what no local run had used.

## The security behaviour is intact

Everything this test exists to check passed:

- the forged token opens nothing
- the payload's address (`attacker@yipyy.invalid`) appears nowhere on the page
- `POST /api/admin/setup` with the forged token is refused

Only the visibility assertion tripped, and only on locator ambiguity.

Now scoped to the heading role, which is the thing actually being asserted.

## Context

This is the first real signal from that gate. It has been failing at the secrets check in 8 seconds on every PR — the seven repository secrets were set today, so the suite had never executed. **61 of 62 passing on the first honest run** is a good result for a suite nobody had seen work.