### PR TITLE
fix(payments): one receipt, not two

### DIFF
--- a/src/app/api/payments/clover/terminal/route.ts
+++ b/src/app/api/payments/clover/terminal/route.ts
@@ -308,8 +308,8 @@ export async function POST(request: NextRequest) {
         parsed.data.deviceSerial,
         receipt,
       );
-      // FALLBACK. SVG text needs a font in the runtime; without one the render
-      // is valid and entirely blank. Ragged columns beat blank paper.
+      // FALLBACK. The image render can fail for want of a usable font
+      // (lib/clover/receipt-image.ts), and ragged columns beat no receipt.
       if (!printed.printed) {
         printed = await printTextOnDevice(
           booking.facility_id,
@@ -319,12 +319,20 @@ export async function POST(request: NextRequest) {
       }
       itemised = printed.printed;
     }
-    // AND Clover's own, which is the card-brand-compliant one. The docs put
-    // that squarely on us for custom receipts — "You are responsible to ensure
-    // the receipts printed by your app comply with all card brand" rules — and
-    // ours is a breakdown, not a compliant payment record. Two prints off one
-    // roll is a cheap way to owe nobody an argument.
-    if (outcome.processorPaymentId) {
+
+    // ── CLOVER'S OWN SLIP IS A LAST RESORT, NOT A COMPANION ────────────────
+    //
+    // It used to print alongside ours on every sale, so the customer was handed
+    // two receipts and the facility spent twice the roll. That was defensible
+    // while ours was only a breakdown: the docs put card-brand compliance on
+    // the integrator for custom receipts, and ours carried no payment record.
+    //
+    // It does now — merchant name and address, the transaction's own timestamp,
+    // card brand, masked pan, entry method and approval code, all off the
+    // payments row. So the second slip earns its paper only when ours did not
+    // come out at all, which is the one case where something is better than
+    // nothing.
+    if (!printed.printed && outcome.processorPaymentId) {
       delivered = await deliverStandardReceipt(
         booking.facility_id,
         parsed.data.deviceSerial,


### PR DESCRIPTION
Clover's own slip printed **alongside** ours on every sale, so the customer was handed two receipts and the facility spent twice the roll. Reported as the receipt being too long, with a photograph of both.

## Why they were paired

That was defensible when ours was only a breakdown. The docs put card-brand compliance on the integrator for custom receipts, and ours carried **no payment record at all** — just line items and a total.

## Why it no longer is

Ours now carries the whole cardholder copy:

| Field | Source |
|---|---|
| Merchant name, address, phone | `facilities` |
| Transaction date and time | the payment |
| Card brand + masked pan | `payments.card_brand` / `card_last4` |
| Entry method | `payments.entry_method` |
| Approval code | `payments.auth_code` |
| Amount, tax, tip, total | the booking and `tax_config` |

`auth_code` and `entry_method` had been sitting in the ledger unused since it was built — one join from being printed.

## What changed

Clover's slip becomes a **last resort** rather than a companion: it prints only when ours did not come out, which is the one case where something beats nothing.

Email and text delivery are unchanged — Clover's copy is still the fallback there, for when our own mailer cannot send.

## Verification

`typecheck`, `eslint` (0 errors), `format:check`, `check:success-claims` green.

Worth stating plainly: this is a **compliance-adjacent** change made at the facility's request. Ours carries the fields a cardholder receipt is expected to have, but if their acquirer wants Clover's specific format — MID, network name, signature line, the online receipt link — restoring it is one condition in this file.